### PR TITLE
fix: unify behavior of implicit biwa execution and biwa run

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -114,10 +114,9 @@ pub async fn run() -> Result<()> {
 	if let Some(command) = cli.command {
 		command.run(&config, quiet, silent).await?;
 	} else if !cli.run_command_args.is_empty() {
-		let (command, args) = cli
-			.run_command_args
-			.split_first()
-			.ok_or_else(|| eyre!("No command provided. Use `biwa --help` for usage information."))?;
+		let (command, args) = cli.run_command_args.split_first().ok_or_else(|| {
+			eyre!("No command provided. Use `biwa --help` for usage information.")
+		})?;
 		run::run_remote(
 			&config,
 			&SyncArgs::default(),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -114,8 +114,10 @@ pub async fn run() -> Result<()> {
 	if let Some(command) = cli.command {
 		command.run(&config, quiet, silent).await?;
 	} else if !cli.run_command_args.is_empty() {
-		let command = cli.run_command_args.first().expect("Command is empty");
-		let args = cli.run_command_args.get(1..).expect("Arguments are empty");
+		let (command, args) = cli
+			.run_command_args
+			.split_first()
+			.unwrap_or_else(|| unreachable!("branch only taken when run_command_args is non-empty"));
 		run::run_remote(
 			&config,
 			&SyncArgs::default(),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -114,10 +114,9 @@ pub async fn run() -> Result<()> {
 	if let Some(command) = cli.command {
 		command.run(&config, quiet, silent).await?;
 	} else if !cli.run_command_args.is_empty() {
-		let (command, args) = cli
-			.run_command_args
-			.split_first()
-			.unwrap_or_else(|| unreachable!("branch only taken when run_command_args is non-empty"));
+		let (command, args) = cli.run_command_args.split_first().unwrap_or_else(|| {
+			unreachable!("branch only taken when run_command_args is non-empty")
+		});
 		run::run_remote(
 			&config,
 			&SyncArgs::default(),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,7 +2,7 @@ use crate::Result;
 use crate::cli::sync::SyncArgs;
 use crate::config::types::Config;
 use clap::{ArgAction, Parser, Subcommand};
-use color_eyre::eyre::bail;
+use color_eyre::eyre::{bail, eyre};
 use tracing::Level;
 use tracing_subscriber::{
 	filter::Targets, fmt, layer::SubscriberExt as _, registry, util::SubscriberInitExt as _,
@@ -114,9 +114,10 @@ pub async fn run() -> Result<()> {
 	if let Some(command) = cli.command {
 		command.run(&config, quiet, silent).await?;
 	} else if !cli.run_command_args.is_empty() {
-		let (command, args) = cli.run_command_args.split_first().unwrap_or_else(|| {
-			unreachable!("branch only taken when run_command_args is non-empty")
-		});
+		let (command, args) = cli
+			.run_command_args
+			.split_first()
+			.ok_or_else(|| eyre!("No command provided. Use `biwa --help` for usage information."))?;
 		run::run_remote(
 			&config,
 			&SyncArgs::default(),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,6 @@
 use crate::Result;
-use crate::{config::types::Config, ssh::exec::execute_command};
+use crate::cli::sync::SyncArgs;
+use crate::config::types::Config;
 use clap::{ArgAction, Parser, Subcommand};
 use color_eyre::eyre::bail;
 use tracing::Level;
@@ -113,11 +114,14 @@ pub async fn run() -> Result<()> {
 	if let Some(command) = cli.command {
 		command.run(&config, quiet, silent).await?;
 	} else if !cli.run_command_args.is_empty() {
-		execute_command(
+		let command = cli.run_command_args.first().expect("Command is empty");
+		let args = cli.run_command_args.get(1..).expect("Arguments are empty");
+		run::run_remote(
 			&config,
-			cli.run_command_args.first().expect("Command is empty"),
-			cli.run_command_args.get(1..).expect("Arguments are empty"),
-			None,
+			&SyncArgs::default(),
+			command,
+			args,
+			config.sync.auto,
 			quiet,
 			silent,
 		)

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -60,17 +60,19 @@ pub(super) async fn run_remote(
 	}
 
 	// Determine working directory: explicit --remote-dir > computed synced dir
-	let working_dir = if let Some(dir) = &sync_args.remote_dir {
-		dir.clone()
+	let computed_working_dir;
+	let working_dir: &str = if let Some(dir) = &sync_args.remote_dir {
+		dir.as_str()
 	} else {
-		compute_project_remote_dir(config, &sync_root)?
+		computed_working_dir = compute_project_remote_dir(config, &sync_root)?;
+		&computed_working_dir
 	};
 
 	execute_command(
 		config,
 		command,
 		command_args,
-		Some(&working_dir),
+		Some(working_dir),
 		quiet,
 		silent,
 	)

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -32,6 +32,52 @@ pub(super) struct Run {
 	command_args: Vec<String>,
 }
 
+/// Shared execution path for remote commands (used by both `biwa run` and implicit `biwa <args>`).
+///
+/// Resolves sync root and working directory, optionally syncs, then runs the command
+/// in the resolved remote directory.
+pub(super) async fn run_remote(
+	config: &Config,
+	sync_args: &SyncArgs,
+	command: &str,
+	command_args: &[String],
+	should_sync: bool,
+	quiet: bool,
+	silent: bool,
+) -> Result<()> {
+	let sync_root = sync_args.resolve_sync_root(config)?;
+
+	if should_sync {
+		let options = sync_args.resolve_options();
+		sync_project(
+			config,
+			&sync_root,
+			&options,
+			sync_args.remote_dir.as_deref(),
+			quiet,
+		)
+		.await?;
+	}
+
+	// Determine working directory: explicit --remote-dir > computed synced dir
+	let working_dir = if let Some(dir) = &sync_args.remote_dir {
+		dir.clone()
+	} else {
+		compute_project_remote_dir(config, &sync_root)?
+	};
+
+	execute_command(
+		config,
+		command,
+		command_args,
+		Some(&working_dir),
+		quiet,
+		silent,
+	)
+	.await?;
+	Ok(())
+}
+
 impl Run {
 	/// Determines whether synchronization should be performed before running the command.
 	const fn should_sync(&self, config_sync_auto: bool) -> bool {
@@ -46,37 +92,16 @@ impl Run {
 
 	/// Run the execution logic for remote command.
 	pub async fn run(self, config: &Config, quiet: bool, silent: bool) -> Result<()> {
-		let sync_root = self.sync_args.resolve_sync_root(config)?;
-
-		if self.should_sync(config.sync.auto) {
-			let options = self.sync_args.resolve_options();
-			sync_project(
-				config,
-				&sync_root,
-				&options,
-				self.sync_args.remote_dir.as_deref(),
-				quiet,
-			)
-			.await?;
-		}
-
-		// Determine working directory: explicit --remote-dir > computed synced dir
-		let working_dir = if let Some(dir) = &self.sync_args.remote_dir {
-			dir.clone()
-		} else {
-			compute_project_remote_dir(config, &sync_root)?
-		};
-
-		execute_command(
+		run_remote(
 			config,
+			&self.sync_args,
 			&self.command,
 			&self.command_args,
-			Some(&working_dir),
+			self.should_sync(config.sync.auto),
 			quiet,
 			silent,
 		)
-		.await?;
-		Ok(())
+		.await
 	}
 }
 

--- a/tests/ssh_e2e_run.rs
+++ b/tests/ssh_e2e_run.rs
@@ -175,3 +175,68 @@ fn e2e_run_remote_dir_tilde() -> Result<()> {
 	pretty_assertions::assert_eq!(stdout.trim(), home_dir);
 	Ok(())
 }
+
+/// Implicit `biwa <args>` and `biwa run <args>` must use the same remote working directory.
+#[test]
+fn e2e_implicit_run_same_working_dir_as_explicit_run() -> Result<()> {
+	// Disable auto-sync so both commands just resolve and use the same project dir without syncing.
+	let explicit = biwa_cmd(&["run", "--skip-sync", "pwd"])
+		.env("BIWA_LOG_QUIET", "true")
+		.env("BIWA_SYNC_AUTO", "false")
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
+	let implicit = biwa_cmd(&["pwd"])
+		.env("BIWA_LOG_QUIET", "true")
+		.env("BIWA_SYNC_AUTO", "false")
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
+
+	assert!(
+		explicit.status.success(),
+		"biwa run pwd failed: {}",
+		String::from_utf8_lossy(&explicit.stderr)
+	);
+	assert!(
+		implicit.status.success(),
+		"biwa pwd failed: {}",
+		String::from_utf8_lossy(&implicit.stderr)
+	);
+
+	let explicit_dir = String::from_utf8_lossy(&explicit.stdout).trim().to_owned();
+	let implicit_dir = String::from_utf8_lossy(&implicit.stdout).trim().to_owned();
+	pretty_assertions::assert_eq!(
+		implicit_dir,
+		explicit_dir,
+		"implicit run and explicit run must resolve to the same remote working directory"
+	);
+	Ok(())
+}
+
+#[test]
+fn e2e_implicit_run_command_executes_in_resolved_dir() -> Result<()> {
+	// Implicit run should run in the resolved project dir, not remote home.
+	let output = biwa_cmd(&["pwd"])
+		.env("BIWA_LOG_QUIET", "true")
+		.env("BIWA_SYNC_AUTO", "false")
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
+
+	assert!(
+		output.status.success(),
+		"biwa pwd failed: {}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+	// Default remote project dir is ~/.cache/biwa/projects/<name>-<hash>
+	assert!(
+		stdout.contains(".cache/biwa/projects/"),
+		"expected path under .cache/biwa/projects/, got: {stdout}"
+	);
+	Ok(())
+}


### PR DESCRIPTION
Fixes #295

**Summary**
- `biwa <args>` (implicit run) and `biwa run <args>` now share the same execution path and resolve the same remote working directory (project root). Previously implicit run passed `working_dir: None`, so commands ran in remote home; `biwa pwd` showed home instead of the resolved project dir.

**Changes**
- **cli/run.rs**: Extracted `run_remote()` with the common logic (resolve sync root, optional sync, resolve working dir, execute). `Run::run` delegates to it.
- **cli/mod.rs**: Implicit-run branch now calls `run::run_remote()` with `SyncArgs::default()` and `config.sync.auto` instead of `execute_command(..., None, ...)`.
- **tests/ssh_e2e_run.rs**: Added `e2e_implicit_run_same_working_dir_as_explicit_run` (both invocations output same `pwd`) and `e2e_implicit_run_command_executes_in_resolved_dir` (implicit `pwd` is under `.cache/biwa/projects/`).

Made with [Cursor](https://cursor.com)