### PR TITLE
feat(schema): mark fields with defaults as optional in JSON schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     outputs:
       build: ${{ steps.filter.outputs.build }}
       test: ${{ steps.filter.outputs.test }}
+      schema: ${{ steps.filter.outputs.schema }}
 
     steps:
       - name: Check release-affecting files
@@ -36,19 +37,27 @@ jobs:
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         with:
           filters: |
+            ci: &ci
+              - 'mise.toml'
+              - '.github/workflows/ci.yml'
             build: &build
+              - *ci
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'src/**'
               - '.github/workflows/release.yml'
               - 'dist-workspace.toml'
-              - 'mise.toml'
             test:
+              - *ci
               - *build
               - 'tests/**'
               - 'tarpaulin.toml'
               - 'tasks.toml'
-              - '.github/workflows/ci.yml'
+            schema:
+              - *ci
+              - 'schema/**'
+              - 'tasks/schema/**'
+              - 'tasks.toml'
 
   test:
     name: Test
@@ -133,6 +142,30 @@ jobs:
           LINT: true
           GITHUB_TOKEN: ${{ github.token }}
 
+  schema:
+    name: Schema
+    needs:
+      - paths
+    if: ${{ !cancelled() && !failure() && needs.paths.outputs.schema == 'true' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install mise
+        uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
+        with:
+          version: 2026.3.7
+
+      - name: Validate schema
+        run: mise run schema
+
   build:
     name: Build
     needs:
@@ -152,6 +185,7 @@ jobs:
       - test
       - lint
       - build
+      - schema
     # ref: https://github.com/aquaproj/aqua-registry/pull/38449#issuecomment-3038859524
     if: always()
     runs-on: ubuntu-24.04

--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,6 @@ cobertura.xml
 
 # biwa
 biwa.toml
+
+# schema fixtures: JSON generated from TOML by tasks/schema/ajv
+schema/fixtures/json/generated/

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -3,5 +3,5 @@
 	"useTabs": true,
 	"experimentalSortImports": {},
 	"vueIndentScriptAndStyle": true,
-	"ignorePatterns": ["CHANGELOG.md", "docs/src/cli/*", "schema/*"]
+	"ignorePatterns": ["CHANGELOG.md", "docs/src/cli/*", "schema/*", "**/*.toml"]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,9 @@
 {
 	// ref: https://code.visualstudio.com/docs/editor/extension-marketplace#_workspace-recommended-extensions
-	"recommendations": ["rust-lang.rust-analyzer", "github.vscode-github-actions", "oxc.oxc-vscode"]
+	"recommendations": [
+		"rust-lang.rust-analyzer",
+		"github.vscode-github-actions",
+		"oxc.oxc-vscode",
+		"tombi-toml.tombi"
+	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,8 +4,11 @@
 	"[rust]": {
 		"editor.defaultFormatter": "rust-lang.rust-analyzer"
 	},
-	"[typescript][javascript][css][vue][json][jsonc][yaml][github-actions-workflow][toml][markdown]": {
+	"[typescript][javascript][css][vue][json][jsonc][yaml][github-actions-workflow][markdown]": {
 		"editor.defaultFormatter": "oxc.oxc-vscode"
+	},
+	"[toml]": {
+		"editor.defaultFormatter": "tombi-toml.tombi"
 	},
 
 	"files.readonlyInclude": {
@@ -13,6 +16,6 @@
 		"**/Cargo.lock": true,
 		"biwa.usage.kdl": true,
 		"docs/src/cli/*": true,
-		"schema/*": true
+		"schema/config.json": true
 	}
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,19 +3,19 @@ name = "biwa"
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.93.1"
+description = "CLI to execute commands on UNSW CSE servers from local"
 repository = "https://github.com/risu729/biwa"
 license = "MIT"
-include = ["/README.md", "/src/**/*.rs"]
-description = "CLI to execute commands on UNSW CSE servers from local"
 keywords = ["unsw"]
 categories = ["command-line-utilities"]
+include = ["/README.md", "/src/**/*.rs"]
 
 [dependencies]
 async-ssh2-tokio = "=0.12.2"
 bytes = "=1.11.1"
 clap = { version = "=4.5.60", features = ["derive"] }
 color-eyre = "=0.6.5"
-confique = { version = "=0.4.0", features = ["toml", "yaml", "json5"] }
+confique = { version = "=0.4.0", features = ["json5", "toml", "yaml"] }
 console = "=0.16.2"
 derive_more = { version = "=2.1.1", features = ["deref"] }
 dialoguer = "=0.12.0"
@@ -53,20 +53,10 @@ rstest = "=0.26.1"
 serial_test = "=3.4.0"
 tempfile = "=3.27.0"
 
-[profile.dist]
-inherits = "release"
-lto = "thin"
-
 [lints.clippy]
-pedantic = { level = "warn", priority = -1 }
-nursery = { level = "warn", priority = -1 }
-cargo = { level = "warn", priority = -1 }
-# cargo-deny checks some cases
-multiple_crate_versions = "allow"
 # We prefer disabling rules than enabling them
 blanket_clippy_restriction_lints = "allow"
-# ref: https://rust-lang.github.io/rust-clippy/master/?groups=restriction
-restriction = { level = "warn", priority = -1 }
+cargo = { level = "warn", priority = -1 }
 default_numeric_fallback = "allow"
 default_union_representation = "allow"
 # We don't need to care about breaking changes in non-public APIs
@@ -86,10 +76,14 @@ min_ident_chars = "allow"
 missing_trait_methods = "allow"
 # Conflicts with `self_named_module_files`
 mod_module_files = "allow"
+# cargo-deny checks some cases
+multiple_crate_versions = "allow"
 # We live in the 2020s
 non_ascii_literal = "allow"
+nursery = { level = "warn", priority = -1 }
 # We can rely on Match Ergonomics
 pattern_type_mismatch = "allow"
+pedantic = { level = "warn", priority = -1 }
 # CLI needs to print to stderr and stdout
 print_stderr = "allow"
 print_stdout = "allow"
@@ -97,6 +91,8 @@ print_stdout = "allow"
 pub_with_shorthand = "allow"
 # We can use `?` operator
 question_mark_used = "allow"
+# ref: https://rust-lang.github.io/rust-clippy/master/?groups=restriction
+restriction = { level = "warn", priority = -1 }
 # Conflicts with `semicolon_inside_block`
 semicolon_outside_block = "allow"
 # Conflicts with `unseparated_literal_suffix`
@@ -114,3 +110,7 @@ unimplemented = "allow"
 
 # TODO: remove this after merging PRs to avoid conflicts
 arbitrary_source_item_ordering = "allow"
+
+[profile.dist]
+inherits = "release"
+lto = "thin"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,24 +1,9 @@
 disallowed-macros = [
-	{
-		path = "std::assert_eq",
-		reason = "Please use pretty_assertions::assert_eq! for better diff output in tests."
-	},
-	{
-		path = "std::assert_ne",
-		reason = "Please use pretty_assertions::assert_ne! for better diff output in tests."
-	},
+	{ path = "std::assert_eq", reason = "Please use pretty_assertions::assert_eq! for better diff output in tests." },
+	{ path = "std::assert_ne", reason = "Please use pretty_assertions::assert_ne! for better diff output in tests." },
 ]
 disallowed-types = [
-	{
-		path = "eyre::Result",
-		reason = "Please use `crate::Result` instead to ensure consistent error handling across the crate."
-	},
-	{
-		path = "color_eyre::Result",
-		reason = "Please use `crate::Result` instead to ensure consistent error handling across the crate."
-	},
-	{
-		path = "color_eyre::eyre::Result",
-		reason = "Please use `crate::Result` instead to ensure consistent error handling across the crate."
-	},
+	{ path = "eyre::Result", reason = "Please use `crate::Result` instead to ensure consistent error handling across the crate." },
+	{ path = "color_eyre::Result", reason = "Please use `crate::Result` instead to ensure consistent error handling across the crate." },
+	{ path = "color_eyre::eyre::Result", reason = "Please use `crate::Result` instead to ensure consistent error handling across the crate." },
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,9 +1,24 @@
 disallowed-macros = [
-	{ path = "std::assert_eq", reason = "Please use pretty_assertions::assert_eq! for better diff output in tests." },
-	{ path = "std::assert_ne", reason = "Please use pretty_assertions::assert_ne! for better diff output in tests." },
+	{
+		path = "std::assert_eq",
+		reason = "Please use pretty_assertions::assert_eq! for better diff output in tests."
+	},
+	{
+		path = "std::assert_ne",
+		reason = "Please use pretty_assertions::assert_ne! for better diff output in tests."
+	},
 ]
 disallowed-types = [
-	{ path = "eyre::Result", reason = "Please use `crate::Result` instead to ensure consistent error handling across the crate." },
-	{ path = "color_eyre::Result", reason = "Please use `crate::Result` instead to ensure consistent error handling across the crate." },
-	{ path = "color_eyre::eyre::Result", reason = "Please use `crate::Result` instead to ensure consistent error handling across the crate." },
+	{
+		path = "eyre::Result",
+		reason = "Please use `crate::Result` instead to ensure consistent error handling across the crate."
+	},
+	{
+		path = "color_eyre::Result",
+		reason = "Please use `crate::Result` instead to ensure consistent error handling across the crate."
+	},
+	{
+		path = "color_eyre::eyre::Result",
+		reason = "Please use `crate::Result` instead to ensure consistent error handling across the crate."
+	},
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -18,7 +18,15 @@ ignore = [
 unused-ignored-advisory = "deny"
 
 [licenses]
-allow = ["MIT", "Apache-2.0", "Unicode-3.0", "BSD-3-Clause", "ISC", "CC0-1.0", "OpenSSL"]
+allow = [
+	"MIT",
+	"Apache-2.0",
+	"Unicode-3.0",
+	"BSD-3-Clause",
+	"ISC",
+	"CC0-1.0",
+	"OpenSSL"
+]
 unused-allowed-license = "deny"
 unused-license-exception = "deny"
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,3 @@
-# ref: https://mise.jdx.dev/configuration.html
-#:schema https://mise.jdx.dev/schema/mise.json
-
 [tools]
 rust = { version = "1.94.0", profile = "default" }
 "aqua:EmbarkStudios/cargo-deny" = "0.19.0"
@@ -22,6 +19,9 @@ bun = "1.3.10"
 oxlint = "1.52.0"
 oxfmt = "0.37.0"
 pitchfork = "2.1.0"
+tombi = "0.9.4"
+"npm:ajv-cli" = "5.0.0"
+yq = "4.52.4"
 
 [settings]
 experimental = true
@@ -30,7 +30,7 @@ experimental = true
 '_'.path = ["target/debug/"]
 
 [task_config]
-includes = ["tasks.toml"]
+includes = ["tasks.toml", "tasks/"]
 
 [prepare.bun_docs]
 auto = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -60,7 +60,11 @@ commit_parsers = [
 	{ message = "^chore", group = "<!-- 9 -->🧹 Chore" },
 	{ message = "^revert", group = "<!-- 10 -->◀️ Revert" },
 	# Renovate dependency updates
-	{ message = '^(chore|fix|ci)\(deps\):', group = "<!-- 99 -->📦️ Dependency Updates", scope = "" },
+	{
+		message = '^(chore|fix|ci)\(deps\):',
+		group = "<!-- 99 -->📦️ Dependency Updates",
+		scope = ""
+	},
 	{ message = "^chore: release", skip = true },
 ]
 link_parsers = [{ pattern = "#(\\d+)", href = "{{ remote.link }}/issues/$1" }]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -60,11 +60,7 @@ commit_parsers = [
 	{ message = "^chore", group = "<!-- 9 -->🧹 Chore" },
 	{ message = "^revert", group = "<!-- 10 -->◀️ Revert" },
 	# Renovate dependency updates
-	{
-		message = '^(chore|fix|ci)\(deps\):',
-		group = "<!-- 99 -->📦️ Dependency Updates",
-		scope = ""
-	},
+	{ message = '^(chore|fix|ci)\(deps\):', group = "<!-- 99 -->📦️ Dependency Updates", scope = "" },
 	{ message = "^chore: release", skip = true },
 ]
 link_parsers = [{ pattern = "#(\\d+)", href = "{{ remote.link }}/issues/$1" }]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,5 +1,4 @@
 # ref: https://release-plz.dev/docs/config
-#:schema https://raw.githubusercontent.com/release-plz/release-plz/main/.schema/latest.json
 
 [workspace]
 pr_labels = ["release"]

--- a/schema/config.json
+++ b/schema/config.json
@@ -162,7 +162,6 @@
         "port": {
           "description": "Port to connect to on the remote host.",
           "type": "integer",
-          "format": "uint16",
           "default": 22,
           "maximum": 65535,
           "minimum": 0
@@ -249,7 +248,6 @@
         "max_files_to_sync": {
           "description": "Abort synchronization if the number of files to upload exceeds this limit.",
           "type": "integer",
-          "format": "uint",
           "default": 100,
           "minimum": 0
         },

--- a/schema/config.json
+++ b/schema/config.json
@@ -6,32 +6,59 @@
   "properties": {
     "env": {
       "description": "Environment variables configuration.",
-      "$ref": "#/$defs/EnvConfig"
+      "$ref": "#/$defs/EnvConfig",
+      "default": {
+        "vars": []
+      }
     },
     "hooks": {
       "description": "Lifecycle hooks for synchronization.",
-      "$ref": "#/$defs/HooksConfig"
+      "$ref": "#/$defs/HooksConfig",
+      "default": {
+        "post_sync": null,
+        "pre_sync": null
+      }
     },
     "log": {
       "description": "Logging configuration.",
-      "$ref": "#/$defs/LogConfig"
+      "$ref": "#/$defs/LogConfig",
+      "default": {
+        "quiet": false,
+        "silent": false
+      }
     },
     "ssh": {
       "description": "SSH connection configuration.",
-      "$ref": "#/$defs/SshConfig"
+      "$ref": "#/$defs/SshConfig",
+      "default": {
+        "host": "cse.unsw.edu.au",
+        "key_path": null,
+        "password": false,
+        "port": 22,
+        "umask": "077",
+        "user": "z1234567"
+      }
     },
     "sync": {
       "description": "Remote synchronization configuration.",
-      "$ref": "#/$defs/SyncConfig"
+      "$ref": "#/$defs/SyncConfig",
+      "default": {
+        "auto": true,
+        "engine": "sftp",
+        "exclude": [
+          "**/.git/**",
+          "**/target/**",
+          "**/node_modules/**"
+        ],
+        "remote_root": "~/.cache/biwa/projects",
+        "sftp": {
+          "max_files_to_sync": 100,
+          "permissions": "recreate"
+        },
+        "sync_root": null
+      }
     }
   },
-  "required": [
-    "ssh",
-    "sync",
-    "env",
-    "hooks",
-    "log"
-  ],
   "$defs": {
     "EnvConfig": {
       "description": "Environment settings.",
@@ -40,14 +67,12 @@
         "vars": {
           "description": "Environment variable keys to inherit/send.",
           "type": "array",
+          "default": [],
           "items": {
             "type": "string"
           }
         }
-      },
-      "required": [
-        "vars"
-      ]
+      }
     },
     "HooksConfig": {
       "description": "Hook settings.",
@@ -75,17 +100,15 @@
       "properties": {
         "quiet": {
           "description": "Suppresses biwa internal logs; only remote command output is shown.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "silent": {
           "description": "Suppresses all output, including remote command stdout/stderr.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         }
-      },
-      "required": [
-        "quiet",
-        "silent"
-      ]
+      }
     },
     "PasswordConfig": {
       "description": "Password authentication configuration.\n\n- `false` (default): No password authentication.\n- `true`: Interactively prompt for a password.\n- `\"string\"`: Use the provided password value.",
@@ -121,7 +144,8 @@
       "properties": {
         "host": {
           "description": "Hostname or IP address of the remote host.",
-          "type": "string"
+          "type": "string",
+          "default": "cse.unsw.edu.au"
         },
         "key_path": {
           "description": "Optional path to the SSH private key.",
@@ -132,31 +156,28 @@
         },
         "password": {
           "description": "Password authentication: `false` (default), `true` (prompt), or a string value.",
-          "$ref": "#/$defs/PasswordConfig"
+          "$ref": "#/$defs/PasswordConfig",
+          "default": false
         },
         "port": {
           "description": "Port to connect to on the remote host.",
           "type": "integer",
           "format": "uint16",
+          "default": 22,
           "maximum": 65535,
           "minimum": 0
         },
         "umask": {
           "description": "Umask to apply before executing commands and creating directories (3-digit octal: owner/group/other).\nTo set the first digit (setuid/setgid/sticky), run `umask` manually on the remote server.\nNote that you cannot loosen the default umask set by the server (e.g., 027 in UNSW CSE).\nYou need to use `chmod` manually if you want looser permissions. However, this umask setting\ncannot restrict manual permission modifications via `chmod` (be careful with `chmod +x` or `+r`).",
-          "$ref": "#/$defs/Umask"
+          "$ref": "#/$defs/Umask",
+          "default": "077"
         },
         "user": {
           "description": "Username for the SSH connection.",
-          "type": "string"
+          "type": "string",
+          "default": "z1234567"
         }
-      },
-      "required": [
-        "host",
-        "port",
-        "user",
-        "password",
-        "umask"
-      ]
+      }
     },
     "SyncConfig": {
       "description": "Synchronization settings.",
@@ -164,22 +185,30 @@
       "properties": {
         "auto": {
           "description": "Automatically synchronize the project before running remote commands.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": true
         },
         "engine": {
           "description": "The synchronization engine to use.",
-          "$ref": "#/$defs/SyncEngine"
+          "$ref": "#/$defs/SyncEngine",
+          "default": "sftp"
         },
         "exclude": {
           "description": "Files and directories to exclude during synchronization using globset patterns.",
           "type": "array",
+          "default": [
+            "**/.git/**",
+            "**/target/**",
+            "**/node_modules/**"
+          ],
           "items": {
             "type": "string"
           }
         },
         "remote_root": {
           "description": "Remote directory to sync the project to.",
-          "type": "string"
+          "type": "string",
+          "default": "~/.cache/biwa/projects"
         },
         "sftp": {
           "description": "SFTP engine specific configuration.",
@@ -194,10 +223,6 @@
         }
       },
       "required": [
-        "auto",
-        "remote_root",
-        "exclude",
-        "engine",
         "sftp"
       ]
     },
@@ -224,17 +249,15 @@
           "description": "Abort synchronization if the number of files to upload exceeds this limit.",
           "type": "integer",
           "format": "uint",
+          "default": 100,
           "minimum": 0
         },
         "permissions": {
           "description": "Strategy for enforcing file permissions on uploaded files.",
-          "$ref": "#/$defs/SftpPermissions"
+          "$ref": "#/$defs/SftpPermissions",
+          "default": "recreate"
         }
-      },
-      "required": [
-        "max_files_to_sync",
-        "permissions"
-      ]
+      }
     },
     "Umask": {
       "description": "Umask value for SSH execution and sync, stored as a normalized 3-digit octal string.\n\nDeserializes from a string parsed as octal (e.g. `\"077\"`, `\"022\"`). Only the lower three\ndigits (owner/group/other) are supported. To set the first digit (setuid/setgid/sticky),\nrun `umask` manually on the remote server. Always serialized as a 3-digit octal string.",

--- a/schema/config.json
+++ b/schema/config.json
@@ -212,7 +212,11 @@
         },
         "sftp": {
           "description": "SFTP engine specific configuration.",
-          "$ref": "#/$defs/SyncSftpConfig"
+          "$ref": "#/$defs/SyncSftpConfig",
+          "default": {
+            "max_files_to_sync": 100,
+            "permissions": "recreate"
+          }
         },
         "sync_root": {
           "description": "Base directory to start the synchronization from. If not specified, uses the current working directory.",
@@ -221,10 +225,7 @@
             "null"
           ]
         }
-      },
-      "required": [
-        "sftp"
-      ]
+      }
     },
     "SyncEngine": {
       "description": "The synchronization engine to use.",

--- a/schema/fixtures/toml/edge-env-vars-empty.toml
+++ b/schema/fixtures/toml/edge-env-vars-empty.toml
@@ -1,0 +1,4 @@
+# Edge case: env.vars empty array
+
+[env]
+vars = []

--- a/schema/fixtures/toml/edge-hooks-null.toml
+++ b/schema/fixtures/toml/edge-hooks-null.toml
@@ -1,0 +1,3 @@
+# Edge case: hooks with no commands (optional keys omitted)
+
+[hooks]

--- a/schema/fixtures/toml/edge-password-string.toml
+++ b/schema/fixtures/toml/edge-password-string.toml
@@ -1,0 +1,6 @@
+# Edge case: password as literal string value
+
+[ssh]
+host = "host"
+user = "u"
+password = "secret"

--- a/schema/fixtures/toml/edge-password-true.toml
+++ b/schema/fixtures/toml/edge-password-true.toml
@@ -1,0 +1,6 @@
+# Edge case: password = true (interactive prompt)
+
+[ssh]
+host = "host"
+user = "u"
+password = true

--- a/schema/fixtures/toml/edge-sftp-permissions-setstat.toml
+++ b/schema/fixtures/toml/edge-sftp-permissions-setstat.toml
@@ -1,0 +1,8 @@
+# Edge case: SFTP permissions strategy setstat
+
+[sync]
+engine = "sftp"
+remote_root = "~/projects"
+
+[sync.sftp]
+permissions = "setstat"

--- a/schema/fixtures/toml/edge-sync-engine-mutagen.toml
+++ b/schema/fixtures/toml/edge-sync-engine-mutagen.toml
@@ -1,0 +1,5 @@
+# Edge case: sync engine mutagen
+
+[sync]
+engine = "mutagen"
+remote_root = "~/projects"

--- a/schema/fixtures/toml/edge-sync-root-null.toml
+++ b/schema/fixtures/toml/edge-sync-root-null.toml
@@ -1,0 +1,5 @@
+# Edge case: sync_root not set (optional null) — use sync only with remote_root
+
+[sync]
+remote_root = "~/projects"
+engine = "sftp"

--- a/schema/fixtures/toml/edge-umask-022.toml
+++ b/schema/fixtures/toml/edge-umask-022.toml
@@ -1,0 +1,6 @@
+# Edge case: umask 022
+
+[ssh]
+host = "host"
+user = "u"
+umask = "022"

--- a/schema/fixtures/toml/full.toml
+++ b/schema/fixtures/toml/full.toml
@@ -1,0 +1,26 @@
+# Full biwa config — all sections with typical values
+
+[ssh]
+host = "cse.unsw.edu.au"
+port = 22
+user = "z1234567"
+umask = "077"
+
+[sync]
+auto = true
+remote_root = "~/.cache/biwa/projects"
+exclude = ["**/.git/**", "**/target/**", "**/node_modules/**"]
+engine = "sftp"
+
+[sync.sftp]
+max_files_to_sync = 100
+permissions = "recreate"
+
+[env]
+vars = ["PATH", "HOME"]
+
+[hooks]
+
+[log]
+quiet = false
+silent = false

--- a/schema/fixtures/toml/partial-log-only.toml
+++ b/schema/fixtures/toml/partial-log-only.toml
@@ -1,0 +1,5 @@
+# Partial config: only [log] section
+
+[log]
+quiet = true
+silent = false

--- a/schema/fixtures/toml/partial-ssh-only.toml
+++ b/schema/fixtures/toml/partial-ssh-only.toml
@@ -1,0 +1,6 @@
+# Partial config: only [ssh] section
+
+[ssh]
+host = "example.com"
+port = 22
+user = "deploy"

--- a/schema/fixtures/toml/partial-sync-only.toml
+++ b/schema/fixtures/toml/partial-sync-only.toml
@@ -1,0 +1,6 @@
+# Partial config: only [sync] section
+
+[sync]
+auto = false
+remote_root = "~/projects"
+engine = "sftp"

--- a/schema/tombi.toml
+++ b/schema/tombi.toml
@@ -1,0 +1,6 @@
+[format.rules]
+indent-style = "tab"
+
+[[schemas]]
+path = "config.json"
+include = ["fixtures/toml/**/*.toml"]

--- a/src/cli/schema.rs
+++ b/src/cli/schema.rs
@@ -1,7 +1,7 @@
 use crate::Result;
 use crate::config::types::Config;
 use clap::Args;
-use schemars::schema_for;
+use schemars::{generate::SchemaSettings, transform::RestrictFormats};
 
 /// Generate the configuration schema.
 #[derive(Args, Debug)]
@@ -12,7 +12,10 @@ impl Schema {
 	/// Run the schema generation logic.
 	#[expect(clippy::unused_self, reason = "schema subcommand doesn't have flags")]
 	pub(super) fn run(self) -> Result<()> {
-		let schema = schema_for!(Config);
+		let schema = SchemaSettings::default()
+			.with_transform(RestrictFormats::default())
+			.into_generator()
+			.into_root_schema_for::<Config>();
 		println!("{}", serde_json::to_string_pretty(&schema)?);
 		Ok(())
 	}

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -267,6 +267,12 @@ pub struct SyncSftpConfig {
 	pub permissions: SftpPermissions,
 }
 
+impl Default for SyncSftpConfig {
+	fn default() -> Self {
+		Config::default().sync.sftp
+	}
+}
+
 /// Synchronization settings.
 #[derive(confique::Config, Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct SyncConfig {
@@ -291,6 +297,7 @@ pub struct SyncConfig {
 	pub engine: SyncEngine,
 	/// SFTP engine specific configuration.
 	#[config(nested)]
+	#[schemars(default)]
 	pub sftp: SyncSftpConfig,
 }
 

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -69,23 +69,79 @@ fn validate_umask(n: u32) -> Result<(), String> {
 	}
 }
 
+/// Default values for schema generation; must match `#[config(default = ...)]` in this module.
+mod schema_defaults {
+	use std::path::PathBuf;
+
+	/// Default for `SshConfig::host` in schema.
+	#[must_use]
+	pub fn ssh_host() -> String {
+		"cse.unsw.edu.au".to_owned()
+	}
+
+	/// Default for `SshConfig::port` in schema.
+	#[must_use]
+	pub const fn ssh_port() -> u16 {
+		22
+	}
+
+	/// Default for `SshConfig::user` in schema.
+	#[must_use]
+	pub fn ssh_user() -> String {
+		"z1234567".to_owned()
+	}
+
+	/// Default for `SyncConfig::remote_root` in schema.
+	#[must_use]
+	pub fn sync_remote_root() -> PathBuf {
+		PathBuf::from("~/.cache/biwa/projects")
+	}
+
+	/// Default for `SyncConfig::exclude` in schema.
+	#[must_use]
+	pub fn sync_exclude() -> Vec<String> {
+		vec![
+			"**/.git/**".to_owned(),
+			"**/target/**".to_owned(),
+			"**/node_modules/**".to_owned(),
+		]
+	}
+
+	/// Default for `SyncConfig::auto` in schema.
+	#[must_use]
+	pub const fn sync_auto() -> bool {
+		true
+	}
+
+	/// Default for `SyncSftpConfig::max_files_to_sync` in schema.
+	#[must_use]
+	pub const fn max_files_to_sync() -> usize {
+		100
+	}
+}
+
 /// Root configuration struct for biwa.
 #[derive(confique::Config, Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Config {
 	/// SSH connection configuration.
 	#[config(nested)]
+	#[schemars(default)]
 	pub ssh: SshConfig,
 	/// Remote synchronization configuration.
 	#[config(nested)]
+	#[schemars(default)]
 	pub sync: SyncConfig,
 	/// Environment variables configuration.
 	#[config(nested)]
+	#[schemars(default)]
 	pub env: EnvConfig,
 	/// Lifecycle hooks for synchronization.
 	#[config(nested)]
+	#[schemars(default)]
 	pub hooks: HooksConfig,
 	/// Logging configuration.
 	#[config(nested)]
+	#[schemars(default)]
 	pub log: LogConfig,
 }
 
@@ -122,18 +178,22 @@ impl Default for Config {
 pub struct SshConfig {
 	/// Hostname or IP address of the remote host.
 	#[config(default = "cse.unsw.edu.au", env = "BIWA_SSH_HOST")]
+	#[schemars(default = "crate::config::types::schema_defaults::ssh_host")]
 	pub host: String,
 	/// Port to connect to on the remote host.
 	#[config(default = 22, env = "BIWA_SSH_PORT")]
+	#[schemars(default = "crate::config::types::schema_defaults::ssh_port")]
 	pub port: u16,
 	/// Username for the SSH connection.
 	#[config(default = "z1234567", env = "BIWA_SSH_USER")]
+	#[schemars(default = "crate::config::types::schema_defaults::ssh_user")]
 	pub user: String,
 	/// Optional path to the SSH private key.
 	#[config(env = "BIWA_SSH_KEY_PATH")]
 	pub key_path: Option<PathBuf>,
 	/// Password authentication: `false` (default), `true` (prompt), or a string value.
 	#[config(default = false, env = "BIWA_SSH_PASSWORD")]
+	#[schemars(default)]
 	pub password: PasswordConfig,
 	/// Umask to apply before executing commands and creating directories (3-digit octal: owner/group/other).
 	/// To set the first digit (setuid/setgid/sticky), run `umask` manually on the remote server.
@@ -141,7 +201,14 @@ pub struct SshConfig {
 	/// You need to use `chmod` manually if you want looser permissions. However, this umask setting
 	/// cannot restrict manual permission modifications via `chmod` (be careful with `chmod +x` or `+r`).
 	#[config(default = "077", env = "BIWA_SSH_UMASK")]
+	#[schemars(default)]
 	pub umask: Umask,
+}
+
+impl Default for SshConfig {
+	fn default() -> Self {
+		Config::default().ssh
+	}
 }
 
 /// Logging configuration settings.
@@ -149,10 +216,18 @@ pub struct SshConfig {
 pub struct LogConfig {
 	/// Suppresses biwa internal logs; only remote command output is shown.
 	#[config(default = false, env = "BIWA_LOG_QUIET")]
+	#[schemars(default)]
 	pub quiet: bool,
 	/// Suppresses all output, including remote command stdout/stderr.
 	#[config(default = false, env = "BIWA_LOG_SILENT")]
+	#[schemars(default)]
 	pub silent: bool,
+}
+
+impl Default for LogConfig {
+	fn default() -> Self {
+		Config::default().log
+	}
 }
 
 /// The synchronization engine to use.
@@ -184,9 +259,11 @@ pub enum SftpPermissions {
 pub struct SyncSftpConfig {
 	/// Abort synchronization if the number of files to upload exceeds this limit.
 	#[config(default = 100, env = "BIWA_SYNC_SFTP_MAX_FILES_TO_SYNC")]
+	#[schemars(default = "crate::config::types::schema_defaults::max_files_to_sync")]
 	pub max_files_to_sync: usize,
 	/// Strategy for enforcing file permissions on uploaded files.
 	#[config(default = "recreate", env = "BIWA_SYNC_SFTP_PERMISSIONS")]
+	#[schemars(default)]
 	pub permissions: SftpPermissions,
 }
 
@@ -195,22 +272,32 @@ pub struct SyncSftpConfig {
 pub struct SyncConfig {
 	/// Automatically synchronize the project before running remote commands.
 	#[config(default = true, env = "BIWA_SYNC_AUTO")]
+	#[schemars(default = "crate::config::types::schema_defaults::sync_auto")]
 	pub auto: bool,
 	/// Base directory to start the synchronization from. If not specified, uses the current working directory.
 	#[config(env = "BIWA_SYNC_ROOT")]
 	pub sync_root: Option<PathBuf>,
 	/// Remote directory to sync the project to.
 	#[config(default = "~/.cache/biwa/projects", env = "BIWA_SYNC_REMOTE_ROOT")]
+	#[schemars(default = "crate::config::types::schema_defaults::sync_remote_root")]
 	pub remote_root: PathBuf,
 	/// Files and directories to exclude during synchronization using globset patterns.
 	#[config(default = ["**/.git/**", "**/target/**", "**/node_modules/**"])]
+	#[schemars(default = "crate::config::types::schema_defaults::sync_exclude")]
 	pub exclude: Vec<String>,
 	/// The synchronization engine to use.
 	#[config(default = "sftp", env = "BIWA_SYNC_ENGINE")]
+	#[schemars(default)]
 	pub engine: SyncEngine,
 	/// SFTP engine specific configuration.
 	#[config(nested)]
 	pub sftp: SyncSftpConfig,
+}
+
+impl Default for SyncConfig {
+	fn default() -> Self {
+		Config::default().sync
+	}
 }
 
 /// Environment settings.
@@ -218,7 +305,14 @@ pub struct SyncConfig {
 pub struct EnvConfig {
 	/// Environment variable keys to inherit/send.
 	#[config(default = [])]
+	#[schemars(default)]
 	pub vars: Vec<String>,
+}
+
+impl Default for EnvConfig {
+	fn default() -> Self {
+		Config::default().env
+	}
 }
 
 /// Hook settings.
@@ -230,10 +324,47 @@ pub struct HooksConfig {
 	pub post_sync: Option<String>,
 }
 
+impl Default for HooksConfig {
+	fn default() -> Self {
+		Config::default().hooks
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use alloc::vec::Vec;
 	use pretty_assertions::assert_eq;
+	use schemars::schema_for;
+
+	/// Ensures the generated JSON schema marks fields with defaults as optional (no required).
+	#[test]
+	fn schema_defaulted_fields_optional() {
+		let schema = schema_for!(Config);
+		let value = serde_json::to_value(&schema).expect("schema serializes to JSON");
+		// Root Config: no required keys (partial configs allowed).
+		let root_required = value.get("required").and_then(|v| v.as_array());
+		assert!(
+			root_required.is_none_or(Vec::is_empty),
+			"root schema must not require any keys; got required = {root_required:?}"
+		);
+		// SshConfig: fields with defaults (e.g. host) must not be in required.
+		let defs = value
+			.get("$defs")
+			.and_then(|v| v.as_object())
+			.expect("schema has $defs");
+		let ssh = defs
+			.get("SshConfig")
+			.and_then(|v| v.as_object())
+			.expect("SshConfig in $defs");
+		let required = ssh.get("required").and_then(|v| v.as_array());
+		if let Some(r) = required {
+			assert!(
+				!r.iter().any(|v| v.as_str() == Some("host")),
+				"SshConfig.required must not contain 'host'; required = {r:?}"
+			);
+		}
+	}
 
 	#[test]
 	fn umask_deserialize_string_octal() {

--- a/tasks.toml
+++ b/tasks.toml
@@ -65,7 +65,14 @@ description = "Run yamllint to lint YAML files."
 
 ["check:oxfmt"]
 run = "oxfmt {% if env.LINT is defined %}--check{% endif %}"
-description = "Run oxfmt to format JS, TS, CSS, Vue, JSON, JSONC, YAML, TOML, and Markdown files."
+description = "Run oxfmt to format JS, TS, CSS, Vue, JSON, JSONC, YAML, and Markdown files."
+
+["check:tombi"]
+run = [
+	"tombi format {% if env.LINT is defined %}--check{% endif %}",
+	"tombi lint --error-on-warnings",
+]
+description = "Run tombi to format TOML files."
 
 ["check:typos"]
 run = "typos {% if env.LINT is undefined %}--write-changes{% endif %}"
@@ -111,3 +118,20 @@ run = [
 	"usage generate markdown -m --out-dir docs/src/cli --url-prefix /cli --html-encode --file biwa.usage.kdl",
 ]
 description = "Generate usage spec and CLI reference docs."
+
+["util:noop"]
+run = ":"
+hide = true
+description = "No-op"
+
+[schema]
+depends = ["schema:*"]
+description = "Validate config schema."
+
+["schema:tombi"]
+depends = [
+	"{% if env.CI is defined %}util:noop{% else %}render:schema{% endif %}",
+]
+run = "tombi lint --error-on-warnings"
+dir = "schema"
+description = "Validate config schema with Tombi."

--- a/tasks/schema/ajv
+++ b/tasks/schema/ajv
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#MISE description="Validate config schema with ajv."
+#MISE depends=["{% if env.CI is defined %}util:noop{% else %}render:schema{% endif %}"]
+
+set -euo pipefail
+
+fixtures="schema/fixtures/"
+generated="${fixtures}/json/generated"
+
+mkdir --parents "${generated}"
+rm --force "${generated}"/*.json
+for file in "${fixtures}"/toml/*.toml; do
+	[[ -f ${file} ]] || continue
+	base=$(basename "${file}" .toml)
+	# yq converts empty TOML to null, but ajv expects an empty object
+	if [[ ! -s ${file} ]]; then
+		echo '{}' >"${generated}/${base}.json"
+	else
+		yq --input-format toml --output-format json "${file}" >"${generated}/${base}.json"
+	fi
+done
+
+failed=0
+for file in "${generated}"/*.json; do
+	if ! ajv validate -s schema/config.json -d "${file}" --spec=draft2020; then
+		echo "Failed: ${file}"
+		failed=$((failed + 1))
+	fi
+done
+
+if [[ "${failed}" -ne 0 ]]; then
+	echo "Total failures: ${failed}"
+	exit 1
+fi

--- a/tests/ssh_e2e_run.rs
+++ b/tests/ssh_e2e_run.rs
@@ -6,7 +6,10 @@
 use std::io::{BufRead as _, BufReader, Read as _};
 
 mod common;
+use color_eyre::eyre::WrapErr as _;
 use common::{Result, biwa_cmd};
+use rstest::rstest;
+use std::{fs, path::PathBuf};
 
 #[test]
 fn e2e_run_command() -> Result<()> {
@@ -237,6 +240,38 @@ fn e2e_implicit_run_command_executes_in_resolved_dir() -> Result<()> {
 	assert!(
 		stdout.contains(".cache/biwa/projects/"),
 		"expected path under .cache/biwa/projects/, got: {stdout}"
+	);
+	Ok(())
+}
+
+/// CLI loads config from each schema fixture when used as biwa.toml.
+#[rstest]
+fn e2e_run_config_from_schema_fixture(
+	#[files("schema/fixtures/toml/*.toml")] fixture: PathBuf,
+) -> Result<()> {
+	let dir = tempfile::tempdir()?;
+	let target_path = dir.path().join("biwa.toml");
+
+	fs::copy(&fixture, &target_path).wrap_err_with(|| {
+		format!(
+			"failed to copy {} to {}",
+			fixture.display(),
+			target_path.display()
+		)
+	})?;
+
+	let output = biwa_cmd(&["run", "--skip-sync", ":"])
+		.dir(dir.path())
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
+
+	assert!(
+		output.status.success(),
+		"fixture {}: biwa run failed: {}",
+		fixture.display(),
+		String::from_utf8_lossy(&output.stderr)
 	);
 	Ok(())
 }

--- a/tombi.toml
+++ b/tombi.toml
@@ -1,0 +1,7 @@
+toml-version = "v1.1.0"
+
+[files]
+exclude = ["schema/fixtures/toml/**/*.toml"]
+
+[format.rules]
+indent-style = "tab"

--- a/tombi.toml
+++ b/tombi.toml
@@ -1,4 +1,4 @@
-toml-version = "v1.1.0"
+toml-version = "v1.0.0"
 
 [files]
 exclude = ["schema/fixtures/toml/**/*.toml"]


### PR DESCRIPTION
Closes #296

- Add `#[schemars(default)]` to root Config sections (ssh, sync, env, hooks, log) so partial configs validate; implement Default for nested config types.
- Add `#[schemars(default)]` or `default = "path"` for all fields with `#[config(default = ...)]`; add `schema_defaults` module for literal defaults.
- Regenerate `schema/config.json`; add test `schema_defaulted_fields_optional`.

Verification: `LINT=true mise run check` and `mise run test` pass.

Made with [Cursor](https://cursor.com)