### PR TITLE
fix(sync): check file limit before SSH connect

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -85,10 +85,10 @@ Storing your password in a configuration file is **not recommended** for securit
 
 #### `[sync.sftp]` — SFTP Engine Settings
 
-| Key                 | Type    | Default      | Description                                                               |
-| ------------------- | ------- | ------------ | ------------------------------------------------------------------------- |
-| `max_files_to_sync` | integer | `100`        | Abort synchronization if the number of files to upload exceeds this limit |
-| `permissions`       | string  | `"recreate"` | Strategy for enforcing file permissions on uploaded files                 |
+| Key                 | Type    | Default      | Description                                                             |
+| ------------------- | ------- | ------------ | ----------------------------------------------------------------------- |
+| `max_files_to_sync` | integer | `100`        | Abort synchronization if the number of files to sync exceeds this limit |
+| `permissions`       | string  | `"recreate"` | Strategy for enforcing file permissions on uploaded files               |
 
 ##### Permission Strategies
 

--- a/schema/config.json
+++ b/schema/config.json
@@ -246,7 +246,7 @@
       "type": "object",
       "properties": {
         "max_files_to_sync": {
-          "description": "Abort synchronization if the number of files to upload exceeds this limit.",
+          "description": "Abort synchronization if the number of files to sync exceeds this limit.",
           "type": "integer",
           "default": 100,
           "minimum": 0

--- a/src/cli/snapshots/biwa__cli__init__tests__init_json5.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_json5.snap
@@ -87,7 +87,7 @@ expression: content
 
     // SFTP engine specific configuration.
     sftp: {
-      // Abort synchronization if the number of files to upload exceeds this limit.
+      // Abort synchronization if the number of files to sync exceeds this limit.
       //
       // Can also be specified via environment variable `BIWA_SYNC_SFTP_MAX_FILES_TO_SYNC`.
       //

--- a/src/cli/snapshots/biwa__cli__init__tests__init_jsonc.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_jsonc.snap
@@ -87,7 +87,7 @@ expression: content
 
     // SFTP engine specific configuration.
     "sftp": {
-      // Abort synchronization if the number of files to upload exceeds this limit.
+      // Abort synchronization if the number of files to sync exceeds this limit.
       //
       // Can also be specified via environment variable `BIWA_SYNC_SFTP_MAX_FILES_TO_SYNC`.
       //

--- a/src/cli/snapshots/biwa__cli__init__tests__init_toml.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_toml.snap
@@ -87,7 +87,7 @@ expression: content
 
 # SFTP engine specific configuration.
 [sync.sftp]
-# Abort synchronization if the number of files to upload exceeds this limit.
+# Abort synchronization if the number of files to sync exceeds this limit.
 #
 # Can also be specified via environment variable `BIWA_SYNC_SFTP_MAX_FILES_TO_SYNC`.
 #

--- a/src/cli/snapshots/biwa__cli__init__tests__init_yaml.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_yaml.snap
@@ -86,7 +86,7 @@ sync:
 
   # SFTP engine specific configuration.
   sftp:
-    # Abort synchronization if the number of files to upload exceeds this limit.
+    # Abort synchronization if the number of files to sync exceeds this limit.
     #
     # Can also be specified via environment variable `BIWA_SYNC_SFTP_MAX_FILES_TO_SYNC`.
     #

--- a/src/cli/snapshots/biwa__cli__init__tests__init_yml.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_yml.snap
@@ -86,7 +86,7 @@ sync:
 
   # SFTP engine specific configuration.
   sftp:
-    # Abort synchronization if the number of files to upload exceeds this limit.
+    # Abort synchronization if the number of files to sync exceeds this limit.
     #
     # Can also be specified via environment variable `BIWA_SYNC_SFTP_MAX_FILES_TO_SYNC`.
     #

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -257,7 +257,7 @@ pub enum SftpPermissions {
 /// SFTP synchronization engine settings.
 #[derive(confique::Config, Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct SyncSftpConfig {
-	/// Abort synchronization if the number of files to upload exceeds this limit.
+	/// Abort synchronization if the number of files to sync exceeds this limit.
 	#[config(default = 100, env = "BIWA_SYNC_SFTP_MAX_FILES_TO_SYNC")]
 	#[schemars(default = "crate::config::types::schema_defaults::max_files_to_sync")]
 	pub max_files_to_sync: usize,

--- a/src/ssh/sync.rs
+++ b/src/ssh/sync.rs
@@ -327,6 +327,19 @@ fn calculate_sync_actions(
 	}
 }
 
+/// Aborts synchronization when the configured file limit is exceeded.
+fn ensure_sync_file_limit(file_count: usize, max_files_to_sync: usize) -> Result<()> {
+	if file_count > max_files_to_sync {
+		bail!(
+			"Aborting synchronization: {} files to upload exceeds the limit of {}.\nIf this is expected, increase `sync.sftp.max_files_to_sync` in your configuration.",
+			file_count,
+			max_files_to_sync
+		);
+	}
+
+	Ok(())
+}
+
 /// SFTP naturally resolves paths not starting with `/` relative to the user's home directory.
 /// It does NOT expand `~/` or `$HOME/` like a shell would. Therefore, we strip them so SFTP
 /// looks in the home directory instead of looking for literal `~` or `$HOME` folders.
@@ -559,6 +572,7 @@ pub async fn sync_project(
 			.wrap_err("Failed to join blocking task")??
 	};
 	info!(local_files = local_files.len(), "Collected local files");
+	ensure_sync_file_limit(local_files.len(), config.sync.sftp.max_files_to_sync)?;
 
 	let client = connect(config, quiet).await?;
 
@@ -596,17 +610,6 @@ pub async fn sync_project(
 		unchanged = stats.unchanged,
 		"Calculated synchronization actions"
 	);
-
-	if actions.to_upload.len() > config.sync.sftp.max_files_to_sync {
-		if let Some(s) = spinner {
-			s.finish_and_clear();
-		}
-		bail!(
-			"Aborting synchronization: {} files to upload exceeds the limit of {}.\nIf this is expected, increase `sync.sftp.max_files_to_sync` in your configuration.",
-			actions.to_upload.len(),
-			config.sync.sftp.max_files_to_sync
-		);
-	}
 
 	apply_sync_actions(
 		&client,
@@ -721,6 +724,20 @@ mod tests {
 		assert_eq!(hashes.get("valid/path.txt").unwrap(), "hash1");
 		assert_eq!(hashes.get("valid2.txt").unwrap(), "hash3");
 		assert!(!hashes.contains_key("../invalid/path.txt"));
+	}
+
+	#[test]
+	fn ensure_sync_file_limit_allows_at_limit() {
+		ensure_sync_file_limit(2, 2).unwrap();
+	}
+
+	#[test]
+	fn ensure_sync_file_limit_rejects_above_limit() {
+		let err = ensure_sync_file_limit(2, 1).unwrap_err();
+		assert_eq!(
+			err.to_string(),
+			"Aborting synchronization: 2 files to upload exceeds the limit of 1.\nIf this is expected, increase `sync.sftp.max_files_to_sync` in your configuration."
+		);
 	}
 
 	#[test]

--- a/src/ssh/sync.rs
+++ b/src/ssh/sync.rs
@@ -327,11 +327,11 @@ fn calculate_sync_actions(
 	}
 }
 
-/// Aborts synchronization when the configured file limit is exceeded.
+/// Aborts synchronization when too many local files are considered for sync.
 fn ensure_sync_file_limit(file_count: usize, max_files_to_sync: usize) -> Result<()> {
 	if file_count > max_files_to_sync {
 		bail!(
-			"Aborting synchronization: {} files to upload exceeds the limit of {}.\nIf this is expected, increase `sync.sftp.max_files_to_sync` in your configuration.",
+			"Aborting synchronization: {} files to sync exceeds the limit of {}.\nIf this is expected, increase `sync.sftp.max_files_to_sync` in your configuration.",
 			file_count,
 			max_files_to_sync
 		);
@@ -736,7 +736,7 @@ mod tests {
 		let err = ensure_sync_file_limit(2, 1).unwrap_err();
 		assert_eq!(
 			err.to_string(),
-			"Aborting synchronization: 2 files to upload exceeds the limit of 1.\nIf this is expected, increase `sync.sftp.max_files_to_sync` in your configuration."
+			"Aborting synchronization: 2 files to sync exceeds the limit of 1.\nIf this is expected, increase `sync.sftp.max_files_to_sync` in your configuration."
 		);
 	}
 

--- a/tests/ssh_e2e_sync.rs
+++ b/tests/ssh_e2e_sync.rs
@@ -320,6 +320,27 @@ fn e2e_sync_abort() -> Result<()> {
 }
 
 #[test]
+fn e2e_sync_abort_before_connecting() -> Result<()> {
+	let dir = tempfile::tempdir()?;
+	fs::write(dir.path().join("file1.txt"), "1")?;
+	fs::write(dir.path().join("file2.txt"), "2")?;
+
+	let output = biwa_cmd_tilde(&["sync"], dir.path())
+		.env("BIWA_SYNC_SFTP_MAX_FILES_TO_SYNC", "1")
+		.env("BIWA_SSH_PORT", "1")
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
+
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	assert!(!output.status.success());
+	assert!(stderr.contains("Aborting synchronization: 2 files to upload exceeds the limit of 1."));
+	assert!(!stderr.contains("Failed to connect to"));
+	Ok(())
+}
+
+#[test]
 fn e2e_sync_ignore_gitignore() -> Result<()> {
 	let dir = tempfile::tempdir()?;
 	fs::write(dir.path().join(".gitignore"), "ignored.txt\n")?;

--- a/tests/ssh_e2e_sync.rs
+++ b/tests/ssh_e2e_sync.rs
@@ -315,7 +315,7 @@ fn e2e_sync_abort() -> Result<()> {
 
 	let stderr = String::from_utf8_lossy(&output.stderr);
 	assert!(!output.status.success());
-	assert!(stderr.contains("Aborting synchronization: 2 files to upload exceeds the limit of 1."));
+	assert!(stderr.contains("Aborting synchronization: 2 files to sync exceeds the limit of 1."));
 	Ok(())
 }
 
@@ -327,6 +327,7 @@ fn e2e_sync_abort_before_connecting() -> Result<()> {
 
 	let output = biwa_cmd_tilde(&["sync"], dir.path())
 		.env("BIWA_SYNC_SFTP_MAX_FILES_TO_SYNC", "1")
+		.env("BIWA_SSH_HOST", "127.0.0.1")
 		.env("BIWA_SSH_PORT", "1")
 		.stdout_capture()
 		.stderr_capture()
@@ -335,7 +336,7 @@ fn e2e_sync_abort_before_connecting() -> Result<()> {
 
 	let stderr = String::from_utf8_lossy(&output.stderr);
 	assert!(!output.status.success());
-	assert!(stderr.contains("Aborting synchronization: 2 files to upload exceeds the limit of 1."));
+	assert!(stderr.contains("Aborting synchronization: 2 files to sync exceeds the limit of 1."));
 	assert!(!stderr.contains("Failed to connect to"));
 	Ok(())
 }


### PR DESCRIPTION
## Summary
- fail fast on `max_files_to_sync` immediately after collecting local files, before any SSH connection or remote hash fetch
- keep the sync limit behavior covered with unit tests around the helper used by the preflight guard
- add an e2e regression test that proves over-limit syncs abort before attempting to connect

Closes #291.

## Test plan
- [x] `cargo test ensure_sync_file_limit`
- [x] `cargo test --test ssh_e2e_sync e2e_sync_abort`
- [x] `LINT=true mise run check`

Made with [Cursor](https://cursor.com)