### PR TITLE
ci: drop intel mac support

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -2,10 +2,10 @@
 
 [graph]
 targets = [
-	"x86_64-unknown-linux-musl",
-	"x86_64-unknown-linux-musl",
 	"aarch64-apple-darwin",
-	"x86_64-apple-darwin",
+	"aarch64-unknown-linux-gnu",
+	"x86_64-unknown-linux-gnu",
+	"x86_64-unknown-linux-musl",
 ]
 all-features = true
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -12,7 +12,6 @@ installers = ["shell"]
 targets = [
 	"aarch64-apple-darwin",
 	"aarch64-unknown-linux-gnu",
-	"x86_64-apple-darwin",
 	"x86_64-unknown-linux-gnu",
 	"x86_64-unknown-linux-musl",
 ]


### PR DESCRIPTION
`cargo install` should work, so I believe we don't need to provide prebuilt binaries for them.