### PR TITLE
ci: migrate from attest-build-provenance to actions/attest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
           DIST_ARGS: ${{ matrix.dist_args }}
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: target/distrib/*${{ join(matrix.targets, ', ') }}*
 


### PR DESCRIPTION
Unwrap `actions/attest-build-provenance` to `actions/attest` in the release workflow. As of v4, attest-build-provenance is a thin wrapper over actions/attest; this uses the same ref (v4.1.0) and inputs for identical behavior.

Made with [Cursor](https://cursor.com)