### PR TITLE
fix(ssh): drain silent command output

### DIFF
--- a/src/ssh/exec.rs
+++ b/src/ssh/exec.rs
@@ -9,7 +9,7 @@ use color_eyre::eyre::{Context as _, bail};
 use console::style;
 use core::time::Duration;
 use std::io::Error as IoError;
-use tokio::io::{copy, stderr, stdout};
+use tokio::io::{copy, sink, stderr, stdout};
 use tokio::sync::mpsc;
 use tokio::time::sleep;
 use tokio_stream::StreamExt as _;
@@ -143,14 +143,26 @@ async fn run_command(
 	);
 
 	let stdout_task = async {
-		if !silent {
-			copy(&mut stdout_reader, &mut stdout()).await.unwrap_or(0);
+		if silent {
+			let mut output_sink = sink();
+			copy(&mut stdout_reader, &mut output_sink)
+				.await
+				.unwrap_or(0);
+		} else {
+			let mut output = stdout();
+			copy(&mut stdout_reader, &mut output).await.unwrap_or(0);
 		}
 	};
 
 	let stderr_task = async {
-		if !silent {
-			copy(&mut stderr_reader, &mut stderr()).await.unwrap_or(0);
+		if silent {
+			let mut output_sink = sink();
+			copy(&mut stderr_reader, &mut output_sink)
+				.await
+				.unwrap_or(0);
+		} else {
+			let mut output = stderr();
+			copy(&mut stderr_reader, &mut output).await.unwrap_or(0);
 		}
 	};
 

--- a/src/ssh/exec.rs
+++ b/src/ssh/exec.rs
@@ -9,7 +9,7 @@ use color_eyre::eyre::{Context as _, bail};
 use console::style;
 use core::time::Duration;
 use std::io::Error as IoError;
-use tokio::io::{copy, sink, stderr, stdout};
+use tokio::io::{AsyncRead, AsyncWrite, copy, sink, stderr, stdout};
 use tokio::sync::mpsc;
 use tokio::time::sleep;
 use tokio_stream::StreamExt as _;
@@ -90,6 +90,14 @@ fn build_command(command: &str, args: &[String]) -> String {
 	}
 }
 
+/// Drain a remote output stream into the chosen local writer.
+async fn drain_output<R>(reader: &mut R, writer: &mut (dyn AsyncWrite + Unpin + Send))
+where
+	R: AsyncRead + Unpin,
+{
+	copy(reader, writer).await.unwrap_or(0);
+}
+
 /// Run a pre-built command string on an already-connected SSH client.
 ///
 /// Returns the remote exit code, printing stdout/stderr as they arrive
@@ -143,27 +151,21 @@ async fn run_command(
 	);
 
 	let stdout_task = async {
-		if silent {
-			let mut output_sink = sink();
-			copy(&mut stdout_reader, &mut output_sink)
-				.await
-				.unwrap_or(0);
+		let mut writer: Box<dyn AsyncWrite + Unpin + Send> = if silent {
+			Box::new(sink())
 		} else {
-			let mut output = stdout();
-			copy(&mut stdout_reader, &mut output).await.unwrap_or(0);
-		}
+			Box::new(stdout())
+		};
+		drain_output(&mut stdout_reader, writer.as_mut()).await;
 	};
 
 	let stderr_task = async {
-		if silent {
-			let mut output_sink = sink();
-			copy(&mut stderr_reader, &mut output_sink)
-				.await
-				.unwrap_or(0);
+		let mut writer: Box<dyn AsyncWrite + Unpin + Send> = if silent {
+			Box::new(sink())
 		} else {
-			let mut output = stderr();
-			copy(&mut stderr_reader, &mut output).await.unwrap_or(0);
-		}
+			Box::new(stderr())
+		};
+		drain_output(&mut stderr_reader, writer.as_mut()).await;
 	};
 
 	let (exit_status, (), ()) = tokio::join!(exec_future, stdout_task, stderr_task);

--- a/tests/ssh_e2e_run.rs
+++ b/tests/ssh_e2e_run.rs
@@ -5,11 +5,12 @@
 #![expect(clippy::panic_in_result_fn, reason = "color_eyre handles panics")]
 use std::io::{BufRead as _, BufReader, Read as _};
 
+use core::time::Duration;
 mod common;
-use color_eyre::eyre::WrapErr as _;
+use color_eyre::eyre::{WrapErr as _, eyre};
 use common::{Result, biwa_cmd};
 use rstest::rstest;
-use std::{fs, path::PathBuf};
+use std::{fs, path::PathBuf, sync::mpsc, thread};
 
 #[test]
 fn e2e_run_command() -> Result<()> {
@@ -114,6 +115,45 @@ fn e2e_run_silent() -> Result<()> {
 	let stderr = String::from_utf8_lossy(&output.stderr);
 
 	assert!(output.status.success());
+	assert!(stdout.trim().is_empty(), "stdout was not empty: {stdout}");
+	assert!(stderr.trim().is_empty(), "stderr was not empty: {stderr}");
+	Ok(())
+}
+
+#[test]
+fn e2e_run_silent_large_output() -> Result<()> {
+	let (result_tx, result_rx) = mpsc::channel();
+
+	thread::spawn(move || {
+		let result = biwa_cmd(&[
+			"--silent",
+			"run",
+			"--skip-sync",
+			"--",
+			"bash",
+			"-c",
+			"head -c 83886080 /dev/zero | tr '\\0' 'o'; head -c 83886080 /dev/zero | tr '\\0' 'e' >&2",
+		])
+		.env("BIWA_LOG_QUIET", "true")
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()
+		.map(|output| (output.status.success(), output.stdout, output.stderr))
+		.map_err(|error| format!("{error:?}"));
+
+		drop(result_tx.send(result));
+	});
+
+	let (success, stdout, stderr) = result_rx
+		.recv_timeout(Duration::from_secs(20))
+		.map_err(|error| eyre!("silent large-output run timed out, likely deadlocked: {error}"))?
+		.map_err(|error| eyre!(error))?;
+
+	let stdout = String::from_utf8_lossy(&stdout);
+	let stderr = String::from_utf8_lossy(&stderr);
+
+	assert!(success, "stderr: {stderr}");
 	assert!(stdout.trim().is_empty(), "stdout was not empty: {stdout}");
 	assert!(stderr.trim().is_empty(), "stderr was not empty: {stderr}");
 	Ok(())

--- a/tests/ssh_e2e_run.rs
+++ b/tests/ssh_e2e_run.rs
@@ -10,7 +10,18 @@ mod common;
 use color_eyre::eyre::{WrapErr as _, eyre};
 use common::{Result, biwa_cmd};
 use rstest::rstest;
-use std::{fs, path::PathBuf, sync::mpsc, thread};
+use std::{fs, path::PathBuf, process::Command, process::Stdio, thread, time::Instant};
+
+fn biwa_process(args: &[&str]) -> Command {
+	let mut command = Command::new(env!("CARGO_BIN_EXE_biwa"));
+	command
+		.args(args)
+		.env("BIWA_SSH_HOST", "127.0.0.1")
+		.env("BIWA_SSH_PORT", "2222")
+		.env("BIWA_SSH_USER", "testuser")
+		.env("BIWA_SSH_PASSWORD", "password123");
+	command
+}
 
 #[test]
 fn e2e_run_command() -> Result<()> {
@@ -122,33 +133,50 @@ fn e2e_run_silent() -> Result<()> {
 
 #[test]
 fn e2e_run_silent_large_output() -> Result<()> {
-	let (result_tx, result_rx) = mpsc::channel();
+	const OUTPUT_LINES: usize = 4096;
+	let command = format!(
+		"for i in $(seq 1 {OUTPUT_LINES}); do printf 'out%04d\\n' \"$i\"; done & \
+		 for i in $(seq 1 {OUTPUT_LINES}); do printf 'err%04d\\n' \"$i\" >&2; done & \
+		 wait"
+	);
 
-	thread::spawn(move || {
-		let result = biwa_cmd(&[
-			"--silent",
-			"run",
-			"--skip-sync",
-			"--",
-			"bash",
-			"-c",
-			"head -c 83886080 /dev/zero | tr '\\0' 'o'; head -c 83886080 /dev/zero | tr '\\0' 'e' >&2",
-		])
+	let mut child = biwa_process(&[
+		"--silent",
+		"run",
+		"--skip-sync",
+		"--",
+		"bash",
+		"-c",
+		&command,
+	]);
+	child
 		.env("BIWA_LOG_QUIET", "true")
-		.stdout_capture()
-		.stderr_capture()
-		.unchecked()
-		.run()
-		.map(|output| (output.status.success(), output.stdout, output.stderr))
-		.map_err(|error| format!("{error:?}"));
+		.stdout(Stdio::piped())
+		.stderr(Stdio::piped());
+	let mut child = child.spawn()?;
 
-		drop(result_tx.send(result));
-	});
+	let deadline = Instant::now() + Duration::from_secs(20);
+	while child.try_wait()?.is_none() {
+		if Instant::now() >= deadline {
+			#[expect(
+				clippy::unused_result_ok,
+				reason = "The process may already have exited between try_wait and kill."
+			)]
+			child.kill().ok();
+			let output = child.wait_with_output()?;
+			let stdout = String::from_utf8_lossy(&output.stdout);
+			let stderr = String::from_utf8_lossy(&output.stderr);
+			return Err(eyre!(
+				"silent large-output run timed out, likely deadlocked\nstdout: {stdout}\nstderr: {stderr}"
+			));
+		}
+		thread::sleep(Duration::from_millis(50));
+	}
 
-	let (success, stdout, stderr) = result_rx
-		.recv_timeout(Duration::from_secs(20))
-		.map_err(|error| eyre!("silent large-output run timed out, likely deadlocked: {error}"))?
-		.map_err(|error| eyre!(error))?;
+	let output = child.wait_with_output()?;
+	let success = output.status.success();
+	let stdout = output.stdout;
+	let stderr = output.stderr;
 
 	let stdout = String::from_utf8_lossy(&stdout);
 	let stderr = String::from_utf8_lossy(&stderr);


### PR DESCRIPTION
## Summary
- drain remote stdout and stderr to `tokio::io::sink()` when `--silent` is enabled so bounded SSH output channels cannot deadlock
- keep the existing non-silent behavior unchanged by still streaming output to local stdout and stderr
- add a high-volume end-to-end regression test that times out if silent remote execution stalls

## Test plan
- [x] `cargo test --test ssh_e2e_run`
- [x] `mise run check:rustfmt`
- [x] `LINT=true mise run check`

Closes #367.

Made with [Cursor](https://cursor.com)