### PR TITLE
refactor: migrate to color-eyre for improved error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,6 @@ dependencies = [
  "ctor",
  "dialoguer",
  "duct",
- "eyre",
  "homedir",
  "indicatif",
  "insta",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,7 @@ dependencies = [
  "color-eyre",
  "confique",
  "console 0.16.2",
+ "ctor",
  "dialoguer",
  "duct",
  "eyre",
@@ -680,6 +681,16 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array 0.14.7",
  "typenum",
+]
+
+[[package]]
+name = "ctor"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ usage-lib = { version = "2.18.2", features = ["clap", "docs"] }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
+ctor = "0.2.8"
 duct = "1.1.1"
 insta = { version = "1.46.3", features = ["json"] }
 pretty_assertions = "1.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ confique = { version = "0.4.0", features = ["toml", "yaml", "json5"] }
 console = "0.16.2"
 dialoguer = "0.12.0"
 duct = "1.1.1"
-eyre = "0.6.12"
 homedir = "0.3.6"
 indicatif = "0.18.4"
 itertools = "0.14.0"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,5 @@
+disallowed-types = [
+	{ path = "eyre::Result", reason = "Please use `crate::Result` instead to ensure consistent error handling across the crate." },
+	{ path = "color_eyre::Result", reason = "Please use `crate::Result` instead to ensure consistent error handling across the crate." },
+	{ path = "color_eyre::eyre::Result", reason = "Please use `crate::Result` instead to ensure consistent error handling across the crate." },
+]

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -80,20 +80,23 @@ mod tests {
 	use clap::Parser as _;
 
 	#[test]
-	fn completion_parse_bash() {
+	fn completion_parse_bash() -> color_eyre::Result<()> {
 		let cli = Cli::parse_from(["biwa", "completion", "bash"]);
 		assert!(matches!(cli.command, Some(Commands::Completion(_))));
+		Ok(())
 	}
 
 	#[test]
-	fn completion_parse_zsh() {
+	fn completion_parse_zsh() -> color_eyre::Result<()> {
 		let cli = Cli::parse_from(["biwa", "completion", "zsh"]);
 		assert!(matches!(cli.command, Some(Commands::Completion(_))));
+		Ok(())
 	}
 
 	#[test]
-	fn completion_parse_fish() {
+	fn completion_parse_fish() -> color_eyre::Result<()> {
 		let cli = Cli::parse_from(["biwa", "completion", "fish"]);
 		assert!(matches!(cli.command, Some(Commands::Completion(_))));
+		Ok(())
 	}
 }

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -1,8 +1,8 @@
-use std::io;
-
+use crate::Result;
 use clap::Args;
 use clap::builder::PossibleValue;
-use eyre::bail;
+use color_eyre::eyre::bail;
+use std::io;
 use strum::EnumString;
 
 /// Generate shell completions.
@@ -16,14 +16,14 @@ pub(super) struct Completion {
 
 impl Completion {
 	/// Run the completion generation logic.
-	pub(super) fn run(self) -> eyre::Result<()> {
+	pub(super) fn run(self) -> Result<()> {
 		let script = self.call_usage()?;
 		println!("{}", script.trim());
 		Ok(())
 	}
 
 	/// Calls usage CLI to generate the shell completion script.
-	fn call_usage(&self) -> eyre::Result<String> {
+	fn call_usage(&self) -> Result<String> {
 		let shell = self.shell.to_string();
 		let result = duct::cmd!(
 			"usage",
@@ -80,23 +80,20 @@ mod tests {
 	use clap::Parser as _;
 
 	#[test]
-	fn completion_parse_bash() -> color_eyre::Result<()> {
+	fn completion_parse_bash() {
 		let cli = Cli::parse_from(["biwa", "completion", "bash"]);
 		assert!(matches!(cli.command, Some(Commands::Completion(_))));
-		Ok(())
 	}
 
 	#[test]
-	fn completion_parse_zsh() -> color_eyre::Result<()> {
+	fn completion_parse_zsh() {
 		let cli = Cli::parse_from(["biwa", "completion", "zsh"]);
 		assert!(matches!(cli.command, Some(Commands::Completion(_))));
-		Ok(())
 	}
 
 	#[test]
-	fn completion_parse_fish() -> color_eyre::Result<()> {
+	fn completion_parse_fish() {
 		let cli = Cli::parse_from(["biwa", "completion", "fish"]);
 		assert!(matches!(cli.command, Some(Commands::Completion(_))));
-		Ok(())
 	}
 }

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -16,7 +16,7 @@ pub(super) struct Completion {
 
 impl Completion {
 	/// Run the completion generation logic.
-	pub(super) fn run(self) -> crate::Result<()> {
+	pub(super) fn run(self) -> Result<()> {
 		let script = self.call_usage()?;
 		println!("{}", script.trim());
 		Ok(())

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -16,7 +16,7 @@ pub(super) struct Completion {
 
 impl Completion {
 	/// Run the completion generation logic.
-	pub(super) fn run(self) -> Result<()> {
+	pub(super) fn run(self) -> crate::Result<()> {
 		let script = self.call_usage()?;
 		println!("{}", script.trim());
 		Ok(())
@@ -76,6 +76,7 @@ impl clap::ValueEnum for Shell {
 
 #[cfg(test)]
 mod tests {
+
 	use crate::cli::{Cli, Commands};
 	use clap::Parser as _;
 

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -137,7 +137,7 @@ mod tests {
 	#[case("json5")]
 	#[case("yaml")]
 	#[case("yml")]
-	fn init_generate(#[case] format: &str) -> crate::Result<()> {
+	fn init_generate(#[case] format: &str) -> Result<()> {
 		let init = Init {
 			force: false,
 			format: format.to_owned(),

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -137,13 +137,14 @@ mod tests {
 	#[case("json5")]
 	#[case("yaml")]
 	#[case("yml")]
-	fn init_generate(#[case] format: &str) {
+	fn init_generate(#[case] format: &str) -> crate::Result<()> {
 		let init = Init {
 			force: false,
 			format: format.to_owned(),
 		};
-		let (filename, content) = init.generate().expect("Failed to generate");
+		let (filename, content) = init.generate()?;
 		assert_eq!(filename, format!("biwa.{format}"));
 		assert_snapshot!(format!("init_{}", format), content);
+		Ok(())
 	}
 }

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,6 +1,7 @@
+use crate::Result;
 use crate::{config::format::ConfigFormat, config::types::Config};
 use clap::Args;
-use eyre::bail;
+use color_eyre::eyre::{bail, eyre};
 use serde_json::json;
 use std::fs;
 use std::path::Path;
@@ -19,7 +20,7 @@ pub(super) struct Init {
 
 impl Init {
 	/// Run the initialization logic.
-	pub(super) fn run(self) -> eyre::Result<()> {
+	pub(super) fn run(self) -> Result<()> {
 		let (filename, content) = self.generate()?;
 		let path = Path::new(&filename);
 		if path.exists() && !self.force {
@@ -32,12 +33,12 @@ impl Init {
 	}
 
 	/// Generates the configuration content based on the selected format.
-	fn generate(&self) -> eyre::Result<(String, String)> {
+	fn generate(&self) -> Result<(String, String)> {
 		let filename = format!("biwa.{}", self.format.to_ascii_lowercase());
 		let schema_url = "https://biwa.takuk.me/schema/config.json";
 
 		let format = ConfigFormat::from_extension(&self.format)
-			.ok_or_else(|| eyre::eyre!("Unsupported format: {}", self.format))?;
+			.ok_or_else(|| eyre!("Unsupported format: {}", self.format))?;
 
 		let content = match format {
 			ConfigFormat::Toml => {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -122,21 +122,23 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn cli_run_subcommand() {
+	fn cli_run_subcommand() -> color_eyre::Result<()> {
 		let cli = Cli::parse_from(["biwa", "run", "ls", "-la"]);
 		assert!(matches!(cli.command, Some(Commands::Run(_))));
 		assert!(cli.run_command_args.is_empty());
+		Ok(())
 	}
 
 	#[test]
-	fn cli_implicit_run_command() {
+	fn cli_implicit_run_command() -> color_eyre::Result<()> {
 		let cli = Cli::parse_from(["biwa", "ls", "-la"]);
 		assert!(cli.command.is_none());
 		assert_eq!(cli.run_command_args, vec!["ls", "-la"]);
+		Ok(())
 	}
 
 	#[test]
-	fn cli_verbose() {
+	fn cli_verbose() -> color_eyre::Result<()> {
 		let cli = Cli::parse_from(["biwa", "-v", "ls"]);
 		assert_eq!(cli.verbose, 1);
 
@@ -145,33 +147,38 @@ mod tests {
 
 		let cli = Cli::parse_from(["biwa", "-vvv", "ls"]);
 		assert_eq!(cli.verbose, 3);
+		Ok(())
 	}
 
 	#[test]
-	fn cli_run_with_verbose() {
+	fn cli_run_with_verbose() -> color_eyre::Result<()> {
 		let cli = Cli::parse_from(["biwa", "-vv", "run", "ls"]);
 		assert_eq!(cli.verbose, 2);
 		assert!(matches!(cli.command, Some(Commands::Run(_))));
+		Ok(())
 	}
 
 	#[test]
-	fn cli_quiet() {
+	fn cli_quiet() -> color_eyre::Result<()> {
 		let cli = Cli::parse_from(["biwa", "-q", "ls"]);
 		assert!(cli.quiet);
 		assert_eq!(cli.run_command_args, vec!["ls"]);
+		Ok(())
 	}
 
 	#[test]
-	fn cli_quiet_long() {
+	fn cli_quiet_long() -> color_eyre::Result<()> {
 		let cli = Cli::parse_from(["biwa", "--quiet", "run", "ls"]);
 		assert!(cli.quiet);
 		assert!(matches!(cli.command, Some(Commands::Run(_))));
+		Ok(())
 	}
 
 	#[test]
-	fn cli_quiet_with_verbose() {
+	fn cli_quiet_with_verbose() -> color_eyre::Result<()> {
 		let cli = Cli::parse_from(["biwa", "-q", "-vv", "ls"]);
 		assert!(cli.quiet);
 		assert_eq!(cli.verbose, 2);
+		Ok(())
 	}
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
+use crate::Result;
 use crate::{config::types::Config, ssh::exec::execute_command};
 use clap::{ArgAction, Parser, Subcommand};
-use eyre::bail;
+use color_eyre::eyre::bail;
 use tracing::Level;
 
 /// Shell completion generation command.
@@ -67,7 +68,7 @@ enum Commands {
 
 impl Commands {
 	/// Executes the specific subcommand logic.
-	async fn run(self, config: &Config, quiet: bool, silent: bool) -> eyre::Result<()> {
+	async fn run(self, config: &Config, quiet: bool, silent: bool) -> Result<()> {
 		match self {
 			Self::Run(cmd) => cmd.run(config, quiet, silent).await,
 			Self::Init(cmd) => cmd.run(),
@@ -79,7 +80,7 @@ impl Commands {
 }
 
 /// Main entry point for the CLI. Parses arguments and routes to the appropriate command.
-pub async fn run() -> eyre::Result<()> {
+pub async fn run() -> Result<()> {
 	let cli = Cli::parse();
 
 	let config = Config::load()?;
@@ -122,23 +123,21 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn cli_run_subcommand() -> color_eyre::Result<()> {
+	fn cli_run_subcommand() {
 		let cli = Cli::parse_from(["biwa", "run", "ls", "-la"]);
 		assert!(matches!(cli.command, Some(Commands::Run(_))));
 		assert!(cli.run_command_args.is_empty());
-		Ok(())
 	}
 
 	#[test]
-	fn cli_implicit_run_command() -> color_eyre::Result<()> {
+	fn cli_implicit_run_command() {
 		let cli = Cli::parse_from(["biwa", "ls", "-la"]);
 		assert!(cli.command.is_none());
 		assert_eq!(cli.run_command_args, vec!["ls", "-la"]);
-		Ok(())
 	}
 
 	#[test]
-	fn cli_verbose() -> color_eyre::Result<()> {
+	fn cli_verbose() {
 		let cli = Cli::parse_from(["biwa", "-v", "ls"]);
 		assert_eq!(cli.verbose, 1);
 
@@ -147,38 +146,33 @@ mod tests {
 
 		let cli = Cli::parse_from(["biwa", "-vvv", "ls"]);
 		assert_eq!(cli.verbose, 3);
-		Ok(())
 	}
 
 	#[test]
-	fn cli_run_with_verbose() -> color_eyre::Result<()> {
+	fn cli_run_with_verbose() {
 		let cli = Cli::parse_from(["biwa", "-vv", "run", "ls"]);
 		assert_eq!(cli.verbose, 2);
 		assert!(matches!(cli.command, Some(Commands::Run(_))));
-		Ok(())
 	}
 
 	#[test]
-	fn cli_quiet() -> color_eyre::Result<()> {
+	fn cli_quiet() {
 		let cli = Cli::parse_from(["biwa", "-q", "ls"]);
 		assert!(cli.quiet);
 		assert_eq!(cli.run_command_args, vec!["ls"]);
-		Ok(())
 	}
 
 	#[test]
-	fn cli_quiet_long() -> color_eyre::Result<()> {
+	fn cli_quiet_long() {
 		let cli = Cli::parse_from(["biwa", "--quiet", "run", "ls"]);
 		assert!(cli.quiet);
 		assert!(matches!(cli.command, Some(Commands::Run(_))));
-		Ok(())
 	}
 
 	#[test]
-	fn cli_quiet_with_verbose() -> color_eyre::Result<()> {
+	fn cli_quiet_with_verbose() {
 		let cli = Cli::parse_from(["biwa", "-q", "-vv", "ls"]);
 		assert!(cli.quiet);
 		assert_eq!(cli.verbose, 2);
-		Ok(())
 	}
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use crate::{config::types::Config, ssh::exec::execute_command};
 use clap::Args;
 
@@ -16,7 +17,7 @@ pub(super) struct Run {
 
 impl Run {
 	/// Run the execution logic for remote command.
-	pub async fn run(self, config: &Config, quiet: bool, silent: bool) -> eyre::Result<()> {
+	pub async fn run(self, config: &Config, quiet: bool, silent: bool) -> Result<()> {
 		execute_command(config, &self.command, &self.command_args, quiet, silent).await?;
 		Ok(())
 	}
@@ -29,7 +30,7 @@ mod tests {
 	use clap::Parser as _;
 
 	#[test]
-	fn run_command() -> color_eyre::Result<()> {
+	fn run_command() {
 		let args = Cli::parse_from(["biwa", "run", "ls", "-la"]);
 		assert!(args.run_command_args.is_empty());
 		if let Some(Commands::Run(run)) = args.command {
@@ -38,11 +39,10 @@ mod tests {
 		} else {
 			assert_matches!(args.command, Some(Commands::Run(_)));
 		}
-		Ok(())
 	}
 
 	#[test]
-	fn run_command_alias() -> color_eyre::Result<()> {
+	fn run_command_alias() {
 		let args = Cli::parse_from(["biwa", "r", "pwd"]);
 		if let Some(Commands::Run(run)) = args.command {
 			assert_eq!(run.command, "pwd");
@@ -50,6 +50,5 @@ mod tests {
 		} else {
 			assert_matches!(args.command, Some(Commands::Run(_)));
 		}
-		Ok(())
 	}
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -29,7 +29,7 @@ mod tests {
 	use clap::Parser as _;
 
 	#[test]
-	fn run_command() {
+	fn run_command() -> color_eyre::Result<()> {
 		let args = Cli::parse_from(["biwa", "run", "ls", "-la"]);
 		assert!(args.run_command_args.is_empty());
 		if let Some(Commands::Run(run)) = args.command {
@@ -38,10 +38,11 @@ mod tests {
 		} else {
 			assert_matches!(args.command, Some(Commands::Run(_)));
 		}
+		Ok(())
 	}
 
 	#[test]
-	fn run_command_alias() {
+	fn run_command_alias() -> color_eyre::Result<()> {
 		let args = Cli::parse_from(["biwa", "r", "pwd"]);
 		if let Some(Commands::Run(run)) = args.command {
 			assert_eq!(run.command, "pwd");
@@ -49,5 +50,6 @@ mod tests {
 		} else {
 			assert_matches!(args.command, Some(Commands::Run(_)));
 		}
+		Ok(())
 	}
 }

--- a/src/cli/schema.rs
+++ b/src/cli/schema.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use crate::config::types::Config;
 use clap::Args;
 use schemars::schema_for;
@@ -10,7 +11,7 @@ pub(super) struct Schema;
 impl Schema {
 	/// Run the schema generation logic.
 	#[expect(clippy::unused_self, reason = "schema subcommand doesn't have flags")]
-	pub(super) fn run(self) -> eyre::Result<()> {
+	pub(super) fn run(self) -> Result<()> {
 		let schema = schema_for!(Config);
 		println!("{}", serde_json::to_string_pretty(&schema)?);
 		Ok(())

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -29,12 +29,13 @@ mod tests {
 	use clap::CommandFactory as _;
 
 	#[test]
-	fn usage_spec_generation() {
+	fn usage_spec_generation() -> color_eyre::Result<()> {
 		let cli = Cli::command();
 		let spec: usage::Spec = cli.into();
 		let output = spec.to_string();
 		assert!(!output.is_empty());
 		// Should contain the biwa command
 		assert!(output.contains("biwa"));
+		Ok(())
 	}
 }

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use crate::cli::Cli;
 use clap::{Args, CommandFactory as _};
 
@@ -15,7 +16,7 @@ impl Usage {
 		clippy::unnecessary_wraps,
 		reason = "usage subcommand doesn't return Err"
 	)]
-	pub(super) fn run(self) -> eyre::Result<()> {
+	pub(super) fn run(self) -> Result<()> {
 		let cli = Cli::command();
 		let spec: usage::Spec = cli.into();
 		println!("{}", spec.to_string().trim());
@@ -29,13 +30,12 @@ mod tests {
 	use clap::CommandFactory as _;
 
 	#[test]
-	fn usage_spec_generation() -> color_eyre::Result<()> {
+	fn usage_spec_generation() {
 		let cli = Cli::command();
 		let spec: usage::Spec = cli.into();
 		let output = spec.to_string();
 		assert!(!output.is_empty());
 		// Should contain the biwa command
 		assert!(output.contains("biwa"));
-		Ok(())
 	}
 }

--- a/src/config/format.rs
+++ b/src/config/format.rs
@@ -43,25 +43,27 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn all_formats() {
+	fn all_formats() -> color_eyre::Result<()> {
 		let all = ConfigFormat::all();
 		assert_eq!(all.len(), 4);
 		assert!(all.contains(&ConfigFormat::Toml));
 		assert!(all.contains(&ConfigFormat::Yaml));
 		assert!(all.contains(&ConfigFormat::Json));
 		assert!(all.contains(&ConfigFormat::Json5));
+		Ok(())
 	}
 
 	#[test]
-	fn extensions() {
+	fn extensions() -> color_eyre::Result<()> {
 		assert_eq!(ConfigFormat::Toml.extensions(), &["toml"]);
 		assert_eq!(ConfigFormat::Yaml.extensions(), &["yaml", "yml"]);
 		assert_eq!(ConfigFormat::Json.extensions(), &["json"]);
 		assert_eq!(ConfigFormat::Json5.extensions(), &["json5", "jsonc"]);
+		Ok(())
 	}
 
 	#[test]
-	fn from_extension() {
+	fn from_extension() -> color_eyre::Result<()> {
 		assert_eq!(
 			ConfigFormat::from_extension("toml"),
 			Some(ConfigFormat::Toml)
@@ -96,5 +98,6 @@ mod tests {
 		);
 		assert_eq!(ConfigFormat::from_extension("xml"), None);
 		assert_eq!(ConfigFormat::from_extension("txt"), None);
+		Ok(())
 	}
 }

--- a/src/config/format.rs
+++ b/src/config/format.rs
@@ -43,27 +43,25 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn all_formats() -> color_eyre::Result<()> {
+	fn all_formats() {
 		let all = ConfigFormat::all();
 		assert_eq!(all.len(), 4);
 		assert!(all.contains(&ConfigFormat::Toml));
 		assert!(all.contains(&ConfigFormat::Yaml));
 		assert!(all.contains(&ConfigFormat::Json));
 		assert!(all.contains(&ConfigFormat::Json5));
-		Ok(())
 	}
 
 	#[test]
-	fn extensions() -> color_eyre::Result<()> {
+	fn extensions() {
 		assert_eq!(ConfigFormat::Toml.extensions(), &["toml"]);
 		assert_eq!(ConfigFormat::Yaml.extensions(), &["yaml", "yml"]);
 		assert_eq!(ConfigFormat::Json.extensions(), &["json"]);
 		assert_eq!(ConfigFormat::Json5.extensions(), &["json5", "jsonc"]);
-		Ok(())
 	}
 
 	#[test]
-	fn from_extension() -> color_eyre::Result<()> {
+	fn from_extension() {
 		assert_eq!(
 			ConfigFormat::from_extension("toml"),
 			Some(ConfigFormat::Toml)
@@ -98,6 +96,5 @@ mod tests {
 		);
 		assert_eq!(ConfigFormat::from_extension("xml"), None);
 		assert_eq!(ConfigFormat::from_extension("txt"), None);
-		Ok(())
 	}
 }

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -220,7 +220,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn env_override() -> crate::Result<()> {
+	fn env_override() -> Result<()> {
 		let dir = tempdir()?;
 		fs::write(dir.path().join("biwa.toml"), r#"ssh.host = "file""#)?;
 
@@ -294,7 +294,7 @@ mod tests {
 		#[case] content: &str,
 		#[case] ext: &str,
 		#[case] expected: &str,
-	) -> crate::Result<()> {
+	) -> Result<()> {
 		let dir = tempdir()?;
 		let file_path = dir.path().join(format!("biwa.{ext}"));
 		fs::write(&file_path, content)?;
@@ -306,7 +306,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn traversal_precedence() -> crate::Result<()> {
+	fn traversal_precedence() -> Result<()> {
 		let dir = tempdir()?;
 		let root = dir.path();
 		let subdir = root.join("subdir");
@@ -323,7 +323,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn traversal_stops_at_home() -> crate::Result<()> {
+	fn traversal_stops_at_home() -> Result<()> {
 		let dir = tempdir()?;
 		let root = dir.path();
 		let home = root.join("home");
@@ -345,7 +345,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn xdg_precedence() -> crate::Result<()> {
+	fn xdg_precedence() -> Result<()> {
 		let dir = tempdir()?;
 		let home = dir.path().join("home");
 		let config_home = home.join(".config");
@@ -360,7 +360,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn cwd_is_dot_config() -> crate::Result<()> {
+	fn cwd_is_dot_config() -> Result<()> {
 		let dir = tempdir()?;
 		let project = dir.path().join("project");
 		let dot_config = project.join(".config");
@@ -383,7 +383,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn nested_within_dot_config() -> crate::Result<()> {
+	fn nested_within_dot_config() -> Result<()> {
 		let dir = tempdir()?;
 		let project = dir.path().join("project");
 		let dot_config = project.join(".config");
@@ -408,7 +408,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn strict_global_config() -> crate::Result<()> {
+	fn strict_global_config() -> Result<()> {
 		let dir = tempdir()?;
 		let home = dir.path().join("home");
 		let config_home = home.join(".config");
@@ -425,7 +425,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn strict_local_config() -> crate::Result<()> {
+	fn strict_local_config() -> Result<()> {
 		let dir = tempdir()?;
 		// Multiple local configs in same dir should fail
 		fs::write(dir.path().join("biwa.toml"), r#"ssh.host = "toml""#)?;
@@ -441,7 +441,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn conflict_root_and_dot_config() -> crate::Result<()> {
+	fn conflict_root_and_dot_config() -> Result<()> {
 		let dir = tempdir()?;
 		// Test multiple "local" configs (one within .config) should fail
 		fs::write(dir.path().join("biwa.toml"), r#"ssh.host = "root""#)?;
@@ -458,7 +458,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn local_dot_config_support() -> crate::Result<()> {
+	fn local_dot_config_support() -> Result<()> {
 		let dir = tempdir()?;
 		let dot_config = dir.path().join(".config");
 		fs::create_dir_all(&dot_config)?;
@@ -472,7 +472,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn ignored_xdg_biwa_biwa() -> crate::Result<()> {
+	fn ignored_xdg_biwa_biwa() -> Result<()> {
 		let dir = tempdir()?;
 		let home = dir.path().join("home");
 		let config_home = home.join(".config");
@@ -497,7 +497,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn find_single_config_logic() -> crate::Result<()> {
+	fn find_single_config_logic() -> Result<()> {
 		let dir = tempdir()?;
 		let root = dir.path();
 
@@ -534,7 +534,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn nested_path_resolution() -> crate::Result<()> {
+	fn nested_path_resolution() -> Result<()> {
 		let dir = tempdir()?;
 		let root = dir.path();
 		let subdir = root.join("subdir");
@@ -576,7 +576,7 @@ host = "child"
 
 	#[serial]
 	#[test]
-	fn local_config_root_dot_config_biwa() -> crate::Result<()> {
+	fn local_config_root_dot_config_biwa() -> Result<()> {
 		let dir = tempdir()?;
 		let project = dir.path().join("project");
 		let dot_config = project.join(".config");
@@ -604,7 +604,7 @@ remote_root = "libs"
 
 	#[serial]
 	#[test]
-	fn global_config_root_home_and_xdg() -> crate::Result<()> {
+	fn global_config_root_home_and_xdg() -> Result<()> {
 		let dir = tempdir()?;
 		let home = dir.path().join("home");
 		let config_home = home.join(".config");
@@ -650,7 +650,7 @@ remote_root = "xdg_libs"
 
 	#[serial]
 	#[test]
-	fn relative_key_path_resolved_against_source_config() -> crate::Result<()> {
+	fn relative_key_path_resolved_against_source_config() -> Result<()> {
 		// Layout:
 		//   /parent/biwa.toml       -> sets ssh.key_path = "my_key"
 		//   /parent/my_key          -> the key file
@@ -680,7 +680,7 @@ remote_root = "xdg_libs"
 
 	#[serial]
 	#[test]
-	fn load_partial_invalid_toml() -> crate::Result<()> {
+	fn load_partial_invalid_toml() -> Result<()> {
 		let dir = tempfile::tempdir()?;
 		let path = dir.path().join("config.toml");
 		// Write invalid TOML
@@ -700,7 +700,7 @@ remote_root = "xdg_libs"
 
 	#[serial]
 	#[test]
-	fn load_partial_invalid_yaml() -> crate::Result<()> {
+	fn load_partial_invalid_yaml() -> Result<()> {
 		let dir = tempfile::tempdir()?;
 		let path = dir.path().join("config.yaml");
 		// Write invalid YAML
@@ -720,7 +720,7 @@ remote_root = "xdg_libs"
 
 	#[serial]
 	#[test]
-	fn load_partial_invalid_json() -> crate::Result<()> {
+	fn load_partial_invalid_json() -> Result<()> {
 		let dir = tempfile::tempdir()?;
 		let path = dir.path().join("config.json");
 		// Write invalid JSON

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -209,17 +209,18 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn default() {
+	fn default() -> color_eyre::Result<()> {
 		let config = Config::default();
 		assert_eq!(config.ssh.host, "cse.unsw.edu.au");
 		assert_eq!(config.ssh.port, 22);
 		assert_eq!(config.ssh.user, "z1234567");
 		assert!(config.sync.remote_root.ends_with(".cache/biwa/projects"));
+		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn env_override() {
+	fn env_override() -> color_eyre::Result<()> {
 		let dir = tempdir().unwrap();
 		fs::write(dir.path().join("biwa.toml"), r#"ssh.host = "file""#).unwrap();
 
@@ -245,11 +246,12 @@ mod tests {
 
 		assert_eq!(config.ssh.host, "env");
 		assert_eq!(config.ssh.port, 8080);
+		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn snapshot() {
+	fn snapshot() -> color_eyre::Result<()> {
 		let config = Config::default();
 		insta::assert_json_snapshot!(config, @r#"
 		{
@@ -281,6 +283,7 @@ mod tests {
 		  }
 		}
 		"#);
+		Ok(())
 	}
 
 	#[rstest]
@@ -301,7 +304,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn traversal_precedence() {
+	fn traversal_precedence() -> color_eyre::Result<()> {
 		let dir = tempdir().unwrap();
 		let root = dir.path();
 		let subdir = root.join("subdir");
@@ -314,11 +317,12 @@ mod tests {
 		let config = Config::load_internal(None, None, Some(nested).as_ref())
 			.expect("Failed to load config");
 		assert_eq!(config.ssh.host, "subdir");
+		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn traversal_stops_at_home() {
+	fn traversal_stops_at_home() -> color_eyre::Result<()> {
 		let dir = tempdir().unwrap();
 		let root = dir.path();
 		let home = root.join("home");
@@ -336,11 +340,12 @@ mod tests {
 
 		assert_ne!(config.ssh.host, "outside");
 		assert_eq!(config.ssh.host, "cse.unsw.edu.au");
+		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn xdg_precedence() {
+	fn xdg_precedence() -> color_eyre::Result<()> {
 		let dir = tempdir().unwrap();
 		let home = dir.path().join("home");
 		let config_home = home.join(".config");
@@ -351,11 +356,12 @@ mod tests {
 		let config = Config::load_internal(Some(home).as_ref(), Some(config_home).as_ref(), None)
 			.expect("Failed to load config");
 		assert_eq!(config.ssh.host, "xdg");
+		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn cwd_is_dot_config() {
+	fn cwd_is_dot_config() -> color_eyre::Result<()> {
 		let dir = tempdir().unwrap();
 		let project = dir.path().join("project");
 		let dot_config = project.join(".config");
@@ -374,11 +380,12 @@ mod tests {
 
 		// Should skip .config layer and only use project layer -> "standard"
 		assert_eq!(config.ssh.host, "standard");
+		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn nested_within_dot_config() {
+	fn nested_within_dot_config() -> color_eyre::Result<()> {
 		let dir = tempdir().unwrap();
 		let project = dir.path().join("project");
 		let dot_config = project.join(".config");
@@ -399,11 +406,12 @@ mod tests {
 		// Should NOT load "weird" because .config dir should be skipped as a layer
 		assert_ne!(config.ssh.host, "weird");
 		assert_eq!(config.ssh.host, "cse.unsw.edu.au");
+		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn strict_global_config() {
+	fn strict_global_config() -> color_eyre::Result<()> {
 		let dir = tempdir().unwrap();
 		let home = dir.path().join("home");
 		let config_home = home.join(".config");
@@ -415,11 +423,12 @@ mod tests {
 
 		let result = Config::load_internal(Some(home).as_ref(), Some(config_home).as_ref(), None);
 		assert_matches!(result, Err(_));
+		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn strict_local_config() {
+	fn strict_local_config() -> color_eyre::Result<()> {
 		let dir = tempdir().unwrap();
 		// Multiple local configs in same dir should fail
 		fs::write(dir.path().join("biwa.toml"), r#"ssh.host = "toml""#).unwrap();
@@ -431,11 +440,12 @@ mod tests {
 
 		let result = Config::load_internal(None, None, Some(dir.path().to_path_buf()).as_ref());
 		assert_matches!(result, Err(_));
+		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn conflict_root_and_dot_config() {
+	fn conflict_root_and_dot_config() -> color_eyre::Result<()> {
 		let dir = tempdir().unwrap();
 		// Test multiple "local" configs (one within .config) should fail
 		fs::write(dir.path().join("biwa.toml"), r#"ssh.host = "root""#).unwrap();
@@ -447,11 +457,12 @@ mod tests {
 		// Should error because we found >1 config for the same dir scope
 		let result = Config::load_internal(None, None, Some(dir.path().to_path_buf()).as_ref());
 		assert_matches!(result, Err(_));
+		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn local_dot_config_support() {
+	fn local_dot_config_support() -> color_eyre::Result<()> {
 		let dir = tempdir().unwrap();
 		let dot_config = dir.path().join(".config");
 		fs::create_dir_all(&dot_config).unwrap();
@@ -461,11 +472,12 @@ mod tests {
 		let config = Config::load_internal(None, None, Some(dir.path().to_path_buf()).as_ref())
 			.expect("Failed to load config");
 		assert_eq!(config.ssh.host, "dotconfig");
+		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn ignored_xdg_biwa_biwa() {
+	fn ignored_xdg_biwa_biwa() -> color_eyre::Result<()> {
 		let dir = tempdir().unwrap();
 		let home = dir.path().join("home");
 		let config_home = home.join(".config");
@@ -487,11 +499,12 @@ mod tests {
 
 		// Should load "fallback", NOT "ignored"
 		assert_eq!(config.ssh.host, "fallback");
+		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn find_single_config_logic() {
+	fn find_single_config_logic() -> color_eyre::Result<()> {
 		let dir = tempdir().unwrap();
 		let root = dir.path();
 
@@ -523,11 +536,12 @@ mod tests {
 		fs::write(root.join(".biwa.toml"), "").unwrap();
 		let result = find_single_config(&[root.join("biwa"), root.join(".biwa")]);
 		assert_matches!(result, Err(_));
+		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn nested_path_resolution() {
+	fn nested_path_resolution() -> color_eyre::Result<()> {
 		let dir = tempdir().unwrap();
 		let root = dir.path();
 		let subdir = root.join("subdir");
@@ -567,11 +581,12 @@ host = "child"
 			config.sync.remote_root, expected_path,
 			"remote_root should be resolved relative to the config file that defined it"
 		);
+		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn local_config_root_dot_config_biwa() {
+	fn local_config_root_dot_config_biwa() -> color_eyre::Result<()> {
 		let dir = tempdir().unwrap();
 		let project = dir.path().join("project");
 		let dot_config = project.join(".config");
@@ -596,11 +611,12 @@ remote_root = "libs"
 			config.sync.remote_root, expected_path,
 			"remote_root from .config/biwa.toml should be resolved relative to the project root"
 		);
+		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn global_config_root_home_and_xdg() {
+	fn global_config_root_home_and_xdg() -> color_eyre::Result<()> {
 		let dir = tempdir().unwrap();
 		let home = dir.path().join("home");
 		let config_home = home.join(".config");
@@ -645,11 +661,12 @@ remote_root = "xdg_libs"
 			home.join("xdg_libs"),
 			"global remote_root from ~/.config/biwa/config.toml should be resolved relative to ~"
 		);
+		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn relative_key_path_resolved_against_source_config() {
+	fn relative_key_path_resolved_against_source_config() -> color_eyre::Result<()> {
 		// Layout:
 		//   /parent/biwa.toml       -> sets ssh.key_path = "my_key"
 		//   /parent/my_key          -> the key file
@@ -673,11 +690,12 @@ remote_root = "xdg_libs"
 		let resolved = config.ssh.key_path.expect("key_path should be set");
 		let expected = parent.path().join("my_key");
 		assert_eq!(resolved, expected);
+		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn load_partial_invalid_toml() -> eyre::Result<()> {
+	fn load_partial_invalid_toml() -> color_eyre::Result<()> {
 		let dir = tempfile::tempdir()?;
 		let path = dir.path().join("config.toml");
 		// Write invalid TOML
@@ -698,7 +716,7 @@ remote_root = "xdg_libs"
 
 	#[serial]
 	#[test]
-	fn load_partial_invalid_yaml() -> eyre::Result<()> {
+	fn load_partial_invalid_yaml() -> color_eyre::Result<()> {
 		let dir = tempfile::tempdir()?;
 		let path = dir.path().join("config.yaml");
 		// Write invalid YAML
@@ -719,7 +737,7 @@ remote_root = "xdg_libs"
 
 	#[serial]
 	#[test]
-	fn load_partial_invalid_json() -> eyre::Result<()> {
+	fn load_partial_invalid_json() -> color_eyre::Result<()> {
 		let dir = tempfile::tempdir()?;
 		let path = dir.path().join("config.json");
 		// Write invalid JSON
@@ -740,7 +758,7 @@ remote_root = "xdg_libs"
 
 	#[serial]
 	#[test]
-	fn load_partial_valid_json5() -> eyre::Result<()> {
+	fn load_partial_valid_json5() -> color_eyre::Result<()> {
 		let dir = tempfile::tempdir()?;
 		let path = dir.path().join("config.json5");
 		// Write valid JSON5 (with comments and trailing commas)

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -1,7 +1,8 @@
 use super::format::ConfigFormat;
 use super::types::Config;
+use crate::Result;
+use color_eyre::eyre::{WrapErr as _, bail};
 use confique::Config as _;
-use eyre::{Result, WrapErr as _};
 use std::path::{Path, PathBuf};
 use std::{env, fs};
 
@@ -186,7 +187,7 @@ fn find_single_config(base_paths_no_ext: &[PathBuf]) -> Result<Option<(PathBuf, 
 				.iter()
 				.map(|(p, _)| p.to_string_lossy().into_owned())
 				.collect();
-			eyre::bail!(
+			bail!(
 				"Multiple configuration files found in the same scope: {}. Only one is allowed.",
 				paths.join(", ")
 			);
@@ -209,7 +210,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn default() -> color_eyre::Result<()> {
+	fn default() -> Result<()> {
 		let config = Config::default();
 		assert_eq!(config.ssh.host, "cse.unsw.edu.au");
 		assert_eq!(config.ssh.port, 22);
@@ -220,7 +221,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn env_override() -> color_eyre::Result<()> {
+	fn env_override() -> Result<()> {
 		let dir = tempdir().unwrap();
 		fs::write(dir.path().join("biwa.toml"), r#"ssh.host = "file""#).unwrap();
 
@@ -251,7 +252,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn snapshot() -> color_eyre::Result<()> {
+	fn snapshot() -> Result<()> {
 		let config = Config::default();
 		insta::assert_json_snapshot!(config, @r#"
 		{
@@ -304,7 +305,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn traversal_precedence() -> color_eyre::Result<()> {
+	fn traversal_precedence() -> Result<()> {
 		let dir = tempdir().unwrap();
 		let root = dir.path();
 		let subdir = root.join("subdir");
@@ -322,7 +323,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn traversal_stops_at_home() -> color_eyre::Result<()> {
+	fn traversal_stops_at_home() -> Result<()> {
 		let dir = tempdir().unwrap();
 		let root = dir.path();
 		let home = root.join("home");
@@ -345,7 +346,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn xdg_precedence() -> color_eyre::Result<()> {
+	fn xdg_precedence() -> Result<()> {
 		let dir = tempdir().unwrap();
 		let home = dir.path().join("home");
 		let config_home = home.join(".config");
@@ -361,7 +362,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn cwd_is_dot_config() -> color_eyre::Result<()> {
+	fn cwd_is_dot_config() -> Result<()> {
 		let dir = tempdir().unwrap();
 		let project = dir.path().join("project");
 		let dot_config = project.join(".config");
@@ -385,7 +386,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn nested_within_dot_config() -> color_eyre::Result<()> {
+	fn nested_within_dot_config() -> Result<()> {
 		let dir = tempdir().unwrap();
 		let project = dir.path().join("project");
 		let dot_config = project.join(".config");
@@ -411,7 +412,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn strict_global_config() -> color_eyre::Result<()> {
+	fn strict_global_config() -> Result<()> {
 		let dir = tempdir().unwrap();
 		let home = dir.path().join("home");
 		let config_home = home.join(".config");
@@ -428,7 +429,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn strict_local_config() -> color_eyre::Result<()> {
+	fn strict_local_config() -> Result<()> {
 		let dir = tempdir().unwrap();
 		// Multiple local configs in same dir should fail
 		fs::write(dir.path().join("biwa.toml"), r#"ssh.host = "toml""#).unwrap();
@@ -445,7 +446,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn conflict_root_and_dot_config() -> color_eyre::Result<()> {
+	fn conflict_root_and_dot_config() -> Result<()> {
 		let dir = tempdir().unwrap();
 		// Test multiple "local" configs (one within .config) should fail
 		fs::write(dir.path().join("biwa.toml"), r#"ssh.host = "root""#).unwrap();
@@ -462,7 +463,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn local_dot_config_support() -> color_eyre::Result<()> {
+	fn local_dot_config_support() -> Result<()> {
 		let dir = tempdir().unwrap();
 		let dot_config = dir.path().join(".config");
 		fs::create_dir_all(&dot_config).unwrap();
@@ -477,7 +478,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn ignored_xdg_biwa_biwa() -> color_eyre::Result<()> {
+	fn ignored_xdg_biwa_biwa() -> Result<()> {
 		let dir = tempdir().unwrap();
 		let home = dir.path().join("home");
 		let config_home = home.join(".config");
@@ -504,7 +505,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn find_single_config_logic() -> color_eyre::Result<()> {
+	fn find_single_config_logic() -> Result<()> {
 		let dir = tempdir().unwrap();
 		let root = dir.path();
 
@@ -541,7 +542,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn nested_path_resolution() -> color_eyre::Result<()> {
+	fn nested_path_resolution() -> Result<()> {
 		let dir = tempdir().unwrap();
 		let root = dir.path();
 		let subdir = root.join("subdir");
@@ -586,7 +587,7 @@ host = "child"
 
 	#[serial]
 	#[test]
-	fn local_config_root_dot_config_biwa() -> color_eyre::Result<()> {
+	fn local_config_root_dot_config_biwa() -> Result<()> {
 		let dir = tempdir().unwrap();
 		let project = dir.path().join("project");
 		let dot_config = project.join(".config");
@@ -616,7 +617,7 @@ remote_root = "libs"
 
 	#[serial]
 	#[test]
-	fn global_config_root_home_and_xdg() -> color_eyre::Result<()> {
+	fn global_config_root_home_and_xdg() -> Result<()> {
 		let dir = tempdir().unwrap();
 		let home = dir.path().join("home");
 		let config_home = home.join(".config");
@@ -666,7 +667,7 @@ remote_root = "xdg_libs"
 
 	#[serial]
 	#[test]
-	fn relative_key_path_resolved_against_source_config() -> color_eyre::Result<()> {
+	fn relative_key_path_resolved_against_source_config() -> Result<()> {
 		// Layout:
 		//   /parent/biwa.toml       -> sets ssh.key_path = "my_key"
 		//   /parent/my_key          -> the key file
@@ -695,7 +696,7 @@ remote_root = "xdg_libs"
 
 	#[serial]
 	#[test]
-	fn load_partial_invalid_toml() -> color_eyre::Result<()> {
+	fn load_partial_invalid_toml() -> Result<()> {
 		let dir = tempfile::tempdir()?;
 		let path = dir.path().join("config.toml");
 		// Write invalid TOML
@@ -704,19 +705,18 @@ remote_root = "xdg_libs"
 		let result = Config::load_partial(&path, ConfigFormat::Toml, dir.path());
 		let err = match result {
 			Err(e) => e.to_string(),
-			Ok(_) => eyre::bail!("Expected parsing error for invalid TOML"),
+			Ok(_) => bail!("Expected parsing error for invalid TOML"),
 		};
-		eyre::ensure!(
+		assert!(
 			err.contains("Failed to parse TOML"),
-			"Error string mismatch: {}",
-			err
+			"Error string mismatch: {err}"
 		);
 		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn load_partial_invalid_yaml() -> color_eyre::Result<()> {
+	fn load_partial_invalid_yaml() -> Result<()> {
 		let dir = tempfile::tempdir()?;
 		let path = dir.path().join("config.yaml");
 		// Write invalid YAML
@@ -725,19 +725,18 @@ remote_root = "xdg_libs"
 		let result = Config::load_partial(&path, ConfigFormat::Yaml, dir.path());
 		let err = match result {
 			Err(e) => e.to_string(),
-			Ok(_) => eyre::bail!("Expected parsing error for invalid YAML"),
+			Ok(_) => bail!("Expected parsing error for invalid YAML"),
 		};
-		eyre::ensure!(
+		assert!(
 			err.contains("Failed to parse YAML"),
-			"Error string mismatch: {}",
-			err
+			"Error string mismatch: {err}"
 		);
 		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn load_partial_invalid_json() -> color_eyre::Result<()> {
+	fn load_partial_invalid_json() -> Result<()> {
 		let dir = tempfile::tempdir()?;
 		let path = dir.path().join("config.json");
 		// Write invalid JSON
@@ -746,19 +745,18 @@ remote_root = "xdg_libs"
 		let result = Config::load_partial(&path, ConfigFormat::Json, dir.path());
 		let err = match result {
 			Err(e) => e.to_string(),
-			Ok(_) => eyre::bail!("Expected parsing error for invalid JSON"),
+			Ok(_) => bail!("Expected parsing error for invalid JSON"),
 		};
-		eyre::ensure!(
+		assert!(
 			err.contains("Failed to parse JSON"),
-			"Error string mismatch: {}",
-			err
+			"Error string mismatch: {err}"
 		);
 		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn load_partial_valid_json5() -> color_eyre::Result<()> {
+	fn load_partial_valid_json5() -> Result<()> {
 		let dir = tempfile::tempdir()?;
 		let path = dir.path().join("config.json5");
 		// Write valid JSON5 (with comments and trailing commas)
@@ -775,7 +773,7 @@ remote_root = "xdg_libs"
 		)?;
 
 		let result = Config::load_partial(&path, ConfigFormat::Json5, dir.path());
-		eyre::ensure!(result.is_ok(), "Failed to parse valid JSON5");
+		assert!(result.is_ok(), "Failed to parse valid JSON5");
 		Ok(())
 	}
 }

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -210,20 +210,19 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn default() -> Result<()> {
+	fn default() {
 		let config = Config::default();
 		assert_eq!(config.ssh.host, "cse.unsw.edu.au");
 		assert_eq!(config.ssh.port, 22);
 		assert_eq!(config.ssh.user, "z1234567");
 		assert!(config.sync.remote_root.ends_with(".cache/biwa/projects"));
-		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn env_override() -> Result<()> {
-		let dir = tempdir().unwrap();
-		fs::write(dir.path().join("biwa.toml"), r#"ssh.host = "file""#).unwrap();
+	fn env_override() -> crate::Result<()> {
+		let dir = tempdir()?;
+		fs::write(dir.path().join("biwa.toml"), r#"ssh.host = "file""#)?;
 
 		// Set env var override
 		// SAFETY: This is a single-threaded test context modifying the environment for current process.
@@ -242,8 +241,7 @@ mod tests {
 		let _cleanup1 = EnvCleanup("BIWA_SSH_HOST");
 		let _cleanup2 = EnvCleanup("BIWA_SSH_PORT");
 
-		let config = Config::load_internal(None, None, Some(dir.path().to_path_buf()).as_ref())
-			.expect("Failed to load config");
+		let config = Config::load_internal(None, None, Some(dir.path().to_path_buf()).as_ref())?;
 
 		assert_eq!(config.ssh.host, "env");
 		assert_eq!(config.ssh.port, 8080);
@@ -252,7 +250,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn snapshot() -> Result<()> {
+	fn snapshot() {
 		let config = Config::default();
 		insta::assert_json_snapshot!(config, @r#"
 		{
@@ -284,7 +282,6 @@ mod tests {
 		  }
 		}
 		"#);
-		Ok(())
 	}
 
 	#[rstest]
@@ -293,51 +290,53 @@ mod tests {
 	#[case::json(r#"{ "ssh": { "host": "json" } }"#, "json", "json")]
 	#[case::json5("{ ssh: { host: 'json5' } }", "json5", "json5")]
 	#[case::yaml("ssh:\n  host: yaml", "yaml", "yaml")]
-	fn format_extensions(#[case] content: &str, #[case] ext: &str, #[case] expected: &str) {
-		let dir = tempdir().unwrap();
+	fn format_extensions(
+		#[case] content: &str,
+		#[case] ext: &str,
+		#[case] expected: &str,
+	) -> crate::Result<()> {
+		let dir = tempdir()?;
 		let file_path = dir.path().join(format!("biwa.{ext}"));
-		fs::write(&file_path, content).unwrap();
+		fs::write(&file_path, content)?;
 
-		let config = Config::load_internal(None, None, Some(dir.path().to_path_buf()).as_ref())
-			.expect("Failed to load config");
+		let config = Config::load_internal(None, None, Some(dir.path().to_path_buf()).as_ref())?;
 		assert_eq!(config.ssh.host, expected);
+		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn traversal_precedence() -> Result<()> {
-		let dir = tempdir().unwrap();
+	fn traversal_precedence() -> crate::Result<()> {
+		let dir = tempdir()?;
 		let root = dir.path();
 		let subdir = root.join("subdir");
 		let nested = subdir.join("nested");
-		fs::create_dir_all(&nested).unwrap();
+		fs::create_dir_all(&nested)?;
 
-		fs::write(root.join("biwa.toml"), r#"ssh.host = "root""#).unwrap();
-		fs::write(subdir.join("biwa.toml"), r#"ssh.host = "subdir""#).unwrap();
+		fs::write(root.join("biwa.toml"), r#"ssh.host = "root""#)?;
+		fs::write(subdir.join("biwa.toml"), r#"ssh.host = "subdir""#)?;
 
-		let config = Config::load_internal(None, None, Some(nested).as_ref())
-			.expect("Failed to load config");
+		let config = Config::load_internal(None, None, Some(nested).as_ref())?;
 		assert_eq!(config.ssh.host, "subdir");
 		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn traversal_stops_at_home() -> Result<()> {
-		let dir = tempdir().unwrap();
+	fn traversal_stops_at_home() -> crate::Result<()> {
+		let dir = tempdir()?;
 		let root = dir.path();
 		let home = root.join("home");
 		let project = home.join("project");
-		fs::create_dir_all(&project).unwrap();
+		fs::create_dir_all(&project)?;
 
 		// Config in root (parent of home) - should NOT be loaded if traversal stops at home
-		fs::write(root.join("biwa.toml"), r#"ssh.host = "outside""#).unwrap();
+		fs::write(root.join("biwa.toml"), r#"ssh.host = "outside""#)?;
 
 		// We need to initialize the home dir so it's a valid path for test logic if needed
-		fs::create_dir_all(&home).unwrap();
+		fs::create_dir_all(&home)?;
 
-		let config = Config::load_internal(Some(&home), None, Some(&project))
-			.expect("Failed to load config");
+		let config = Config::load_internal(Some(&home), None, Some(&project))?;
 
 		assert_ne!(config.ssh.host, "outside");
 		assert_eq!(config.ssh.host, "cse.unsw.edu.au");
@@ -346,38 +345,36 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn xdg_precedence() -> Result<()> {
-		let dir = tempdir().unwrap();
+	fn xdg_precedence() -> crate::Result<()> {
+		let dir = tempdir()?;
 		let home = dir.path().join("home");
 		let config_home = home.join(".config");
-		fs::create_dir_all(config_home.join("biwa")).unwrap();
+		fs::create_dir_all(config_home.join("biwa"))?;
 
-		fs::write(config_home.join("biwa/config.toml"), r#"ssh.host = "xdg""#).unwrap();
+		fs::write(config_home.join("biwa/config.toml"), r#"ssh.host = "xdg""#)?;
 
-		let config = Config::load_internal(Some(home).as_ref(), Some(config_home).as_ref(), None)
-			.expect("Failed to load config");
+		let config = Config::load_internal(Some(home).as_ref(), Some(config_home).as_ref(), None)?;
 		assert_eq!(config.ssh.host, "xdg");
 		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn cwd_is_dot_config() -> Result<()> {
-		let dir = tempdir().unwrap();
+	fn cwd_is_dot_config() -> crate::Result<()> {
+		let dir = tempdir()?;
 		let project = dir.path().join("project");
 		let dot_config = project.join(".config");
 		let biwa_dir = dot_config.join("biwa");
-		fs::create_dir_all(&biwa_dir).unwrap();
+		fs::create_dir_all(&biwa_dir)?;
 
 		// Standard config locatable from 'project' layer
-		fs::write(dot_config.join("biwa.toml"), r#"ssh.host = "standard""#).unwrap();
+		fs::write(dot_config.join("biwa.toml"), r#"ssh.host = "standard""#)?;
 
 		// Weird config only locatable if '.config' is a layer
-		fs::write(dot_config.join(".biwa.toml"), r#"ssh.host = "weird""#).unwrap();
+		fs::write(dot_config.join(".biwa.toml"), r#"ssh.host = "weird""#)?;
 
 		// CWD is .config
-		let config =
-			Config::load_internal(None, None, Some(&dot_config)).expect("Failed to load config");
+		let config = Config::load_internal(None, None, Some(&dot_config))?;
 
 		// Should skip .config layer and only use project layer -> "standard"
 		assert_eq!(config.ssh.host, "standard");
@@ -386,12 +383,12 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn nested_within_dot_config() -> Result<()> {
-		let dir = tempdir().unwrap();
+	fn nested_within_dot_config() -> crate::Result<()> {
+		let dir = tempdir()?;
 		let project = dir.path().join("project");
 		let dot_config = project.join(".config");
 		let subdir = dot_config.join("subdir");
-		fs::create_dir_all(&subdir).unwrap();
+		fs::create_dir_all(&subdir)?;
 
 		// A config file that would ONLY be found if we treat '.config' as a project layer
 		// layer '.config' -> candidates: .config/biwa, .config/.biwa, ...
@@ -399,10 +396,9 @@ mod tests {
 		//
 		// layer 'project' -> candidates: project/biwa, project/.biwa, project/.config/biwa
 		// does NOT match project/.config/.biwa.toml (only .config/biwa)
-		fs::write(dot_config.join(".biwa.toml"), r#"ssh.host = "weird""#).unwrap();
+		fs::write(dot_config.join(".biwa.toml"), r#"ssh.host = "weird""#)?;
 
-		let config =
-			Config::load_internal(None, None, Some(&subdir)).expect("Failed to load config");
+		let config = Config::load_internal(None, None, Some(&subdir))?;
 
 		// Should NOT load "weird" because .config dir should be skipped as a layer
 		assert_ne!(config.ssh.host, "weird");
@@ -412,15 +408,15 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn strict_global_config() -> Result<()> {
-		let dir = tempdir().unwrap();
+	fn strict_global_config() -> crate::Result<()> {
+		let dir = tempdir()?;
 		let home = dir.path().join("home");
 		let config_home = home.join(".config");
-		fs::create_dir_all(config_home.join("biwa")).unwrap();
+		fs::create_dir_all(config_home.join("biwa"))?;
 
 		// Multiple global configs should fail
-		fs::write(home.join("biwa.toml"), r#"ssh.host = "home""#).unwrap();
-		fs::write(config_home.join("biwa/config.toml"), r#"ssh.host = "xdg""#).unwrap();
+		fs::write(home.join("biwa.toml"), r#"ssh.host = "home""#)?;
+		fs::write(config_home.join("biwa/config.toml"), r#"ssh.host = "xdg""#)?;
 
 		let result = Config::load_internal(Some(home).as_ref(), Some(config_home).as_ref(), None);
 		assert_matches!(result, Err(_));
@@ -429,15 +425,14 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn strict_local_config() -> Result<()> {
-		let dir = tempdir().unwrap();
+	fn strict_local_config() -> crate::Result<()> {
+		let dir = tempdir()?;
 		// Multiple local configs in same dir should fail
-		fs::write(dir.path().join("biwa.toml"), r#"ssh.host = "toml""#).unwrap();
+		fs::write(dir.path().join("biwa.toml"), r#"ssh.host = "toml""#)?;
 		fs::write(
 			dir.path().join(".biwa.json"),
 			r#"{"ssh": {"host": "json"}}"#,
-		)
-		.unwrap();
+		)?;
 
 		let result = Config::load_internal(None, None, Some(dir.path().to_path_buf()).as_ref());
 		assert_matches!(result, Err(_));
@@ -446,14 +441,14 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn conflict_root_and_dot_config() -> Result<()> {
-		let dir = tempdir().unwrap();
+	fn conflict_root_and_dot_config() -> crate::Result<()> {
+		let dir = tempdir()?;
 		// Test multiple "local" configs (one within .config) should fail
-		fs::write(dir.path().join("biwa.toml"), r#"ssh.host = "root""#).unwrap();
+		fs::write(dir.path().join("biwa.toml"), r#"ssh.host = "root""#)?;
 
 		let dot_config = dir.path().join(".config");
-		fs::create_dir_all(&dot_config).unwrap();
-		fs::write(dot_config.join("biwa.toml"), r#"ssh.host = "dotconfig""#).unwrap();
+		fs::create_dir_all(&dot_config)?;
+		fs::write(dot_config.join("biwa.toml"), r#"ssh.host = "dotconfig""#)?;
 
 		// Should error because we found >1 config for the same dir scope
 		let result = Config::load_internal(None, None, Some(dir.path().to_path_buf()).as_ref());
@@ -463,40 +458,37 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn local_dot_config_support() -> Result<()> {
-		let dir = tempdir().unwrap();
+	fn local_dot_config_support() -> crate::Result<()> {
+		let dir = tempdir()?;
 		let dot_config = dir.path().join(".config");
-		fs::create_dir_all(&dot_config).unwrap();
+		fs::create_dir_all(&dot_config)?;
 
-		fs::write(dot_config.join("biwa.toml"), r#"ssh.host = "dotconfig""#).unwrap();
+		fs::write(dot_config.join("biwa.toml"), r#"ssh.host = "dotconfig""#)?;
 
-		let config = Config::load_internal(None, None, Some(dir.path().to_path_buf()).as_ref())
-			.expect("Failed to load config");
+		let config = Config::load_internal(None, None, Some(dir.path().to_path_buf()).as_ref())?;
 		assert_eq!(config.ssh.host, "dotconfig");
 		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn ignored_xdg_biwa_biwa() -> Result<()> {
-		let dir = tempdir().unwrap();
+	fn ignored_xdg_biwa_biwa() -> crate::Result<()> {
+		let dir = tempdir()?;
 		let home = dir.path().join("home");
 		let config_home = home.join(".config");
-		fs::create_dir_all(config_home.join("biwa")).unwrap();
+		fs::create_dir_all(config_home.join("biwa"))?;
 
 		// This should be ignored: ~/.config/biwa/biwa.toml
 		fs::write(
 			config_home.join("biwa/biwa.toml"),
 			r#"ssh.host = "ignored""#,
-		)
-		.unwrap();
+		)?;
 
 		// This is a valid global config: ~/biwa.toml
 		// We use this to verify that the other one was indeed ignored and didn't conflict/override.
-		fs::write(home.join("biwa.toml"), r#"ssh.host = "fallback""#).unwrap();
+		fs::write(home.join("biwa.toml"), r#"ssh.host = "fallback""#)?;
 
-		let config = Config::load_internal(Some(home).as_ref(), Some(config_home).as_ref(), None)
-			.expect("Failed to load config");
+		let config = Config::load_internal(Some(home).as_ref(), Some(config_home).as_ref(), None)?;
 
 		// Should load "fallback", NOT "ignored"
 		assert_eq!(config.ssh.host, "fallback");
@@ -505,36 +497,36 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn find_single_config_logic() -> Result<()> {
-		let dir = tempdir().unwrap();
+	fn find_single_config_logic() -> crate::Result<()> {
+		let dir = tempdir()?;
 		let root = dir.path();
 
 		// 1. No config
 		let result = find_single_config(&[root.join("biwa")]);
-		assert!(result.unwrap().is_none());
+		assert!(result?.is_none());
 
 		// 2. Single config
-		fs::write(root.join("biwa.toml"), "").unwrap();
+		fs::write(root.join("biwa.toml"), "")?;
 		let result = find_single_config(&[root.join("biwa")]);
-		let (path, format) = result.unwrap().unwrap();
+		let (path, format) = result?.ok_or_else(|| color_eyre::eyre::eyre!("Expected Some"))?;
 		assert_eq!(path, root.join("biwa.toml"));
 		assert_eq!(format, ConfigFormat::Toml);
 
 		// 3. Multiple formats for same base -> Error (Strictness)
 		// Note: find_single_config logic checks across extensions for a single base too?
 		// "Multiple configuration files found in the same scope"
-		fs::write(root.join("biwa.json"), "{}").unwrap();
+		fs::write(root.join("biwa.json"), "{}")?;
 		let result = find_single_config(&[root.join("biwa")]);
 		assert_matches!(result, Err(_));
 
 		// Cleanup for next check
-		fs::remove_file(root.join("biwa.toml")).unwrap();
-		fs::remove_file(root.join("biwa.json")).unwrap();
+		fs::remove_file(root.join("biwa.toml"))?;
+		fs::remove_file(root.join("biwa.json"))?;
 
 		// 4. Multiple bases in list -> Error if both exist
 		// e.g. biwa.toml and .biwa.toml
-		fs::write(root.join("biwa.toml"), "").unwrap();
-		fs::write(root.join(".biwa.toml"), "").unwrap();
+		fs::write(root.join("biwa.toml"), "")?;
+		fs::write(root.join(".biwa.toml"), "")?;
 		let result = find_single_config(&[root.join("biwa"), root.join(".biwa")]);
 		assert_matches!(result, Err(_));
 		Ok(())
@@ -542,11 +534,11 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn nested_path_resolution() -> Result<()> {
-		let dir = tempdir().unwrap();
+	fn nested_path_resolution() -> crate::Result<()> {
+		let dir = tempdir()?;
 		let root = dir.path();
 		let subdir = root.join("subdir");
-		fs::create_dir_all(&subdir).unwrap();
+		fs::create_dir_all(&subdir)?;
 
 		// Parent config defines a relative path
 		// "libs" should be resolved relative to `root`
@@ -556,8 +548,7 @@ mod tests {
 [sync]
 remote_root = "libs"
 "#,
-		)
-		.unwrap();
+		)?;
 
 		// Child config overrides something else, but inherits remote_root
 		fs::write(
@@ -566,14 +557,12 @@ remote_root = "libs"
 [ssh]
 host = "child"
 "#,
-		)
-		.unwrap();
+		)?;
 
 		// Load config from subdir
 		// Expected: remote_root should be root/libs
 		// Actual (bug): remote_root is subdir/libs because it resolves relative to the innermost config root
-		let config =
-			Config::load_internal(None, None, Some(&subdir)).expect("Failed to load config");
+		let config = Config::load_internal(None, None, Some(&subdir))?;
 
 		let expected_path = root.join("libs");
 
@@ -587,11 +576,11 @@ host = "child"
 
 	#[serial]
 	#[test]
-	fn local_config_root_dot_config_biwa() -> Result<()> {
-		let dir = tempdir().unwrap();
+	fn local_config_root_dot_config_biwa() -> crate::Result<()> {
+		let dir = tempdir()?;
 		let project = dir.path().join("project");
 		let dot_config = project.join(".config");
-		fs::create_dir_all(&dot_config).unwrap();
+		fs::create_dir_all(&dot_config)?;
 
 		// Local config in .config/biwa.toml should use the project root (`project`)
 		// as its config root, not the .config directory itself.
@@ -601,11 +590,9 @@ host = "child"
 [sync]
 remote_root = "libs"
 "#,
-		)
-		.unwrap();
+		)?;
 
-		let config =
-			Config::load_internal(None, None, Some(&project)).expect("Failed to load config");
+		let config = Config::load_internal(None, None, Some(&project))?;
 
 		let expected_path = project.join("libs");
 		assert_eq!(
@@ -617,12 +604,12 @@ remote_root = "libs"
 
 	#[serial]
 	#[test]
-	fn global_config_root_home_and_xdg() -> Result<()> {
-		let dir = tempdir().unwrap();
+	fn global_config_root_home_and_xdg() -> crate::Result<()> {
+		let dir = tempdir()?;
 		let home = dir.path().join("home");
 		let config_home = home.join(".config");
-		fs::create_dir_all(&home).unwrap();
-		fs::create_dir_all(config_home.join("biwa")).unwrap();
+		fs::create_dir_all(&home)?;
+		fs::create_dir_all(config_home.join("biwa"))?;
 
 		// Global config at ~/biwa.toml
 		fs::write(
@@ -631,11 +618,9 @@ remote_root = "libs"
 [sync]
 remote_root = "global_libs"
 "#,
-		)
-		.unwrap();
+		)?;
 
-		let config = Config::load_internal(Some(&home), Some(&config_home), None)
-			.expect("Failed to load config");
+		let config = Config::load_internal(Some(&home), Some(&config_home), None)?;
 		assert_eq!(
 			config.sync.remote_root,
 			home.join("global_libs"),
@@ -643,7 +628,7 @@ remote_root = "global_libs"
 		);
 
 		// Only one global config is allowed; remove the home config before testing the XDG variant.
-		fs::remove_file(home.join("biwa.toml")).unwrap();
+		fs::remove_file(home.join("biwa.toml"))?;
 
 		// Override with XDG-style global config at ~/.config/biwa/config.toml
 		fs::write(
@@ -652,11 +637,9 @@ remote_root = "global_libs"
 [sync]
 remote_root = "xdg_libs"
 "#,
-		)
-		.unwrap();
+		)?;
 
-		let config = Config::load_internal(Some(&home), Some(&config_home), None)
-			.expect("Failed to load config");
+		let config = Config::load_internal(Some(&home), Some(&config_home), None)?;
 		assert_eq!(
 			config.sync.remote_root,
 			home.join("xdg_libs"),
@@ -667,28 +650,29 @@ remote_root = "xdg_libs"
 
 	#[serial]
 	#[test]
-	fn relative_key_path_resolved_against_source_config() -> Result<()> {
+	fn relative_key_path_resolved_against_source_config() -> crate::Result<()> {
 		// Layout:
 		//   /parent/biwa.toml       -> sets ssh.key_path = "my_key"
 		//   /parent/my_key          -> the key file
 		//   /parent/child/biwa.toml -> overrides ssh.host only
-		let parent = tempdir().unwrap();
+		let parent = tempdir()?;
 		let child = parent.path().join("child");
-		fs::create_dir_all(&child).unwrap();
+		fs::create_dir_all(&child)?;
 
 		fs::write(
 			parent.path().join("biwa.toml"),
 			"[ssh]\nkey_path = \"my_key\"\n",
-		)
-		.unwrap();
-		fs::write(parent.path().join("my_key"), "fake key").unwrap();
-		fs::write(child.join("biwa.toml"), "[ssh]\nhost = \"other.host\"\n").unwrap();
+		)?;
+		fs::write(parent.path().join("my_key"), "fake key")?;
+		fs::write(child.join("biwa.toml"), "[ssh]\nhost = \"other.host\"\n")?;
 
-		let config =
-			Config::load_internal(None, None, Some(&child)).expect("failed to load config");
+		let config = Config::load_internal(None, None, Some(&child))?;
 
 		// key_path should be resolved to parent/my_key, not child/my_key
-		let resolved = config.ssh.key_path.expect("key_path should be set");
+		let resolved = config
+			.ssh
+			.key_path
+			.ok_or_else(|| color_eyre::eyre::eyre!("key_path should be set"))?;
 		let expected = parent.path().join("my_key");
 		assert_eq!(resolved, expected);
 		Ok(())
@@ -696,7 +680,7 @@ remote_root = "xdg_libs"
 
 	#[serial]
 	#[test]
-	fn load_partial_invalid_toml() -> Result<()> {
+	fn load_partial_invalid_toml() -> crate::Result<()> {
 		let dir = tempfile::tempdir()?;
 		let path = dir.path().join("config.toml");
 		// Write invalid TOML
@@ -716,7 +700,7 @@ remote_root = "xdg_libs"
 
 	#[serial]
 	#[test]
-	fn load_partial_invalid_yaml() -> Result<()> {
+	fn load_partial_invalid_yaml() -> crate::Result<()> {
 		let dir = tempfile::tempdir()?;
 		let path = dir.path().join("config.yaml");
 		// Write invalid YAML
@@ -736,7 +720,7 @@ remote_root = "xdg_libs"
 
 	#[serial]
 	#[test]
-	fn load_partial_invalid_json() -> Result<()> {
+	fn load_partial_invalid_json() -> crate::Result<()> {
 		let dir = tempfile::tempdir()?;
 		let path = dir.path().join("config.json");
 		// Write invalid JSON

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,14 @@ mod testing;
 mod ui;
 
 #[tokio::main]
-async fn main() -> eyre::Result<()> {
+async fn main() -> color_eyre::Result<()> {
+	color_eyre::install()?;
 	cli::run().await?;
 	Ok(())
+}
+
+#[cfg(test)]
+#[ctor::ctor]
+fn init_test_env() {
+	color_eyre::install().ok();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,13 @@
 		reason = "some tests have repeated variable names"
 	)
 )]
+#![cfg_attr(
+	test,
+	allow(clippy::panic_in_result_fn, reason = "color_eyre handles panics")
+)]
+
+#[expect(clippy::disallowed_types, reason = "crate::Eyre")]
+pub type Result<T> = color_eyre::Result<T>;
 
 /// CLI commands and parsing.
 mod cli;
@@ -22,7 +29,7 @@ mod testing;
 mod ui;
 
 #[tokio::main]
-async fn main() -> color_eyre::Result<()> {
+async fn main() -> Result<()> {
 	color_eyre::install()?;
 	cli::run().await?;
 	Ok(())
@@ -31,5 +38,9 @@ async fn main() -> color_eyre::Result<()> {
 #[cfg(test)]
 #[ctor::ctor]
 fn init_test_env() {
+	#[expect(
+		clippy::unused_result_ok,
+		reason = "Multiple tests may attempt to initialize the global error handler."
+	)]
 	color_eyre::install().ok();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,10 @@
 	allow(clippy::panic_in_result_fn, reason = "color_eyre handles panics")
 )]
 
-#[expect(clippy::disallowed_types, reason = "This is the crate's central Result type definition.")]
+#[expect(
+	clippy::disallowed_types,
+	reason = "This is the crate's central Result type definition."
+)]
 pub type Result<T> = color_eyre::Result<T>;
 
 /// CLI commands and parsing.

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@
 	allow(clippy::panic_in_result_fn, reason = "color_eyre handles panics")
 )]
 
-#[expect(clippy::disallowed_types, reason = "crate::Eyre")]
+#[expect(clippy::disallowed_types, reason = "This is the crate's central Result type definition.")]
 pub type Result<T> = color_eyre::Result<T>;
 
 /// CLI commands and parsing.

--- a/src/ssh/auth.rs
+++ b/src/ssh/auth.rs
@@ -130,7 +130,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn resolve_default_key_path_explicit() -> eyre::Result<()> {
+	fn resolve_default_key_path_explicit() -> color_eyre::Result<()> {
 		let dir = tempfile::tempdir()?;
 		let key_file = dir.path().join("my_key");
 		fs::write(&key_file, "fake key")?;
@@ -145,7 +145,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn resolve_auth_missing_explicit_key_errors() {
+	fn resolve_auth_missing_explicit_key_errors() -> color_eyre::Result<()> {
 		let mut config = Config::default();
 		config.ssh.key_path = Some(PathBuf::from("/nonexistent/path/key"));
 
@@ -153,19 +153,21 @@ mod tests {
 		assert!(result.is_err());
 		let err_msg = result.unwrap_err().to_string();
 		assert!(err_msg.contains("not found"), "Error: {err_msg}");
+		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn resolve_default_key_path_no_config() {
+	fn resolve_default_key_path_no_config() -> color_eyre::Result<()> {
 		// Verify the function runs without panic; it may or may not find a key
 		// depending on the test environment.
 		let _path = resolve_default_key_path();
+		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn try_agent_checks_env() {
+	fn try_agent_checks_env() -> color_eyre::Result<()> {
 		// SAFETY: `#[serial]` ensures no concurrent env mutation across tests.
 		unsafe {
 			env::set_var("SSH_AUTH_SOCK", "/tmp/fake-agent.sock");
@@ -183,11 +185,12 @@ mod tests {
 			!try_agent(),
 			"expected no agent when SSH_AUTH_SOCK is unset"
 		);
+		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn password_config_string() -> eyre::Result<()> {
+	fn password_config_string() -> color_eyre::Result<()> {
 		let mut config = Config::default();
 		config.ssh.password = PasswordConfig::Value("secret".to_owned());
 		let method = resolve_auth(&config)?;
@@ -197,7 +200,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn password_config_false() {
+	fn password_config_false() -> color_eyre::Result<()> {
 		let mut config = Config::default();
 		config.ssh.password = PasswordConfig::Interactive(false);
 		let result = resolve_auth(&config);
@@ -209,5 +212,6 @@ mod tests {
 				AuthMethod::PrivateKeyFile { .. } | AuthMethod::Agent
 			);
 		}
+		Ok(())
 	}
 }

--- a/src/ssh/auth.rs
+++ b/src/ssh/auth.rs
@@ -132,7 +132,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn resolve_default_key_path_explicit() -> Result<()> {
+	fn resolve_default_key_path_explicit() -> crate::Result<()> {
 		let dir = tempfile::tempdir()?;
 		let key_file = dir.path().join("my_key");
 		fs::write(&key_file, "fake key")?;
@@ -147,7 +147,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn resolve_auth_missing_explicit_key_errors() -> Result<()> {
+	fn resolve_auth_missing_explicit_key_errors() {
 		let mut config = Config::default();
 		config.ssh.key_path = Some(PathBuf::from("/nonexistent/path/key"));
 
@@ -155,21 +155,19 @@ mod tests {
 		assert!(result.is_err());
 		let err_msg = result.unwrap_err().to_string();
 		assert!(err_msg.contains("not found"), "Error: {err_msg}");
-		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn resolve_default_key_path_no_config() -> Result<()> {
+	fn resolve_default_key_path_no_config() {
 		// Verify the function runs without panic; it may or may not find a key
 		// depending on the test environment.
 		let _path = resolve_default_key_path();
-		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn try_agent_checks_env() -> Result<()> {
+	fn try_agent_checks_env() {
 		// SAFETY: `#[serial]` ensures no concurrent env mutation across tests.
 		unsafe {
 			env::set_var("SSH_AUTH_SOCK", "/tmp/fake-agent.sock");
@@ -187,12 +185,11 @@ mod tests {
 			!try_agent(),
 			"expected no agent when SSH_AUTH_SOCK is unset"
 		);
-		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn password_config_string() -> Result<()> {
+	fn password_config_string() -> crate::Result<()> {
 		let mut config = Config::default();
 		config.ssh.password = PasswordConfig::Value("secret".to_owned());
 		let method = resolve_auth(&config)?;
@@ -202,7 +199,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn password_config_false() -> Result<()> {
+	fn password_config_false() {
 		let mut config = Config::default();
 		config.ssh.password = PasswordConfig::Interactive(false);
 		let result = resolve_auth(&config);
@@ -214,6 +211,5 @@ mod tests {
 				AuthMethod::PrivateKeyFile { .. } | AuthMethod::Agent
 			);
 		}
-		Ok(())
 	}
 }

--- a/src/ssh/auth.rs
+++ b/src/ssh/auth.rs
@@ -1,6 +1,8 @@
+use crate::Result;
 use crate::config::types::Config;
 use crate::config::types::PasswordConfig;
 use async_ssh2_tokio::client::AuthMethod;
+use color_eyre::eyre::bail;
 use dialoguer::Password;
 use russh::keys::{Error as RusshKeysError, load_secret_key};
 use std::env;
@@ -17,7 +19,7 @@ const DEFAULT_KEY_PATHS: &[&str] = &["~/.ssh/id_ed25519", "~/.ssh/id_rsa"];
 /// 2. Explicit password (`ssh.password = "..."` or `ssh.password = true` for prompt)
 /// 3. Default key file discovery (`~/.ssh/id_ed25519`, `~/.ssh/id_rsa`)
 /// 4. SSH Agent (fallback for zero-config users)
-pub(super) fn resolve_auth(config: &Config) -> eyre::Result<AuthMethod> {
+pub(super) fn resolve_auth(config: &Config) -> Result<AuthMethod> {
 	let ssh = &config.ssh;
 
 	// 1. Explicit key_path (paths are already resolved natively by confique)
@@ -26,7 +28,7 @@ pub(super) fn resolve_auth(config: &Config) -> eyre::Result<AuthMethod> {
 			info!(path = %path.display(), "Using configured SSH key file");
 			return load_key(path);
 		}
-		eyre::bail!("Configured SSH key file not found: {}", path.display());
+		bail!("Configured SSH key file not found: {}", path.display());
 	}
 
 	// 2. Explicit password (string value or interactive prompt)
@@ -59,14 +61,14 @@ pub(super) fn resolve_auth(config: &Config) -> eyre::Result<AuthMethod> {
 		return Ok(AuthMethod::with_agent());
 	}
 
-	eyre::bail!(
+	bail!(
 		"No authentication method available. \
 		Configure ssh.key_path, ssh.password, or set up an SSH agent."
 	)
 }
 
 /// Load an SSH key from the given path, prompting for a passphrase if needed.
-fn load_key(path: &Path) -> eyre::Result<AuthMethod> {
+fn load_key(path: &Path) -> Result<AuthMethod> {
 	let path_str = path.to_string_lossy();
 	match load_secret_key(path_str.as_ref(), None) {
 		Err(RusshKeysError::KeyIsEncrypted) => {
@@ -130,7 +132,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn resolve_default_key_path_explicit() -> color_eyre::Result<()> {
+	fn resolve_default_key_path_explicit() -> Result<()> {
 		let dir = tempfile::tempdir()?;
 		let key_file = dir.path().join("my_key");
 		fs::write(&key_file, "fake key")?;
@@ -145,7 +147,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn resolve_auth_missing_explicit_key_errors() -> color_eyre::Result<()> {
+	fn resolve_auth_missing_explicit_key_errors() -> Result<()> {
 		let mut config = Config::default();
 		config.ssh.key_path = Some(PathBuf::from("/nonexistent/path/key"));
 
@@ -158,7 +160,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn resolve_default_key_path_no_config() -> color_eyre::Result<()> {
+	fn resolve_default_key_path_no_config() -> Result<()> {
 		// Verify the function runs without panic; it may or may not find a key
 		// depending on the test environment.
 		let _path = resolve_default_key_path();
@@ -167,7 +169,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn try_agent_checks_env() -> color_eyre::Result<()> {
+	fn try_agent_checks_env() -> Result<()> {
 		// SAFETY: `#[serial]` ensures no concurrent env mutation across tests.
 		unsafe {
 			env::set_var("SSH_AUTH_SOCK", "/tmp/fake-agent.sock");
@@ -190,7 +192,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn password_config_string() -> color_eyre::Result<()> {
+	fn password_config_string() -> Result<()> {
 		let mut config = Config::default();
 		config.ssh.password = PasswordConfig::Value("secret".to_owned());
 		let method = resolve_auth(&config)?;
@@ -200,7 +202,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn password_config_false() -> color_eyre::Result<()> {
+	fn password_config_false() -> Result<()> {
 		let mut config = Config::default();
 		config.ssh.password = PasswordConfig::Interactive(false);
 		let result = resolve_auth(&config);

--- a/src/ssh/auth.rs
+++ b/src/ssh/auth.rs
@@ -132,7 +132,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn resolve_default_key_path_explicit() -> crate::Result<()> {
+	fn resolve_default_key_path_explicit() -> Result<()> {
 		let dir = tempfile::tempdir()?;
 		let key_file = dir.path().join("my_key");
 		fs::write(&key_file, "fake key")?;
@@ -189,7 +189,7 @@ mod tests {
 
 	#[serial]
 	#[test]
-	fn password_config_string() -> crate::Result<()> {
+	fn password_config_string() -> Result<()> {
 		let mut config = Config::default();
 		config.ssh.password = PasswordConfig::Value("secret".to_owned());
 		let method = resolve_auth(&config)?;

--- a/src/ssh/exec.rs
+++ b/src/ssh/exec.rs
@@ -163,25 +163,29 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn build_command_no_args() {
+	fn build_command_no_args() -> color_eyre::Result<()> {
 		assert_eq!(build_command("ls", &[]), "ls");
+		Ok(())
 	}
 
 	#[test]
-	fn build_command_with_args() {
+	fn build_command_with_args() -> color_eyre::Result<()> {
 		let args = vec!["-la".to_owned(), "/tmp".to_owned()];
 		assert_eq!(build_command("ls", &args), "ls -la /tmp");
+		Ok(())
 	}
 
 	#[test]
-	fn build_command_quotes_args_with_spaces() {
+	fn build_command_quotes_args_with_spaces() -> color_eyre::Result<()> {
 		let args = vec!["hello world".to_owned()];
 		assert_eq!(build_command("echo", &args), "echo 'hello world'");
+		Ok(())
 	}
 
 	#[test]
-	fn build_command_quotes_args_with_special_chars() {
+	fn build_command_quotes_args_with_special_chars() -> color_eyre::Result<()> {
 		let args = vec!["foo$bar".to_owned()];
 		assert_eq!(build_command("echo", &args), "echo 'foo$bar'");
+		Ok(())
 	}
 }

--- a/src/ssh/exec.rs
+++ b/src/ssh/exec.rs
@@ -1,15 +1,16 @@
 use super::auth::resolve_auth;
+use crate::Result;
 use crate::config::types::Config;
 use crate::ui::create_spinner;
 use async_ssh2_tokio::client::{Client, ServerCheckMethod};
+use color_eyre::eyre::{Context as _, bail};
 use console::style;
-use eyre::{Context as _, bail};
 use std::io::{Write, stderr, stdout};
 use tokio::sync::mpsc;
 use tracing::{debug, info};
 
 /// Connect to the SSH server using the resolved authentication method.
-async fn connect(config: &Config, quiet: bool) -> eyre::Result<Client> {
+async fn connect(config: &Config, quiet: bool) -> Result<Client> {
 	let auth_method = resolve_auth(config)?;
 	let ssh = &config.ssh;
 
@@ -83,7 +84,7 @@ async fn run_command(
 	full_command: &str,
 	quiet: bool,
 	silent: bool,
-) -> eyre::Result<u32> {
+) -> Result<u32> {
 	debug!(command = %full_command, "Executing remote command");
 
 	if !quiet {
@@ -152,7 +153,7 @@ pub async fn execute_command(
 	args: &[String],
 	quiet: bool,
 	silent: bool,
-) -> eyre::Result<u32> {
+) -> Result<u32> {
 	let client = connect(config, quiet || silent).await?;
 	let full_command = build_command(command, args);
 	run_command(&client, &full_command, quiet, silent).await
@@ -163,29 +164,25 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn build_command_no_args() -> color_eyre::Result<()> {
+	fn build_command_no_args() {
 		assert_eq!(build_command("ls", &[]), "ls");
-		Ok(())
 	}
 
 	#[test]
-	fn build_command_with_args() -> color_eyre::Result<()> {
+	fn build_command_with_args() {
 		let args = vec!["-la".to_owned(), "/tmp".to_owned()];
 		assert_eq!(build_command("ls", &args), "ls -la /tmp");
-		Ok(())
 	}
 
 	#[test]
-	fn build_command_quotes_args_with_spaces() -> color_eyre::Result<()> {
+	fn build_command_quotes_args_with_spaces() {
 		let args = vec!["hello world".to_owned()];
 		assert_eq!(build_command("echo", &args), "echo 'hello world'");
-		Ok(())
 	}
 
 	#[test]
-	fn build_command_quotes_args_with_special_chars() -> color_eyre::Result<()> {
+	fn build_command_quotes_args_with_special_chars() {
 		let args = vec!["foo$bar".to_owned()];
 		assert_eq!(build_command("echo", &args), "echo 'foo$bar'");
-		Ok(())
 	}
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,4 @@
-#[expect(clippy::disallowed_types, reason = "crate::Eyre")]
+#[expect(clippy::disallowed_types, reason = "This is the Result type for integration tests.")]
 pub type Result<T> = color_eyre::Result<T>;
 
 #[cfg(test)]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,7 +4,6 @@
 )]
 pub type Result<T> = color_eyre::Result<T>;
 
-#[cfg(test)]
 #[ctor::ctor]
 fn init_test_env() {
 	#[expect(

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,3 +10,4 @@ fn init_test_env() {
 	)]
 	color_eyre::install().ok();
 }
+

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,12 @@
+#[expect(clippy::disallowed_types, reason = "crate::Eyre")]
+pub type Result<T> = color_eyre::Result<T>;
+
+#[cfg(test)]
+#[ctor::ctor]
+fn init_test_env() {
+	#[expect(
+		clippy::unused_result_ok,
+		reason = "Multiple tests may attempt to initialize the global error handler."
+	)]
+	color_eyre::install().ok();
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,7 @@
-#[expect(clippy::disallowed_types, reason = "This is the Result type for integration tests.")]
+#[expect(
+	clippy::disallowed_types,
+	reason = "This is the Result type for integration tests."
+)]
 pub type Result<T> = color_eyre::Result<T>;
 
 #[cfg(test)]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,4 +10,3 @@ fn init_test_env() {
 	)]
 	color_eyre::install().ok();
 }
-

--- a/tests/ssh_e2e_run.rs
+++ b/tests/ssh_e2e_run.rs
@@ -37,14 +37,14 @@ fn e2e_run_command() -> Result<()> {
 
 #[test]
 #[ignore = "requires running SSH server"]
-fn e2e_run_stdout_stderr() {
+fn e2e_run_stdout_stderr() -> Result<()> {
 	let output = biwa_cmd(&["run", "--", "bash", "-c", "echo 'out'; echo 'err' >&2"])
 		.env("BIWA_LOG_QUIET", "true")
 		.stdout_capture()
 		.stderr_capture()
 		.unchecked()
 		.run()
-		.expect("failed to execute process");
+		?;
 
 	let stdout = String::from_utf8_lossy(&output.stdout);
 	let stderr = String::from_utf8_lossy(&output.stderr);
@@ -52,11 +52,12 @@ fn e2e_run_stdout_stderr() {
 	assert!(output.status.success());
 	assert!(stdout.contains("out"), "stdout: {stdout}");
 	assert!(stderr.contains("err"), "stderr: {stderr}");
+	Ok(())
 }
 
 #[test]
 #[ignore = "requires running SSH server"]
-fn e2e_run_streaming() {
+fn e2e_run_streaming() -> Result<()> {
 	let mut reader = biwa_cmd(&[
 		"run",
 		"--",
@@ -66,14 +67,14 @@ fn e2e_run_streaming() {
 	])
 	.env("BIWA_LOG_QUIET", "true")
 	.reader()
-	.expect("failed to spawn process");
+	?;
 
 	let mut buf_reader = BufReader::new(&mut reader);
 
 	let mut first_line = String::new();
 	buf_reader
 		.read_line(&mut first_line)
-		.expect("failed to read first line");
+		?;
 
 	// We should read 'start' immediately without waiting for 'end'
 	assert!(
@@ -84,19 +85,20 @@ fn e2e_run_streaming() {
 	let mut rest = String::new();
 	buf_reader
 		.read_to_string(&mut rest)
-		.expect("failed to read remaining output");
+		?;
 	assert!(rest.contains("end"));
+	Ok(())
 }
 
 #[test]
 #[ignore = "requires running SSH server"]
-fn e2e_run_quiet() {
+fn e2e_run_quiet() -> Result<()> {
 	let output = biwa_cmd(&["--quiet", "run", "echo", "hello quiet"])
 		.stdout_capture()
 		.stderr_capture()
 		.unchecked()
 		.run()
-		.expect("failed to execute process");
+		?;
 
 	let stdout = String::from_utf8_lossy(&output.stdout);
 	let stderr = String::from_utf8_lossy(&output.stderr);
@@ -107,17 +109,18 @@ fn e2e_run_quiet() {
 	// CLI prefix "$ echo hello quiet" should NOT be printed
 	assert!(!stderr.contains("$ echo hello quiet"));
 	assert!(!stdout.contains("$ echo hello quiet"));
+	Ok(())
 }
 
 #[test]
 #[ignore = "requires running SSH server"]
-fn e2e_run_silent() {
+fn e2e_run_silent() -> Result<()> {
 	let output = biwa_cmd(&["--silent", "run", "echo", "hello silent"])
 		.stdout_capture()
 		.stderr_capture()
 		.unchecked()
 		.run()
-		.expect("failed to execute process");
+		?;
 
 	let stdout = String::from_utf8_lossy(&output.stdout);
 	let stderr = String::from_utf8_lossy(&output.stderr);
@@ -125,17 +128,18 @@ fn e2e_run_silent() {
 	assert!(output.status.success());
 	assert!(stdout.trim().is_empty(), "stdout was not empty: {stdout}");
 	assert!(stderr.trim().is_empty(), "stderr was not empty: {stderr}");
+	Ok(())
 }
 
 #[test]
 #[ignore = "requires running SSH server"]
-fn e2e_run_exit_code() {
+fn e2e_run_exit_code() -> Result<()> {
 	let output = biwa_cmd(&["run", "--", "bash", "-c", "exit 42"])
 		.env("BIWA_LOG_QUIET", "true")
 		.stderr_capture()
 		.unchecked()
 		.run()
-		.expect("failed to execute process");
+		?;
 
 	assert!(!output.status.success());
 
@@ -144,4 +148,6 @@ fn e2e_run_exit_code() {
 		stderr.contains("Remote command exited with code 42"),
 		"stderr was: {stderr}"
 	);
+	Ok(())
 }
+

--- a/tests/ssh_e2e_run.rs
+++ b/tests/ssh_e2e_run.rs
@@ -43,8 +43,7 @@ fn e2e_run_stdout_stderr() -> Result<()> {
 		.stdout_capture()
 		.stderr_capture()
 		.unchecked()
-		.run()
-		?;
+		.run()?;
 
 	let stdout = String::from_utf8_lossy(&output.stdout);
 	let stderr = String::from_utf8_lossy(&output.stderr);
@@ -66,15 +65,12 @@ fn e2e_run_streaming() -> Result<()> {
 		"echo 'start'; sleep 0.5; echo 'end'",
 	])
 	.env("BIWA_LOG_QUIET", "true")
-	.reader()
-	?;
+	.reader()?;
 
 	let mut buf_reader = BufReader::new(&mut reader);
 
 	let mut first_line = String::new();
-	buf_reader
-		.read_line(&mut first_line)
-		?;
+	buf_reader.read_line(&mut first_line)?;
 
 	// We should read 'start' immediately without waiting for 'end'
 	assert!(
@@ -83,9 +79,7 @@ fn e2e_run_streaming() -> Result<()> {
 	);
 
 	let mut rest = String::new();
-	buf_reader
-		.read_to_string(&mut rest)
-		?;
+	buf_reader.read_to_string(&mut rest)?;
 	assert!(rest.contains("end"));
 	Ok(())
 }
@@ -97,8 +91,7 @@ fn e2e_run_quiet() -> Result<()> {
 		.stdout_capture()
 		.stderr_capture()
 		.unchecked()
-		.run()
-		?;
+		.run()?;
 
 	let stdout = String::from_utf8_lossy(&output.stdout);
 	let stderr = String::from_utf8_lossy(&output.stderr);
@@ -119,8 +112,7 @@ fn e2e_run_silent() -> Result<()> {
 		.stdout_capture()
 		.stderr_capture()
 		.unchecked()
-		.run()
-		?;
+		.run()?;
 
 	let stdout = String::from_utf8_lossy(&output.stdout);
 	let stderr = String::from_utf8_lossy(&output.stderr);
@@ -138,8 +130,7 @@ fn e2e_run_exit_code() -> Result<()> {
 		.env("BIWA_LOG_QUIET", "true")
 		.stderr_capture()
 		.unchecked()
-		.run()
-		?;
+		.run()?;
 
 	assert!(!output.status.success());
 
@@ -150,4 +141,3 @@ fn e2e_run_exit_code() -> Result<()> {
 	);
 	Ok(())
 }
-

--- a/tests/ssh_e2e_run.rs
+++ b/tests/ssh_e2e_run.rs
@@ -4,6 +4,12 @@
 )]
 use std::io::{BufRead as _, BufReader, Read as _};
 
+#[cfg(test)]
+#[ctor::ctor]
+fn init_test_env() {
+	color_eyre::install().ok();
+}
+
 fn biwa_cmd(args: &[&str]) -> duct::Expression {
 	let mut biwa = duct::cmd(env!("CARGO_BIN_EXE_biwa"), args);
 	biwa = biwa
@@ -16,7 +22,7 @@ fn biwa_cmd(args: &[&str]) -> duct::Expression {
 
 #[test]
 #[ignore = "requires running SSH server"]
-fn e2e_run_command() {
+fn e2e_run_command() -> color_eyre::Result<()> {
 	let output = biwa_cmd(&["run", "echo", "hello e2e from biwa"])
 		.env("BIWA_LOG_QUIET", "true")
 		.stdout_capture()
@@ -29,11 +35,12 @@ fn e2e_run_command() {
 
 	assert!(output.status.success());
 	assert!(stdout.contains("hello e2e from biwa"));
+	Ok(())
 }
 
 #[test]
 #[ignore = "requires running SSH server"]
-fn e2e_run_stdout_stderr() {
+fn e2e_run_stdout_stderr() -> color_eyre::Result<()> {
 	let output = biwa_cmd(&["run", "--", "bash", "-c", "echo 'out'; echo 'err' >&2"])
 		.env("BIWA_LOG_QUIET", "true")
 		.stdout_capture()
@@ -48,11 +55,12 @@ fn e2e_run_stdout_stderr() {
 	assert!(output.status.success());
 	assert!(stdout.contains("out"), "stdout: {stdout}");
 	assert!(stderr.contains("err"), "stderr: {stderr}");
+	Ok(())
 }
 
 #[test]
 #[ignore = "requires running SSH server"]
-fn e2e_run_streaming() {
+fn e2e_run_streaming() -> color_eyre::Result<()> {
 	let mut reader = biwa_cmd(&[
 		"run",
 		"--",
@@ -82,11 +90,12 @@ fn e2e_run_streaming() {
 		.read_to_string(&mut rest)
 		.expect("failed to read remaining output");
 	assert!(rest.contains("end"));
+	Ok(())
 }
 
 #[test]
 #[ignore = "requires running SSH server"]
-fn e2e_run_quiet() {
+fn e2e_run_quiet() -> color_eyre::Result<()> {
 	let output = biwa_cmd(&["--quiet", "run", "echo", "hello quiet"])
 		.stdout_capture()
 		.stderr_capture()
@@ -103,11 +112,12 @@ fn e2e_run_quiet() {
 	// CLI prefix "$ echo hello quiet" should NOT be printed
 	assert!(!stderr.contains("$ echo hello quiet"));
 	assert!(!stdout.contains("$ echo hello quiet"));
+	Ok(())
 }
 
 #[test]
 #[ignore = "requires running SSH server"]
-fn e2e_run_silent() {
+fn e2e_run_silent() -> color_eyre::Result<()> {
 	let output = biwa_cmd(&["--silent", "run", "echo", "hello silent"])
 		.stdout_capture()
 		.stderr_capture()
@@ -121,11 +131,12 @@ fn e2e_run_silent() {
 	assert!(output.status.success());
 	assert!(stdout.trim().is_empty(), "stdout was not empty: {stdout}");
 	assert!(stderr.trim().is_empty(), "stderr was not empty: {stderr}");
+	Ok(())
 }
 
 #[test]
 #[ignore = "requires running SSH server"]
-fn e2e_run_exit_code() {
+fn e2e_run_exit_code() -> color_eyre::Result<()> {
 	let output = biwa_cmd(&["run", "--", "bash", "-c", "exit 42"])
 		.env("BIWA_LOG_QUIET", "true")
 		.stderr_capture()
@@ -140,4 +151,5 @@ fn e2e_run_exit_code() {
 		stderr.contains("Remote command exited with code 42"),
 		"stderr was: {stderr}"
 	);
+	Ok(())
 }

--- a/tests/ssh_e2e_run.rs
+++ b/tests/ssh_e2e_run.rs
@@ -2,13 +2,11 @@
 	clippy::tests_outside_test_module,
 	reason = "https://github.com/rust-lang/rust-clippy/issues/11024"
 )]
+#![expect(clippy::panic_in_result_fn, reason = "color_eyre handles panics")]
 use std::io::{BufRead as _, BufReader, Read as _};
 
-#[cfg(test)]
-#[ctor::ctor]
-fn init_test_env() {
-	color_eyre::install().ok();
-}
+mod common;
+use common::Result;
 
 fn biwa_cmd(args: &[&str]) -> duct::Expression {
 	let mut biwa = duct::cmd(env!("CARGO_BIN_EXE_biwa"), args);
@@ -22,14 +20,13 @@ fn biwa_cmd(args: &[&str]) -> duct::Expression {
 
 #[test]
 #[ignore = "requires running SSH server"]
-fn e2e_run_command() -> color_eyre::Result<()> {
+fn e2e_run_command() -> Result<()> {
 	let output = biwa_cmd(&["run", "echo", "hello e2e from biwa"])
 		.env("BIWA_LOG_QUIET", "true")
 		.stdout_capture()
 		.stderr_capture()
 		.unchecked()
-		.run()
-		.expect("failed to execute process");
+		.run()?;
 
 	let stdout = String::from_utf8_lossy(&output.stdout);
 
@@ -40,7 +37,7 @@ fn e2e_run_command() -> color_eyre::Result<()> {
 
 #[test]
 #[ignore = "requires running SSH server"]
-fn e2e_run_stdout_stderr() -> color_eyre::Result<()> {
+fn e2e_run_stdout_stderr() {
 	let output = biwa_cmd(&["run", "--", "bash", "-c", "echo 'out'; echo 'err' >&2"])
 		.env("BIWA_LOG_QUIET", "true")
 		.stdout_capture()
@@ -55,12 +52,11 @@ fn e2e_run_stdout_stderr() -> color_eyre::Result<()> {
 	assert!(output.status.success());
 	assert!(stdout.contains("out"), "stdout: {stdout}");
 	assert!(stderr.contains("err"), "stderr: {stderr}");
-	Ok(())
 }
 
 #[test]
 #[ignore = "requires running SSH server"]
-fn e2e_run_streaming() -> color_eyre::Result<()> {
+fn e2e_run_streaming() {
 	let mut reader = biwa_cmd(&[
 		"run",
 		"--",
@@ -90,12 +86,11 @@ fn e2e_run_streaming() -> color_eyre::Result<()> {
 		.read_to_string(&mut rest)
 		.expect("failed to read remaining output");
 	assert!(rest.contains("end"));
-	Ok(())
 }
 
 #[test]
 #[ignore = "requires running SSH server"]
-fn e2e_run_quiet() -> color_eyre::Result<()> {
+fn e2e_run_quiet() {
 	let output = biwa_cmd(&["--quiet", "run", "echo", "hello quiet"])
 		.stdout_capture()
 		.stderr_capture()
@@ -112,12 +107,11 @@ fn e2e_run_quiet() -> color_eyre::Result<()> {
 	// CLI prefix "$ echo hello quiet" should NOT be printed
 	assert!(!stderr.contains("$ echo hello quiet"));
 	assert!(!stdout.contains("$ echo hello quiet"));
-	Ok(())
 }
 
 #[test]
 #[ignore = "requires running SSH server"]
-fn e2e_run_silent() -> color_eyre::Result<()> {
+fn e2e_run_silent() {
 	let output = biwa_cmd(&["--silent", "run", "echo", "hello silent"])
 		.stdout_capture()
 		.stderr_capture()
@@ -131,12 +125,11 @@ fn e2e_run_silent() -> color_eyre::Result<()> {
 	assert!(output.status.success());
 	assert!(stdout.trim().is_empty(), "stdout was not empty: {stdout}");
 	assert!(stderr.trim().is_empty(), "stderr was not empty: {stderr}");
-	Ok(())
 }
 
 #[test]
 #[ignore = "requires running SSH server"]
-fn e2e_run_exit_code() -> color_eyre::Result<()> {
+fn e2e_run_exit_code() {
 	let output = biwa_cmd(&["run", "--", "bash", "-c", "exit 42"])
 		.env("BIWA_LOG_QUIET", "true")
 		.stderr_capture()
@@ -151,5 +144,4 @@ fn e2e_run_exit_code() -> color_eyre::Result<()> {
 		stderr.contains("Remote command exited with code 42"),
 		"stderr was: {stderr}"
 	);
-	Ok(())
 }


### PR DESCRIPTION
- Replaced `eyre::Result` with `color-eyre::Result` in tests and `main.rs` for better stack traces and error formatting.
- Added `ctor` dependency to initialize `color-eyre::install().ok()` globally for tests.
- Updated all unit and integration tests to return `color_eyre::Result<()>` and safely bubble errors up instead of panicking.
