### PR TITLE
fix(sync): synchronize empty directories

### DIFF
--- a/docs/src/sync-behavior.md
+++ b/docs/src/sync-behavior.md
@@ -12,7 +12,7 @@ By default, `biwa run` automatically runs `biwa sync` before executing your comm
 - **Ignore files & Standard Filters**: By default, standard filters are used (`.gitignore`, parent git ignores, git excludes). Hidden files (such as `.env`) are **not** ignored by default. You can use the custom `.biwaignore` file to ignore them.
 - **Secure Permissions**: Enforces `0700` for directories. File permissions are preserved from the local filesystem but restricted to user-only access (e.g. `0644` becomes `0600`, `0755` becomes `0700`).
 
-If a directory still exists locally after its last file is removed, `biwa sync` keeps that directory on the remote side as an empty directory instead of deleting it.
+If a directory still exists locally after its last file is removed, `biwa sync` will keep it on the remote side as an empty directory instead of deleting it.
 
 ## Target Filtering & Path Resolution
 

--- a/docs/src/sync-behavior.md
+++ b/docs/src/sync-behavior.md
@@ -7,9 +7,12 @@ By default, `biwa run` automatically runs `biwa sync` before executing your comm
 ## Features
 
 - **Smart Hashing**: Computes SHA-256 hash to only upload modified/new files.
-- **Cleanup**: Automatically deletes remote files that no longer exist locally.
+- **Directory Tracking**: Synchronizes directory presence as well as file contents, including empty directories.
+- **Cleanup**: Automatically deletes remote files and directories that no longer exist locally.
 - **Ignore files & Standard Filters**: By default, standard filters are used (`.gitignore`, parent git ignores, git excludes). Hidden files (such as `.env`) are **not** ignored by default. You can use the custom `.biwaignore` file to ignore them.
 - **Secure Permissions**: Enforces `0700` for directories. File permissions are preserved from the local filesystem but restricted to user-only access (e.g. `0644` becomes `0600`, `0755` becomes `0700`).
+
+If a directory still exists locally after its last file is removed, `biwa sync` keeps that directory on the remote side as an empty directory instead of deleting it.
 
 ## Target Filtering & Path Resolution
 

--- a/src/ssh/sync.rs
+++ b/src/ssh/sync.rs
@@ -93,6 +93,19 @@ fn build_globset(patterns: &[String]) -> Result<Option<GlobSet>> {
 		.map(Some)
 }
 
+/// Returns whether a path matches a globset.
+///
+/// For directories, also try the path with a trailing slash so patterns like
+/// `foo/**` match the `foo` directory entry itself, not just its descendants.
+fn path_matches_globset(globset: &GlobSet, path: &Path, is_dir: bool) -> bool {
+	let path = path.to_string_lossy();
+	if globset.is_match(path.as_ref()) {
+		return true;
+	}
+
+	is_dir && globset.is_match(format!("{path}/"))
+}
+
 /// Checks if the remote root path is absolute and prints a warning.
 pub(super) fn check_remote_root(remote_root: &Path) {
 	if remote_root.is_absolute() {
@@ -164,17 +177,17 @@ fn should_sync_path(
 		return Ok(None);
 	}
 
-	let absolute_str = path.to_string_lossy().into_owned();
+	let is_dir = path.is_dir();
 	if exclude_globs
 		.as_ref()
-		.is_some_and(|set| set.is_match(&absolute_str))
+		.is_some_and(|set| path_matches_globset(set, path, is_dir))
 	{
 		return Ok(None);
 	}
 
 	if include_globs
 		.as_ref()
-		.is_some_and(|set| !set.is_match(&absolute_str))
+		.is_some_and(|set| !path_matches_globset(set, path, is_dir))
 	{
 		return Ok(None);
 	}
@@ -292,9 +305,8 @@ pub fn compute_project_remote_dir(config: &Config, project_root: &Path) -> Resul
 	))
 }
 
-/// Collects parent directories implied by the provided local files.
-fn collect_parent_directories(files: &[LocalFile]) -> HashSet<String> {
-	let mut directories = HashSet::new();
+/// Extends a directory set with parent directories implied by local files.
+fn collect_parent_directories_into(files: &[LocalFile], directories: &mut HashSet<String>) {
 	for local_file in files {
 		for ancestor in local_file.path.ancestors() {
 			if ancestor.as_os_str().is_empty() || ancestor == local_file.path.as_path() {
@@ -303,8 +315,6 @@ fn collect_parent_directories(files: &[LocalFile]) -> HashSet<String> {
 			directories.insert(ancestor.to_string_lossy().into_owned());
 		}
 	}
-
-	directories
 }
 
 /// Fetches the current remote directory and file state.
@@ -370,7 +380,7 @@ fn calculate_sync_actions(
 	options: &Options,
 ) -> SyncActions {
 	let mut desired_dirs = local_state.directories.clone();
-	desired_dirs.extend(collect_parent_directories(&local_state.files));
+	collect_parent_directories_into(&local_state.files, &mut desired_dirs);
 
 	let mut to_upload = Vec::new();
 	let mut local_paths_str = HashSet::new();
@@ -875,10 +885,23 @@ pub async fn sync_project(
 	Ok(stats)
 }
 
-/// Normalizes a remote relative path and rejects traversal components.
+/// Normalizes a remote relative path and rejects absolute or traversal paths.
 fn parse_remote_path(raw_path: &str, entry_kind: &str) -> Option<String> {
 	let path = raw_path.strip_prefix("./").unwrap_or(raw_path);
 	if path.is_empty() || path == "." {
+		return None;
+	}
+
+	if path.starts_with('/')
+		|| path == "~"
+		|| path.starts_with("~/")
+		|| path == "$HOME"
+		|| path.starts_with("$HOME/")
+	{
+		warn!(
+			"Skipping remote {entry_kind} with invalid absolute path: {}",
+			path
+		);
 		return None;
 	}
 
@@ -1013,6 +1036,32 @@ mod tests {
 	}
 
 	#[test]
+	fn collect_local_state_respects_glob_exclude_for_empty_directories() {
+		let dir = tempdir().unwrap();
+		fs::create_dir_all(dir.path().join("tests")).unwrap();
+		fs::create_dir_all(dir.path().join("kept")).unwrap();
+
+		let state = collect_local_state(
+			dir.path(),
+			&[],
+			&Options {
+				exclude: vec![
+					dir.path()
+						.join("tests")
+						.join("**")
+						.to_string_lossy()
+						.into_owned(),
+				],
+				..Options::default()
+			},
+		)
+		.unwrap();
+
+		assert!(!state.directories.contains("tests"));
+		assert!(state.directories.contains("kept"));
+	}
+
+	#[test]
 	fn parse_remote_hashes_traversal() {
 		let output = "__BIWA_FILE_HASHES__\nhash1  ./valid/path.txt\nhash2  ./../invalid/path.txt\nhash3  valid2.txt";
 		let hashes = parse_remote_state(output).file_hashes;
@@ -1020,6 +1069,15 @@ mod tests {
 		assert_eq!(hashes.get("valid/path.txt").unwrap(), "hash1");
 		assert_eq!(hashes.get("valid2.txt").unwrap(), "hash3");
 		assert!(!hashes.contains_key("../invalid/path.txt"));
+	}
+
+	#[test]
+	fn parse_remote_state_rejects_absolute_paths() {
+		let output = "/etc\n~/dotdir\n$HOME/secret\n__BIWA_FILE_HASHES__\nhash1  /etc/passwd\nhash2  ./valid.txt";
+		let state = parse_remote_state(output);
+		assert!(state.directories.is_empty());
+		assert_eq!(state.file_hashes.len(), 1);
+		assert_eq!(state.file_hashes.get("valid.txt").unwrap(), "hash2");
 	}
 
 	#[test]

--- a/src/ssh/sync.rs
+++ b/src/ssh/sync.rs
@@ -14,7 +14,7 @@ use russh_sftp::client::SftpSession;
 use russh_sftp::protocol::{FileAttributes, OpenFlags};
 use sha2::{Digest as _, Sha256};
 use std::collections::{HashMap, HashSet};
-use std::fs::File;
+use std::fs::{self, File};
 use std::io;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt as _;
@@ -169,6 +169,8 @@ fn hash_file(path: &Path) -> Result<String> {
 fn should_sync_path(
 	root: &Path,
 	path: &Path,
+	is_dir: bool,
+	is_symlink: bool,
 	exclude_globs: Option<&GlobSet>,
 	include_globs: Option<&GlobSet>,
 ) -> Result<Option<PathBuf>> {
@@ -177,7 +179,10 @@ fn should_sync_path(
 		return Ok(None);
 	}
 
-	let is_dir = path.is_dir();
+	if is_symlink {
+		return Ok(None);
+	}
+
 	if exclude_globs
 		.as_ref()
 		.is_some_and(|set| path_matches_globset(set, path, is_dir))
@@ -219,13 +224,24 @@ fn collect_local_state(
 	for entry in builder.build() {
 		let entry = entry?;
 		let path = entry.path();
-		let Some(relative) =
-			should_sync_path(root, path, exclude_globs.as_ref(), include_globs.as_ref())?
+		let file_type = fs::symlink_metadata(path)
+			.wrap_err_with(|| format!("Failed to read metadata for {}", path.display()))?
+			.file_type();
+		let is_dir = file_type.is_dir();
+		let is_symlink = file_type.is_symlink();
+		let Some(relative) = should_sync_path(
+			root,
+			path,
+			is_dir,
+			is_symlink,
+			exclude_globs.as_ref(),
+			include_globs.as_ref(),
+		)?
 		else {
 			continue;
 		};
 
-		if path.is_file() {
+		if !is_dir && !is_symlink && path.is_file() {
 			state.files.push(LocalFile {
 				path: relative,
 				hash: hash_file(path)?,
@@ -233,7 +249,7 @@ fn collect_local_state(
 			continue;
 		}
 
-		if path.is_dir() {
+		if is_dir {
 			state
 				.directories
 				.insert(relative.to_string_lossy().into_owned());
@@ -1059,6 +1075,34 @@ mod tests {
 
 		assert!(!state.directories.contains("tests"));
 		assert!(state.directories.contains("kept"));
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn collect_local_state_skips_symlink_entries() {
+		use std::os::unix::fs::symlink;
+
+		let dir = tempdir().unwrap();
+		fs::create_dir_all(dir.path().join("real-dir")).unwrap();
+		fs::write(dir.path().join("real-file.txt"), "hello").unwrap();
+		symlink(dir.path().join("real-dir"), dir.path().join("dir-link")).unwrap();
+		symlink(
+			dir.path().join("real-file.txt"),
+			dir.path().join("file-link.txt"),
+		)
+		.unwrap();
+
+		let state = collect_local_state(dir.path(), &[], &Options::default()).unwrap();
+		let file_paths = state
+			.files
+			.iter()
+			.map(|file| file.path.to_string_lossy().into_owned())
+			.collect::<Vec<_>>();
+
+		assert!(state.directories.contains("real-dir"));
+		assert!(!state.directories.contains("dir-link"));
+		assert!(file_paths.contains(&"real-file.txt".to_owned()));
+		assert!(!file_paths.contains(&"file-link.txt".to_owned()));
 	}
 
 	#[test]

--- a/src/ssh/sync.rs
+++ b/src/ssh/sync.rs
@@ -5,6 +5,7 @@ use crate::ui::create_spinner;
 use async_ssh2_tokio::client::Client;
 use color_eyre::eyre::{Context as _, ContextCompat as _, bail};
 use console::style;
+use core::mem::take;
 use gethostname::gethostname;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use ignore::WalkBuilder;
@@ -25,6 +26,8 @@ use tracing::{debug, info, warn};
 
 /// Separator emitted by the remote sync-state script before file hash lines.
 const REMOTE_FILE_MARKER: &str = "__BIWA_FILE_HASHES__";
+/// Conservative upper bound for a batched remote `mkdir -p` command.
+const MAX_REMOTE_MKDIR_COMMAND_LEN: usize = 4096;
 
 /// Statistics for a synchronization operation.
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -465,20 +468,19 @@ fn resolve_sftp_path(remote_path: &str) -> &str {
 		})
 }
 
-/// Deletes remote directories one-by-one so failures can be logged without aborting sync.
-async fn delete_remote_directories(client: &Client, remote_dir: &str, relative_paths: &[String]) {
+/// Deletes remote directories one-by-one over the existing SFTP session.
+async fn delete_remote_directories(
+	sftp: &SftpSession,
+	remote_dir: &str,
+	relative_paths: &[String],
+) {
 	for path in relative_paths {
 		let full_path = format!("{remote_dir}/{path}");
-		let remove_dir_cmd = format!("rmdir -- {}", shell_quote_path(&full_path));
-		match client.execute(&remove_dir_cmd).await {
-			Ok(result) if result.exit_status == 0 => {}
-			Ok(result) => warn!(
-				path = %full_path,
-				stderr = result.stderr.trim(),
-				"Failed to delete remote directory"
-			),
+		let sftp_path = resolve_sftp_path(&full_path);
+		match sftp.remove_dir(sftp_path).await {
+			Ok(()) => {}
 			Err(error) => {
-				warn!(error = %error, path = %full_path, "Failed to delete remote directory");
+				warn!(error = %error, path = sftp_path, "Failed to delete remote directory");
 			}
 		}
 	}
@@ -505,6 +507,41 @@ fn collect_directories_to_create(actions: &SyncActions) -> Vec<String> {
 	directories
 }
 
+/// Splits directory creation into bounded `mkdir -p` batches.
+fn build_mkdir_commands(umask: &str, remote_dir: &str, relative_paths: &[String]) -> Vec<String> {
+	if relative_paths.is_empty() {
+		return Vec::new();
+	}
+
+	let prefix = format!("umask {umask} && mkdir -p --");
+	let mut commands = Vec::new();
+	let mut current = prefix.clone();
+
+	for quoted_path in relative_paths
+		.iter()
+		.map(|path| format!("{remote_dir}/{path}"))
+		.map(|path| shell_quote_path(&path))
+	{
+		let projected_len = current
+			.len()
+			.saturating_add(1)
+			.saturating_add(quoted_path.len());
+		if current.len() > prefix.len() && projected_len > MAX_REMOTE_MKDIR_COMMAND_LEN {
+			commands.push(take(&mut current));
+			current.clone_from(&prefix);
+		}
+
+		current.push(' ');
+		current.push_str(&quoted_path);
+	}
+
+	if current.len() > prefix.len() {
+		commands.push(current);
+	}
+
+	commands
+}
+
 /// Creates remote directories with the configured umask.
 async fn create_remote_directories(
 	client: &Client,
@@ -512,26 +549,18 @@ async fn create_remote_directories(
 	remote_dir: &str,
 	relative_paths: &[String],
 ) -> Result<()> {
-	if relative_paths.is_empty() {
-		return Ok(());
-	}
-
-	let mkdirs = relative_paths
-		.iter()
-		.map(|path| format!("{remote_dir}/{path}"))
-		.map(|path| shell_quote_path(&path))
-		.collect::<Vec<_>>()
-		.join(" ");
-	let mkdir_cmd = format!("umask {} && mkdir -p -- {mkdirs}", config.ssh.umask);
-	let result = client
-		.execute(&mkdir_cmd)
-		.await
-		.wrap_err("Failed to create remote directories")?;
-	if result.exit_status != 0 {
-		bail!(
-			"Failed to create remote directories: {}",
-			result.stderr.trim()
-		);
+	for mkdir_cmd in build_mkdir_commands(&config.ssh.umask.to_string(), remote_dir, relative_paths)
+	{
+		let result = client
+			.execute(&mkdir_cmd)
+			.await
+			.wrap_err("Failed to create remote directories")?;
+		if result.exit_status != 0 {
+			bail!(
+				"Failed to create remote directories: {}",
+				result.stderr.trim()
+			);
+		}
 	}
 
 	Ok(())
@@ -662,7 +691,7 @@ async fn apply_sync_actions(
 	}
 
 	// Remove deleted directories deepest-first so parents become empty first.
-	delete_remote_directories(client, remote_dir, &actions.directory_deletions).await;
+	delete_remote_directories(&sftp, remote_dir, &actions.directory_deletions).await;
 
 	// Pre-create directories respecting umask.
 	let dirs_to_create = collect_directories_to_create(&actions);
@@ -1028,6 +1057,26 @@ mod tests {
 		assert_eq!(
 			actions.directory_deletions,
 			vec!["a/b/c".to_owned(), "a/b".to_owned(), "a".to_owned()]
+		);
+	}
+
+	#[test]
+	fn build_mkdir_commands_chunks_large_directory_sets() {
+		let relative_paths = (0..300)
+			.map(|i| format!("very-long-directory-name-{i:03}/nested"))
+			.collect::<Vec<_>>();
+		let commands = build_mkdir_commands("0077", "~/.cache/biwa/projects/demo", &relative_paths);
+
+		assert!(commands.len() > 1);
+		assert!(
+			commands
+				.iter()
+				.all(|command| command.starts_with("umask 0077 && mkdir -p -- "))
+		);
+		assert!(
+			commands
+				.iter()
+				.all(|command| command.len() <= MAX_REMOTE_MKDIR_COMMAND_LEN)
 		);
 	}
 

--- a/src/ssh/sync.rs
+++ b/src/ssh/sync.rs
@@ -497,21 +497,27 @@ fn collect_leaf_directories(paths: &[String]) -> Vec<String> {
 	leaves
 }
 
-/// Deletes remote directories in batched `rmdir` commands.
-async fn delete_remote_directories(client: &Client, remote_dir: &str, relative_paths: &[String]) {
-	for rmdir_cmd in build_rmdir_commands(remote_dir, relative_paths) {
-		match client.execute(&rmdir_cmd).await {
-			Ok(result) if result.exit_status == 0 => {}
-			Ok(result) => warn!(
-				stderr = result.stderr.trim(),
-				command = %rmdir_cmd,
-				"Failed to delete remote directories"
-			),
+/// Deletes remote directories one-by-one over the existing SFTP session.
+async fn delete_remote_directories(
+	sftp: &SftpSession,
+	remote_dir: &str,
+	relative_paths: &[String],
+) -> usize {
+	let mut deleted = 0_usize;
+	for path in relative_paths {
+		let full_path = format!("{remote_dir}/{path}");
+		let sftp_path = resolve_sftp_path(&full_path);
+		match sftp.remove_dir(sftp_path).await {
+			Ok(()) => {
+				deleted = deleted.saturating_add(1);
+			}
 			Err(error) => {
-				warn!(error = %error, command = %rmdir_cmd, "Failed to delete remote directories");
+				warn!(error = %error, path = sftp_path, "Failed to delete remote directory");
 			}
 		}
 	}
+
+	deleted
 }
 
 /// Collects the set of directories that must exist before uploading files.
@@ -542,41 +548,6 @@ fn build_mkdir_commands(umask: &str, remote_dir: &str, relative_paths: &[String]
 	}
 
 	let prefix = format!("umask {umask} && mkdir -p --");
-	let mut commands = Vec::new();
-	let mut current = prefix.clone();
-
-	for quoted_path in relative_paths
-		.iter()
-		.map(|path| format!("{remote_dir}/{path}"))
-		.map(|path| shell_quote_path(&path))
-	{
-		let projected_len = current
-			.len()
-			.saturating_add(1)
-			.saturating_add(quoted_path.len());
-		if current.len() > prefix.len() && projected_len > MAX_REMOTE_MKDIR_COMMAND_LEN {
-			commands.push(take(&mut current));
-			current.clone_from(&prefix);
-		}
-
-		current.push(' ');
-		current.push_str(&quoted_path);
-	}
-
-	if current.len() > prefix.len() {
-		commands.push(current);
-	}
-
-	commands
-}
-
-/// Splits directory deletion into bounded `rmdir` batches.
-fn build_rmdir_commands(remote_dir: &str, relative_paths: &[String]) -> Vec<String> {
-	if relative_paths.is_empty() {
-		return Vec::new();
-	}
-
-	let prefix = "rmdir --ignore-fail-on-non-empty --".to_owned();
 	let mut commands = Vec::new();
 	let mut current = prefix.clone();
 
@@ -749,15 +720,15 @@ async fn apply_sync_actions(
 		let sftp_path = resolve_sftp_path(&full_path);
 		if let Err(e) = sftp.remove_file(sftp_path).await {
 			warn!(error = %e, path = sftp_path, "Failed to delete remote file");
+		} else {
+			stats.deleted = stats.deleted.saturating_add(1);
 		}
-		stats.deleted = stats.deleted.saturating_add(1);
 	}
 
 	// Remove deleted directories deepest-first so parents become empty first.
-	delete_remote_directories(client, remote_dir, &actions.directory_deletions).await;
-	stats.deleted = stats
-		.deleted
-		.saturating_add(actions.directory_deletions.len());
+	stats.deleted = stats.deleted.saturating_add(
+		delete_remote_directories(&sftp, remote_dir, &actions.directory_deletions).await,
+	);
 
 	// Pre-create directories respecting umask.
 	let dirs_to_create = collect_directories_to_create(&actions);
@@ -1160,28 +1131,6 @@ mod tests {
 				.iter()
 				.all(|command| command.len() <= MAX_REMOTE_MKDIR_COMMAND_LEN)
 		);
-	}
-
-	#[test]
-	fn build_rmdir_commands_keeps_explicit_directory_deletions() {
-		let commands = build_rmdir_commands(
-			"~/.cache/biwa/projects/demo",
-			&[
-				"a".to_owned(),
-				"a/b".to_owned(),
-				"a/b/c".to_owned(),
-				"a/d".to_owned(),
-			],
-		);
-
-		assert_eq!(commands.len(), 1);
-		let command = commands.first().unwrap();
-		assert!(command.starts_with("rmdir --ignore-fail-on-non-empty -- "));
-		assert!(!command.contains("rmdir -p"));
-		assert!(command.contains("a "));
-		assert!(command.contains("a/b "));
-		assert!(command.contains("a/b/c"));
-		assert!(command.contains("a/d"));
 	}
 
 	#[test]

--- a/src/ssh/sync.rs
+++ b/src/ssh/sync.rs
@@ -497,7 +497,7 @@ fn collect_leaf_directories(paths: &[String]) -> Vec<String> {
 	leaves
 }
 
-/// Deletes remote directories in batched `rmdir -p` commands.
+/// Deletes remote directories in batched `rmdir` commands.
 async fn delete_remote_directories(client: &Client, remote_dir: &str, relative_paths: &[String]) {
 	for rmdir_cmd in build_rmdir_commands(remote_dir, relative_paths) {
 		match client.execute(&rmdir_cmd).await {
@@ -570,19 +570,18 @@ fn build_mkdir_commands(umask: &str, remote_dir: &str, relative_paths: &[String]
 	commands
 }
 
-/// Splits directory deletion into bounded `rmdir -p` batches.
+/// Splits directory deletion into bounded `rmdir` batches.
 fn build_rmdir_commands(remote_dir: &str, relative_paths: &[String]) -> Vec<String> {
-	let leaf_paths = collect_leaf_directories(relative_paths);
-	if leaf_paths.is_empty() {
+	if relative_paths.is_empty() {
 		return Vec::new();
 	}
 
-	let prefix = "rmdir -p --ignore-fail-on-non-empty --".to_owned();
+	let prefix = "rmdir --ignore-fail-on-non-empty --".to_owned();
 	let mut commands = Vec::new();
 	let mut current = prefix.clone();
 
-	for quoted_path in leaf_paths
-		.into_iter()
+	for quoted_path in relative_paths
+		.iter()
 		.map(|path| format!("{remote_dir}/{path}"))
 		.map(|path| shell_quote_path(&path))
 	{
@@ -756,6 +755,9 @@ async fn apply_sync_actions(
 
 	// Remove deleted directories deepest-first so parents become empty first.
 	delete_remote_directories(client, remote_dir, &actions.directory_deletions).await;
+	stats.deleted = stats
+		.deleted
+		.saturating_add(actions.directory_deletions.len());
 
 	// Pre-create directories respecting umask.
 	let dirs_to_create = collect_directories_to_create(&actions);
@@ -1161,7 +1163,7 @@ mod tests {
 	}
 
 	#[test]
-	fn build_rmdir_commands_uses_leaf_directories() {
+	fn build_rmdir_commands_keeps_explicit_directory_deletions() {
 		let commands = build_rmdir_commands(
 			"~/.cache/biwa/projects/demo",
 			&[
@@ -1174,10 +1176,12 @@ mod tests {
 
 		assert_eq!(commands.len(), 1);
 		let command = commands.first().unwrap();
+		assert!(command.starts_with("rmdir --ignore-fail-on-non-empty -- "));
+		assert!(!command.contains("rmdir -p"));
+		assert!(command.contains("a "));
+		assert!(command.contains("a/b "));
 		assert!(command.contains("a/b/c"));
 		assert!(command.contains("a/d"));
-		assert!(!command.contains("projects/demo/a "));
-		assert!(!command.contains("projects/demo/a/b "));
 	}
 
 	#[test]

--- a/src/ssh/sync.rs
+++ b/src/ssh/sync.rs
@@ -23,6 +23,9 @@ use tokio::io::{BufReader as AsyncBufReader, copy as async_copy};
 use tokio::task::spawn_blocking;
 use tracing::{debug, info, warn};
 
+/// Separator emitted by the remote sync-state script before file hash lines.
+const REMOTE_FILE_MARKER: &str = "__BIWA_FILE_HASHES__";
+
 /// Statistics for a synchronization operation.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct Stats {
@@ -41,6 +44,24 @@ pub(super) struct LocalFile {
 	pub path: PathBuf,
 	/// The SHA-256 hash of the file content.
 	pub hash: String,
+}
+
+/// The local sync state collected from the project root.
+#[derive(Debug, Default)]
+struct LocalState {
+	/// The local files that should exist on the remote side.
+	files: Vec<LocalFile>,
+	/// The local directories that should exist on the remote side.
+	directories: HashSet<String>,
+}
+
+/// The remote sync state collected from the project directory.
+#[derive(Debug, Default)]
+struct RemoteState {
+	/// The remote files and their hashes.
+	file_hashes: HashMap<String, String>,
+	/// The remote directories that currently exist.
+	directories: HashSet<String>,
 }
 
 /// Options for a synchronization operation.
@@ -128,12 +149,42 @@ fn hash_file(path: &Path) -> Result<String> {
 	Ok(hex::encode(hasher.finalize()))
 }
 
-/// Collects local files from the project root, respecting ignore rules.
-pub(super) fn collect_local_files(
+/// Returns whether a local path should participate in synchronization.
+fn should_sync_path(
+	root: &Path,
+	path: &Path,
+	exclude_globs: Option<&GlobSet>,
+	include_globs: Option<&GlobSet>,
+) -> Result<Option<PathBuf>> {
+	let relative = path.strip_prefix(root).wrap_err("Failed to strip prefix")?;
+	if relative.as_os_str().is_empty() {
+		return Ok(None);
+	}
+
+	let absolute_str = path.to_string_lossy().into_owned();
+	if exclude_globs
+		.as_ref()
+		.is_some_and(|set| set.is_match(&absolute_str))
+	{
+		return Ok(None);
+	}
+
+	if include_globs
+		.as_ref()
+		.is_some_and(|set| !set.is_match(&absolute_str))
+	{
+		return Ok(None);
+	}
+
+	Ok(Some(relative.to_path_buf()))
+}
+
+/// Collects local files and directories from the project root, respecting ignore rules.
+fn collect_local_state(
 	root: &Path,
 	config_exclude: &[String],
 	options: &Options,
-) -> Result<Vec<LocalFile>> {
+) -> Result<LocalState> {
 	let mut builder = WalkBuilder::new(root);
 	builder.standard_filters(true); // .gitignore, .ignore, etc.
 	builder.add_custom_ignore_filename(".biwaignore");
@@ -148,35 +199,42 @@ pub(super) fn collect_local_files(
 	let exclude_globs = build_globset(&combined_exclude)?;
 	let include_globs = build_globset(&options.include)?;
 
-	let mut result = Vec::new();
+	let mut state = LocalState::default();
 	for entry in builder.build() {
 		let entry = entry?;
 		let path = entry.path();
+		let Some(relative) =
+			should_sync_path(root, path, exclude_globs.as_ref(), include_globs.as_ref())?
+		else {
+			continue;
+		};
+
 		if path.is_file() {
-			let relative = path.strip_prefix(root).wrap_err("Failed to strip prefix")?;
-			let absolute_str = path.to_string_lossy().into_owned();
-
-			if exclude_globs
-				.as_ref()
-				.is_some_and(|set| set.is_match(&absolute_str))
-			{
-				continue;
-			}
-
-			if include_globs
-				.as_ref()
-				.is_some_and(|set| !set.is_match(&absolute_str))
-			{
-				continue;
-			}
-
-			result.push(LocalFile {
-				path: relative.to_path_buf(),
+			state.files.push(LocalFile {
+				path: relative,
 				hash: hash_file(path)?,
 			});
+			continue;
+		}
+
+		if path.is_dir() {
+			state
+				.directories
+				.insert(relative.to_string_lossy().into_owned());
 		}
 	}
-	Ok(result)
+
+	Ok(state)
+}
+
+/// Collects local files from the project root, respecting ignore rules.
+#[cfg(test)]
+pub(super) fn collect_local_files(
+	root: &Path,
+	config_exclude: &[String],
+	options: &Options,
+) -> Result<Vec<LocalFile>> {
+	Ok(collect_local_state(root, config_exclude, options)?.files)
 }
 
 /// Computes the absolute remote path for a given local file.
@@ -241,21 +299,39 @@ pub fn compute_project_remote_dir(config: &Config, project_root: &Path) -> Resul
 	))
 }
 
-/// Fetches the SHA-256 hashes of the files currently in the remote directory.
-async fn fetch_remote_hashes(
+/// Collects parent directories implied by the provided local files.
+fn collect_parent_directories(files: &[LocalFile]) -> HashSet<String> {
+	let mut directories = HashSet::new();
+	for local_file in files {
+		for ancestor in local_file.path.ancestors() {
+			if ancestor.as_os_str().is_empty() || ancestor == local_file.path.as_path() {
+				continue;
+			}
+			directories.insert(ancestor.to_string_lossy().into_owned());
+		}
+	}
+
+	directories
+}
+
+/// Fetches the current remote directory and file state.
+async fn fetch_remote_state(
 	client: &Client,
 	config: &Config,
 	remote_dir: &str,
-) -> Result<HashMap<String, String>> {
+) -> Result<RemoteState> {
 	let quoted_remote_dir = shell_quote_path(remote_dir);
 	let dir_mode = format!("{:04o}", 0o777 & !config.ssh.umask.as_u32());
+	let quoted_marker = shell_words::quote(REMOTE_FILE_MARKER).into_owned();
 
-	// Create remote dir with target permissions and fetch current hashes
+	// Create the remote dir, normalize directory permissions, then print directories and file hashes.
 	let script = format!(
 		"umask {} && mkdir -p -- {quoted_remote_dir} && \
 		 if [ -L {quoted_remote_dir} ]; then echo 'Error: remote directory is a symlink' >&2; exit 1; fi && \
 		 cd -- {quoted_remote_dir} && \
 		 (find . -type d -exec chmod {dir_mode} {{}} + || true) && \
+		 (find . -mindepth 1 -type d -print || true) && \
+		 printf '%s\n' {quoted_marker} && \
 		 (find . -type f -exec sha256sum {{}} + || true)",
 		&config.ssh.umask
 	);
@@ -279,32 +355,40 @@ async fn fetch_remote_hashes(
 
 	let output = result.stdout;
 
-	Ok(parse_remote_hashes(&output))
+	Ok(parse_remote_state(&output))
 }
 
 /// Actions to perform during synchronization.
 struct SyncActions {
 	/// Files to upload to the remote server.
-	to_upload: Vec<PathBuf>,
+	uploads: Vec<PathBuf>,
 	/// Files to delete from the remote server.
-	to_delete: Vec<String>,
+	file_deletions: Vec<String>,
+	/// Directories to create on the remote server.
+	directory_creations: Vec<String>,
+	/// Directories to delete from the remote server.
+	directory_deletions: Vec<String>,
 }
 
-/// Compares local files with remote hashes to determine which files need to be uploaded or deleted.
+/// Compares local and remote sync state to determine which actions are required.
 fn calculate_sync_actions(
-	local_files: &[LocalFile],
-	remote_hashes: &HashMap<String, String>,
+	local_state: &LocalState,
+	remote_state: &RemoteState,
 	options: &Options,
 ) -> SyncActions {
+	let mut desired_dirs = local_state.directories.clone();
+	desired_dirs.extend(collect_parent_directories(&local_state.files));
+
 	let mut to_upload = Vec::new();
 	let mut local_paths_str = HashSet::new();
 
-	for local_file in local_files {
+	for local_file in &local_state.files {
 		let rel_path_str = local_file.path.to_string_lossy().into_owned();
 		local_paths_str.insert(rel_path_str.clone());
 
 		if !options.force
-			&& let Some(remote_hash) = remote_hashes.get(&rel_path_str)
+			&& !remote_state.directories.contains(&rel_path_str)
+			&& let Some(remote_hash) = remote_state.file_hashes.get(&rel_path_str)
 			&& remote_hash == &local_file.hash
 		{
 			continue;
@@ -312,18 +396,43 @@ fn calculate_sync_actions(
 		to_upload.push(local_file.path.clone());
 	}
 
-	let mut to_delete = Vec::new();
-	let mut remote_paths: Vec<_> = remote_hashes.keys().cloned().collect();
+	let mut to_delete_files = HashSet::new();
+	let mut remote_paths: Vec<_> = remote_state.file_hashes.keys().cloned().collect();
 	remote_paths.sort_unstable(); // Sort to avoid iter_over_hash_type issue and ensure determinism
 	for remote_path in remote_paths {
-		if !local_paths_str.contains(&remote_path) {
-			to_delete.push(remote_path);
+		if !local_paths_str.contains(&remote_path) || desired_dirs.contains(&remote_path) {
+			to_delete_files.insert(remote_path);
 		}
 	}
 
+	let mut to_create_dirs = desired_dirs
+		.iter()
+		.filter(|path| !remote_state.directories.contains(*path))
+		.cloned()
+		.collect::<Vec<_>>();
+	to_create_dirs.sort_unstable();
+
+	let mut to_delete_dirs = remote_state
+		.directories
+		.iter()
+		.filter(|path| !desired_dirs.contains(*path) || local_paths_str.contains(*path))
+		.cloned()
+		.collect::<Vec<_>>();
+	to_delete_dirs.sort_unstable_by(|left, right| {
+		let left_depth = left.bytes().filter(|byte| *byte == b'/').count();
+		let right_depth = right.bytes().filter(|byte| *byte == b'/').count();
+		right_depth.cmp(&left_depth).then_with(|| left.cmp(right))
+	});
+
+	let mut to_delete_files = to_delete_files.into_iter().collect::<Vec<_>>();
+	to_delete_files.sort_unstable();
+	to_upload.sort_unstable();
+
 	SyncActions {
-		to_upload,
-		to_delete,
+		uploads: to_upload,
+		file_deletions: to_delete_files,
+		directory_creations: to_create_dirs,
+		directory_deletions: to_delete_dirs,
 	}
 }
 
@@ -354,6 +463,78 @@ fn resolve_sftp_path(remote_path: &str) -> &str {
 				remote_path
 			}
 		})
+}
+
+/// Deletes remote directories one-by-one so failures can be logged without aborting sync.
+async fn delete_remote_directories(client: &Client, remote_dir: &str, relative_paths: &[String]) {
+	for path in relative_paths {
+		let full_path = format!("{remote_dir}/{path}");
+		let remove_dir_cmd = format!("rmdir -- {}", shell_quote_path(&full_path));
+		match client.execute(&remove_dir_cmd).await {
+			Ok(result) if result.exit_status == 0 => {}
+			Ok(result) => warn!(
+				path = %full_path,
+				stderr = result.stderr.trim(),
+				"Failed to delete remote directory"
+			),
+			Err(error) => {
+				warn!(error = %error, path = %full_path, "Failed to delete remote directory");
+			}
+		}
+	}
+}
+
+/// Collects the set of directories that must exist before uploading files.
+fn collect_directories_to_create(actions: &SyncActions) -> Vec<String> {
+	let mut directories = actions
+		.directory_creations
+		.iter()
+		.cloned()
+		.collect::<HashSet<_>>();
+	for rel_path in &actions.uploads {
+		if let Some(parent) = rel_path.parent() {
+			let parent = parent.to_string_lossy().into_owned();
+			if !parent.is_empty() {
+				directories.insert(parent);
+			}
+		}
+	}
+
+	let mut directories = directories.into_iter().collect::<Vec<_>>();
+	directories.sort_unstable();
+	directories
+}
+
+/// Creates remote directories with the configured umask.
+async fn create_remote_directories(
+	client: &Client,
+	config: &Config,
+	remote_dir: &str,
+	relative_paths: &[String],
+) -> Result<()> {
+	if relative_paths.is_empty() {
+		return Ok(());
+	}
+
+	let mkdirs = relative_paths
+		.iter()
+		.map(|path| format!("{remote_dir}/{path}"))
+		.map(|path| shell_quote_path(&path))
+		.collect::<Vec<_>>()
+		.join(" ");
+	let mkdir_cmd = format!("umask {} && mkdir -p -- {mkdirs}", config.ssh.umask);
+	let result = client
+		.execute(&mkdir_cmd)
+		.await
+		.wrap_err("Failed to create remote directories")?;
+	if result.exit_status != 0 {
+		bail!(
+			"Failed to create remote directories: {}",
+			result.stderr.trim()
+		);
+	}
+
+	Ok(())
 }
 
 /// Uploads a file to a remote SFTP server using an existing session.
@@ -450,7 +631,11 @@ async fn apply_sync_actions(
 		actions,
 	} = target;
 
-	if actions.to_delete.is_empty() && actions.to_upload.is_empty() {
+	if actions.file_deletions.is_empty()
+		&& actions.directory_creations.is_empty()
+		&& actions.directory_deletions.is_empty()
+		&& actions.uploads.is_empty()
+	{
 		return Ok(());
 	}
 
@@ -466,8 +651,8 @@ async fn apply_sync_actions(
 		.await
 		.wrap_err("Failed to initialize SFTP session")?;
 
-	// Remove deleted files via SFTP
-	for path in &actions.to_delete {
+	// Remove deleted files via SFTP.
+	for path in &actions.file_deletions {
 		let full_path = format!("{remote_dir}/{path}");
 		let sftp_path = resolve_sftp_path(&full_path);
 		if let Err(e) = sftp.remove_file(sftp_path).await {
@@ -476,33 +661,16 @@ async fn apply_sync_actions(
 		stats.deleted = stats.deleted.saturating_add(1);
 	}
 
-	// Pre-create subdirectories respecting umask
-	let mut dirs_to_create = HashSet::new();
-	for rel_path in &actions.to_upload {
-		if let Some(parent) = rel_path.parent() {
-			let p_str = parent.to_string_lossy().into_owned();
-			if !p_str.is_empty() {
-				dirs_to_create.insert(format!("{remote_dir}/{p_str}"));
-			}
-		}
-	}
+	// Remove deleted directories deepest-first so parents become empty first.
+	delete_remote_directories(client, remote_dir, &actions.directory_deletions).await;
 
-	if !dirs_to_create.is_empty() {
-		let mkdirs = dirs_to_create
-			.into_iter()
-			.map(|d| shell_quote_path(&d))
-			.collect::<Vec<_>>()
-			.join(" ");
-		let mkdir_cmd = format!("umask {} && mkdir -p -- {mkdirs}", config.ssh.umask);
-		client
-			.execute(&mkdir_cmd)
-			.await
-			.wrap_err("Failed to create remote directories")?;
-	}
+	// Pre-create directories respecting umask.
+	let dirs_to_create = collect_directories_to_create(&actions);
+	create_remote_directories(client, config, remote_dir, &dirs_to_create).await?;
 
 	// Upload files and change permissions to match local user permissions (respecting umask)
-	let total_to_upload = actions.to_upload.len();
-	for (i, rel_path) in actions.to_upload.into_iter().enumerate() {
+	let total_to_upload = actions.uploads.len();
+	for (i, rel_path) in actions.uploads.into_iter().enumerate() {
 		if let Some(s) = spinner {
 			s.set_message(format!(
 				"Synchronizing files... ({}/{total_to_upload})",
@@ -563,16 +731,20 @@ pub async fn sync_project(
 
 	let unique_project_name = compute_unique_project_name(project_root)?;
 
-	let local_files = {
+	let local_state = {
 		let project_root = project_root.to_path_buf();
 		let exclude = config.sync.exclude.clone();
 		let options = options.clone();
-		spawn_blocking(move || collect_local_files(&project_root, &exclude, &options))
+		spawn_blocking(move || collect_local_state(&project_root, &exclude, &options))
 			.await
 			.wrap_err("Failed to join blocking task")??
 	};
-	info!(local_files = local_files.len(), "Collected local files");
-	ensure_sync_file_limit(local_files.len(), config.sync.sftp.max_files_to_sync)?;
+	info!(
+		local_directories = local_state.directories.len(),
+		local_files = local_state.files.len(),
+		"Collected local sync state"
+	);
+	ensure_sync_file_limit(local_state.files.len(), config.sync.sftp.max_files_to_sync)?;
 
 	let client = connect(config, quiet).await?;
 
@@ -594,19 +766,25 @@ pub async fn sync_project(
 		String::from,
 	);
 
-	let remote_hashes = fetch_remote_hashes(&client, config, &remote_dir).await?;
+	let remote_state = fetch_remote_state(&client, config, &remote_dir).await?;
 	debug!(
 		remote_dir = %remote_dir,
-		remote_files = remote_hashes.len(),
-		"Fetched remote file hashes"
+		remote_directories = remote_state.directories.len(),
+		remote_files = remote_state.file_hashes.len(),
+		"Fetched remote sync state"
 	);
 
 	let mut stats = Stats::default();
-	let actions = calculate_sync_actions(&local_files, &remote_hashes, options);
-	stats.unchanged = local_files.len().saturating_sub(actions.to_upload.len());
+	let actions = calculate_sync_actions(&local_state, &remote_state, options);
+	stats.unchanged = local_state
+		.files
+		.len()
+		.saturating_sub(actions.uploads.len());
 	info!(
-		to_upload = actions.to_upload.len(),
-		to_delete = actions.to_delete.len(),
+		to_create_dirs = actions.directory_creations.len(),
+		to_delete_dirs = actions.directory_deletions.len(),
+		to_upload = actions.uploads.len(),
+		to_delete = actions.file_deletions.len(),
 		unchanged = stats.unchanged,
 		"Calculated synchronization actions"
 	);
@@ -641,26 +819,56 @@ pub async fn sync_project(
 	Ok(stats)
 }
 
-/// Parses the output of `find . -type f -exec sha256sum {} +` into a `HashMap` mapping paths to hashes.
-/// Validates paths to prevent directory traversal attacks during sync.
-fn parse_remote_hashes(output: &str) -> HashMap<String, String> {
-	let mut remote_hashes = HashMap::new();
+/// Normalizes a remote relative path and rejects traversal components.
+fn parse_remote_path(raw_path: &str, entry_kind: &str) -> Option<String> {
+	let path = raw_path.strip_prefix("./").unwrap_or(raw_path);
+	if path.is_empty() || path == "." {
+		return None;
+	}
+
+	if path.split('/').any(|comp| comp == "..") {
+		warn!(
+			"Skipping remote {entry_kind} with invalid path traversal components: {}",
+			path
+		);
+		return None;
+	}
+
+	Some(path.to_owned())
+}
+
+/// Parses the output of the remote sync-state script into a directory set and file hash map.
+fn parse_remote_state(output: &str) -> RemoteState {
+	let mut remote_state = RemoteState::default();
+	let mut parsing_files = false;
+
 	for line in output.lines() {
-		if let Some((hash, raw_path)) = line.split_once("  ") {
-			let path = raw_path.strip_prefix("./").unwrap_or(raw_path);
-			// Validate that the remote path does not contain directory traversal components
-			// to prevent malicious deletion attacks during the sync cleanup phase.
-			if path.split('/').any(|comp| comp == "..") {
-				warn!(
-					"Skipping remote file with invalid path traversal components: {}",
-					path
-				);
-			} else {
-				remote_hashes.insert(path.to_owned(), hash.to_owned());
+		if line == REMOTE_FILE_MARKER {
+			parsing_files = true;
+			continue;
+		}
+
+		if parsing_files {
+			if let Some((hash, raw_path)) = line.split_once("  ")
+				&& let Some(path) = parse_remote_path(raw_path, "file")
+			{
+				remote_state.file_hashes.insert(path, hash.to_owned());
 			}
+			continue;
+		}
+
+		if let Some(path) = parse_remote_path(line, "directory") {
+			remote_state.directories.insert(path);
 		}
 	}
-	remote_hashes
+
+	remote_state
+}
+
+/// Parses the output of the remote sync-state script into a file hash map.
+#[cfg(test)]
+fn parse_remote_hashes(output: &str) -> HashMap<String, String> {
+	parse_remote_state(output).file_hashes
 }
 
 #[cfg(test)]
@@ -717,13 +925,110 @@ mod tests {
 	}
 
 	#[test]
+	fn collect_local_state_includes_empty_directories() {
+		let dir = tempdir().unwrap();
+		fs::create_dir_all(dir.path().join("empty/nested")).unwrap();
+		fs::write(dir.path().join("file.txt"), "hello").unwrap();
+
+		let state = collect_local_state(dir.path(), &[], &Options::default()).unwrap();
+		assert!(state.directories.contains("empty"));
+		assert!(state.directories.contains("empty/nested"));
+		assert_eq!(state.files.len(), 1);
+	}
+
+	#[test]
+	fn collect_local_state_respects_include_for_empty_directories() {
+		let dir = tempdir().unwrap();
+		fs::create_dir_all(dir.path().join("kept")).unwrap();
+		fs::create_dir_all(dir.path().join("ignored")).unwrap();
+
+		let state = collect_local_state(
+			dir.path(),
+			&[],
+			&Options {
+				include: vec![dir.path().join("kept").to_string_lossy().into_owned()],
+				..Options::default()
+			},
+		)
+		.unwrap();
+
+		assert!(state.directories.contains("kept"));
+		assert!(!state.directories.contains("ignored"));
+	}
+
+	#[test]
 	fn parse_remote_hashes_traversal() {
-		let output = "hash1  ./valid/path.txt\nhash2  ./../invalid/path.txt\nhash3  valid2.txt";
+		let output = "__BIWA_FILE_HASHES__\nhash1  ./valid/path.txt\nhash2  ./../invalid/path.txt\nhash3  valid2.txt";
 		let hashes = parse_remote_hashes(output);
 		assert_eq!(hashes.len(), 2);
 		assert_eq!(hashes.get("valid/path.txt").unwrap(), "hash1");
 		assert_eq!(hashes.get("valid2.txt").unwrap(), "hash3");
 		assert!(!hashes.contains_key("../invalid/path.txt"));
+	}
+
+	#[test]
+	fn parse_remote_state_collects_directories() {
+		let output = "./empty\n./nested/child\n__BIWA_FILE_HASHES__\nhash1  ./nested/file.txt";
+		let state = parse_remote_state(output);
+		assert!(state.directories.contains("empty"));
+		assert!(state.directories.contains("nested/child"));
+		assert_eq!(state.file_hashes.get("nested/file.txt").unwrap(), "hash1");
+	}
+
+	#[test]
+	fn calculate_sync_actions_creates_and_deletes_empty_directories() {
+		let actions = calculate_sync_actions(
+			&LocalState {
+				files: Vec::new(),
+				directories: HashSet::from(["empty".to_owned()]),
+			},
+			&RemoteState {
+				file_hashes: HashMap::new(),
+				directories: HashSet::from(["stale".to_owned()]),
+			},
+			&Options::default(),
+		);
+
+		assert_eq!(actions.directory_creations, vec!["empty".to_owned()]);
+		assert_eq!(actions.directory_deletions, vec!["stale".to_owned()]);
+		assert!(actions.file_deletions.is_empty());
+		assert!(actions.uploads.is_empty());
+	}
+
+	#[test]
+	fn calculate_sync_actions_preserves_directory_when_last_file_removed() {
+		let actions = calculate_sync_actions(
+			&LocalState {
+				files: Vec::new(),
+				directories: HashSet::from(["dir".to_owned()]),
+			},
+			&RemoteState {
+				file_hashes: HashMap::from([("dir/file.txt".to_owned(), "hash".to_owned())]),
+				directories: HashSet::from(["dir".to_owned()]),
+			},
+			&Options::default(),
+		);
+
+		assert_eq!(actions.file_deletions, vec!["dir/file.txt".to_owned()]);
+		assert!(actions.directory_deletions.is_empty());
+		assert!(actions.directory_creations.is_empty());
+	}
+
+	#[test]
+	fn calculate_sync_actions_deletes_directories_deepest_first() {
+		let actions = calculate_sync_actions(
+			&LocalState::default(),
+			&RemoteState {
+				file_hashes: HashMap::new(),
+				directories: HashSet::from(["a".to_owned(), "a/b".to_owned(), "a/b/c".to_owned()]),
+			},
+			&Options::default(),
+		);
+
+		assert_eq!(
+			actions.directory_deletions,
+			vec!["a/b/c".to_owned(), "a/b".to_owned(), "a".to_owned()]
+		);
 	}
 
 	#[test]

--- a/src/ssh/sync.rs
+++ b/src/ssh/sync.rs
@@ -921,12 +921,6 @@ fn parse_remote_state(output: &str) -> RemoteState {
 	remote_state
 }
 
-/// Parses the output of the remote sync-state script into a file hash map.
-#[cfg(test)]
-fn parse_remote_hashes(output: &str) -> HashMap<String, String> {
-	parse_remote_state(output).file_hashes
-}
-
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -1021,7 +1015,7 @@ mod tests {
 	#[test]
 	fn parse_remote_hashes_traversal() {
 		let output = "__BIWA_FILE_HASHES__\nhash1  ./valid/path.txt\nhash2  ./../invalid/path.txt\nhash3  valid2.txt";
-		let hashes = parse_remote_hashes(output);
+		let hashes = parse_remote_state(output).file_hashes;
 		assert_eq!(hashes.len(), 2);
 		assert_eq!(hashes.get("valid/path.txt").unwrap(), "hash1");
 		assert_eq!(hashes.get("valid2.txt").unwrap(), "hash3");

--- a/src/ssh/sync.rs
+++ b/src/ssh/sync.rs
@@ -468,19 +468,47 @@ fn resolve_sftp_path(remote_path: &str) -> &str {
 		})
 }
 
-/// Deletes remote directories one-by-one over the existing SFTP session.
-async fn delete_remote_directories(
-	sftp: &SftpSession,
-	remote_dir: &str,
-	relative_paths: &[String],
-) {
-	for path in relative_paths {
-		let full_path = format!("{remote_dir}/{path}");
-		let sftp_path = resolve_sftp_path(&full_path);
-		match sftp.remove_dir(sftp_path).await {
-			Ok(()) => {}
+/// Returns whether `candidate` is nested beneath `ancestor`.
+fn is_nested_directory(candidate: &str, ancestor: &str) -> bool {
+	candidate != ancestor && Path::new(candidate).starts_with(ancestor)
+}
+
+/// Reduces a directory set to its deepest leaf paths.
+fn collect_leaf_directories(paths: &[String]) -> Vec<String> {
+	let mut sorted = paths.to_vec();
+	sorted.sort_unstable_by(|left, right| {
+		let left_depth = left.bytes().filter(|byte| *byte == b'/').count();
+		let right_depth = right.bytes().filter(|byte| *byte == b'/').count();
+		right_depth.cmp(&left_depth).then_with(|| left.cmp(right))
+	});
+
+	let mut leaves = Vec::new();
+	for path in sorted {
+		if leaves
+			.iter()
+			.any(|existing: &String| is_nested_directory(existing, &path))
+		{
+			continue;
+		}
+		leaves.push(path);
+	}
+
+	leaves.sort_unstable();
+	leaves
+}
+
+/// Deletes remote directories in batched `rmdir -p` commands.
+async fn delete_remote_directories(client: &Client, remote_dir: &str, relative_paths: &[String]) {
+	for rmdir_cmd in build_rmdir_commands(remote_dir, relative_paths) {
+		match client.execute(&rmdir_cmd).await {
+			Ok(result) if result.exit_status == 0 => {}
+			Ok(result) => warn!(
+				stderr = result.stderr.trim(),
+				command = %rmdir_cmd,
+				"Failed to delete remote directories"
+			),
 			Err(error) => {
-				warn!(error = %error, path = sftp_path, "Failed to delete remote directory");
+				warn!(error = %error, command = %rmdir_cmd, "Failed to delete remote directories");
 			}
 		}
 	}
@@ -504,7 +532,7 @@ fn collect_directories_to_create(actions: &SyncActions) -> Vec<String> {
 
 	let mut directories = directories.into_iter().collect::<Vec<_>>();
 	directories.sort_unstable();
-	directories
+	collect_leaf_directories(&directories)
 }
 
 /// Splits directory creation into bounded `mkdir -p` batches.
@@ -519,6 +547,42 @@ fn build_mkdir_commands(umask: &str, remote_dir: &str, relative_paths: &[String]
 
 	for quoted_path in relative_paths
 		.iter()
+		.map(|path| format!("{remote_dir}/{path}"))
+		.map(|path| shell_quote_path(&path))
+	{
+		let projected_len = current
+			.len()
+			.saturating_add(1)
+			.saturating_add(quoted_path.len());
+		if current.len() > prefix.len() && projected_len > MAX_REMOTE_MKDIR_COMMAND_LEN {
+			commands.push(take(&mut current));
+			current.clone_from(&prefix);
+		}
+
+		current.push(' ');
+		current.push_str(&quoted_path);
+	}
+
+	if current.len() > prefix.len() {
+		commands.push(current);
+	}
+
+	commands
+}
+
+/// Splits directory deletion into bounded `rmdir -p` batches.
+fn build_rmdir_commands(remote_dir: &str, relative_paths: &[String]) -> Vec<String> {
+	let leaf_paths = collect_leaf_directories(relative_paths);
+	if leaf_paths.is_empty() {
+		return Vec::new();
+	}
+
+	let prefix = "rmdir -p --ignore-fail-on-non-empty --".to_owned();
+	let mut commands = Vec::new();
+	let mut current = prefix.clone();
+
+	for quoted_path in leaf_paths
+		.into_iter()
 		.map(|path| format!("{remote_dir}/{path}"))
 		.map(|path| shell_quote_path(&path))
 	{
@@ -691,7 +755,7 @@ async fn apply_sync_actions(
 	}
 
 	// Remove deleted directories deepest-first so parents become empty first.
-	delete_remote_directories(&sftp, remote_dir, &actions.directory_deletions).await;
+	delete_remote_directories(client, remote_dir, &actions.directory_deletions).await;
 
 	// Pre-create directories respecting umask.
 	let dirs_to_create = collect_directories_to_create(&actions);
@@ -1061,6 +1125,22 @@ mod tests {
 	}
 
 	#[test]
+	fn collect_leaf_directories_prefers_deepest_paths() {
+		let leaves = collect_leaf_directories(&[
+			"a".to_owned(),
+			"a/b".to_owned(),
+			"a/b/c".to_owned(),
+			"a/d".to_owned(),
+			"e".to_owned(),
+		]);
+
+		assert_eq!(
+			leaves,
+			vec!["a/b/c".to_owned(), "a/d".to_owned(), "e".to_owned()]
+		);
+	}
+
+	#[test]
 	fn build_mkdir_commands_chunks_large_directory_sets() {
 		let relative_paths = (0..300)
 			.map(|i| format!("very-long-directory-name-{i:03}/nested"))
@@ -1078,6 +1158,26 @@ mod tests {
 				.iter()
 				.all(|command| command.len() <= MAX_REMOTE_MKDIR_COMMAND_LEN)
 		);
+	}
+
+	#[test]
+	fn build_rmdir_commands_uses_leaf_directories() {
+		let commands = build_rmdir_commands(
+			"~/.cache/biwa/projects/demo",
+			&[
+				"a".to_owned(),
+				"a/b".to_owned(),
+				"a/b/c".to_owned(),
+				"a/d".to_owned(),
+			],
+		);
+
+		assert_eq!(commands.len(), 1);
+		let command = commands.first().unwrap();
+		assert!(command.contains("a/b/c"));
+		assert!(command.contains("a/d"));
+		assert!(!command.contains("projects/demo/a "));
+		assert!(!command.contains("projects/demo/a/b "));
 	}
 
 	#[test]

--- a/src/ssh/sync.rs
+++ b/src/ssh/sync.rs
@@ -230,16 +230,6 @@ fn collect_local_state(
 	Ok(state)
 }
 
-/// Collects local files from the project root, respecting ignore rules.
-#[cfg(test)]
-pub(super) fn collect_local_files(
-	root: &Path,
-	config_exclude: &[String],
-	options: &Options,
-) -> Result<Vec<LocalFile>> {
-	Ok(collect_local_state(root, config_exclude, options)?.files)
-}
-
 /// Computes the absolute remote path for a given local file.
 pub(super) fn compute_remote_path(
 	remote_root: &Path,
@@ -950,7 +940,9 @@ mod tests {
 		let file_path = dir.path().join("test.txt");
 		fs::write(&file_path, "hello").unwrap();
 
-		let files = collect_local_files(dir.path(), &[], &Options::default()).unwrap();
+		let files = collect_local_state(dir.path(), &[], &Options::default())
+			.unwrap()
+			.files;
 		assert_eq!(files.len(), 1);
 		assert_eq!(files.first().unwrap().path.to_string_lossy(), "test.txt");
 
@@ -965,7 +957,9 @@ mod tests {
 		fs::write(dir.path().join("ignored.txt"), "ignored").unwrap();
 		fs::write(dir.path().join("kept.txt"), "kept").unwrap();
 
-		let files = collect_local_files(dir.path(), &[], &Options::default()).unwrap();
+		let files = collect_local_state(dir.path(), &[], &Options::default())
+			.unwrap()
+			.files;
 		let names: Vec<_> = files
 			.iter()
 			.map(|f| f.path.to_string_lossy().to_string())
@@ -981,7 +975,9 @@ mod tests {
 		fs::write(dir.path().join(".hidden"), "hidden content").unwrap();
 		fs::write(dir.path().join("visible.txt"), "visible content").unwrap();
 
-		let files = collect_local_files(dir.path(), &[], &Options::default()).unwrap();
+		let files = collect_local_state(dir.path(), &[], &Options::default())
+			.unwrap()
+			.files;
 		let names: Vec<_> = files
 			.iter()
 			.map(|f| f.path.to_string_lossy().to_string())

--- a/tests/ssh_e2e_sync.rs
+++ b/tests/ssh_e2e_sync.rs
@@ -636,6 +636,28 @@ fn e2e_sync_exclude_globset() -> Result<()> {
 	let stderr = String::from_utf8_lossy(&output.stderr);
 	assert!(output.status.success(), "stderr: {stderr}");
 	assert!(stderr.contains("1 uploaded"), "stderr: {stderr}"); // Only b.txt
+
+	let remote_proj_dir = common::get_remote_project_dir(dir.path())?;
+	let remote_tests_dir = format!("{remote_proj_dir}/tests");
+	let check_output = biwa_cmd_tilde(
+		&[
+			"run",
+			"--skip-sync",
+			"sh",
+			"-c",
+			"test ! -e \"$1\"",
+			"--",
+			&remote_tests_dir,
+		],
+		dir.path(),
+	)
+	.unchecked()
+	.run()?;
+	assert!(
+		check_output.status.success(),
+		"excluded dir was created: {remote_tests_dir}"
+	);
+
 	Ok(())
 }
 

--- a/tests/ssh_e2e_sync.rs
+++ b/tests/ssh_e2e_sync.rs
@@ -145,6 +145,171 @@ fn e2e_sync_cleaning() -> Result<()> {
 	Ok(())
 }
 
+#[test]
+fn e2e_sync_empty_dir_created() -> Result<()> {
+	let dir = tempfile::tempdir()?;
+	fs::create_dir_all(dir.path().join("empty"))?;
+
+	let output = biwa_cmd_tilde(&["sync"], dir.path())
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	assert!(output.status.success(), "stderr: {stderr}");
+
+	let remote_proj_dir = common::get_remote_project_dir(dir.path())?;
+	let remote_empty = format!("{remote_proj_dir}/empty");
+	let check_output = biwa_cmd_tilde(
+		&[
+			"run",
+			"--skip-sync",
+			"sh",
+			"-c",
+			&format!("test -d {remote_empty}"),
+		],
+		dir.path(),
+	)
+	.unchecked()
+	.run()?;
+	assert!(
+		check_output.status.success(),
+		"remote dir missing: {remote_empty}"
+	);
+
+	Ok(())
+}
+
+#[test]
+fn e2e_sync_empty_dir_removed() -> Result<()> {
+	let dir = tempfile::tempdir()?;
+	let empty_dir = dir.path().join("empty");
+	fs::create_dir_all(&empty_dir)?;
+
+	let first_sync = biwa_cmd_tilde(&["sync"], dir.path())
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
+	assert!(
+		first_sync.status.success(),
+		"stderr: {}",
+		String::from_utf8_lossy(&first_sync.stderr)
+	);
+
+	fs::remove_dir(&empty_dir)?;
+
+	let second_sync = biwa_cmd_tilde(&["sync"], dir.path())
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
+	assert!(
+		second_sync.status.success(),
+		"stderr: {}",
+		String::from_utf8_lossy(&second_sync.stderr)
+	);
+
+	let remote_proj_dir = common::get_remote_project_dir(dir.path())?;
+	let remote_empty = format!("{remote_proj_dir}/empty");
+	let check_output = biwa_cmd_tilde(
+		&[
+			"run",
+			"--skip-sync",
+			"sh",
+			"-c",
+			&format!("test ! -e {remote_empty}"),
+		],
+		dir.path(),
+	)
+	.unchecked()
+	.run()?;
+	assert!(
+		check_output.status.success(),
+		"remote dir still exists: {remote_empty}"
+	);
+
+	Ok(())
+}
+
+#[test]
+fn e2e_sync_preserves_dir_when_last_file_deleted() -> Result<()> {
+	let dir = tempfile::tempdir()?;
+	let nested_dir = dir.path().join("dir");
+	fs::create_dir_all(&nested_dir)?;
+	let file_path = nested_dir.join("file.txt");
+	fs::write(&file_path, "hello")?;
+
+	let first_sync = biwa_cmd_tilde(&["sync"], dir.path())
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
+	assert!(
+		first_sync.status.success(),
+		"stderr: {}",
+		String::from_utf8_lossy(&first_sync.stderr)
+	);
+
+	fs::remove_file(&file_path)?;
+
+	let second_sync = biwa_cmd_tilde(&["sync"], dir.path())
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
+	assert!(
+		second_sync.status.success(),
+		"stderr: {}",
+		String::from_utf8_lossy(&second_sync.stderr)
+	);
+	assert!(
+		String::from_utf8_lossy(&second_sync.stderr).contains("1 deleted"),
+		"stderr: {}",
+		String::from_utf8_lossy(&second_sync.stderr)
+	);
+
+	let remote_proj_dir = common::get_remote_project_dir(dir.path())?;
+	let remote_dir = format!("{remote_proj_dir}/dir");
+	let remote_file = format!("{remote_dir}/file.txt");
+
+	let dir_output = biwa_cmd_tilde(
+		&[
+			"run",
+			"--skip-sync",
+			"sh",
+			"-c",
+			&format!("test -d {remote_dir}"),
+		],
+		dir.path(),
+	)
+	.unchecked()
+	.run()?;
+	assert!(
+		dir_output.status.success(),
+		"remote dir missing: {remote_dir}"
+	);
+
+	let file_output = biwa_cmd_tilde(
+		&[
+			"run",
+			"--skip-sync",
+			"sh",
+			"-c",
+			&format!("test ! -e {remote_file}"),
+		],
+		dir.path(),
+	)
+	.unchecked()
+	.run()?;
+	assert!(
+		file_output.status.success(),
+		"remote file still exists: {remote_file}"
+	);
+
+	Ok(())
+}
+
 #[rstest]
 #[case::default(None, "drwx------", "-rw-------", "-rwx------", "-rw-------")]
 #[case::umask_0077(Some("0077"), "drwx------", "-rw-------", "-rwx------", "-rw-------")]
@@ -401,6 +566,41 @@ fn e2e_sync_exclude_globset() -> Result<()> {
 }
 
 #[test]
+fn e2e_sync_exclude_empty_dir() -> Result<()> {
+	let dir = tempfile::tempdir()?;
+	fs::create_dir_all(dir.path().join("ignored"))?;
+
+	let output = biwa_cmd_tilde(&["sync", "--exclude", "ignored"], dir.path())
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	assert!(output.status.success(), "stderr: {stderr}");
+
+	let remote_proj_dir = common::get_remote_project_dir(dir.path())?;
+	let remote_dir = format!("{remote_proj_dir}/ignored");
+	let check_output = biwa_cmd_tilde(
+		&[
+			"run",
+			"--skip-sync",
+			"sh",
+			"-c",
+			&format!("test ! -e {remote_dir}"),
+		],
+		dir.path(),
+	)
+	.unchecked()
+	.run()?;
+	assert!(
+		check_output.status.success(),
+		"excluded dir was created: {remote_dir}"
+	);
+
+	Ok(())
+}
+
+#[test]
 fn e2e_sync_exclude_config() -> Result<()> {
 	let dir = tempfile::tempdir()?;
 	fs::write(
@@ -571,6 +771,47 @@ fn e2e_sync_intermediate_dir_permissions() -> Result<()> {
 			.stderr_capture()
 			.unchecked()
 			.run()?;
+
+		let ls_stdout = String::from_utf8_lossy(&ls_output.stdout);
+		assert!(
+			ls_output.status.success(),
+			"ls failed for {remote_path}: {ls_stdout}\nstderr: {}",
+			String::from_utf8_lossy(&ls_output.stderr)
+		);
+		assert!(
+			ls_stdout.contains("drwx------"),
+			"Directory {remote_path} does not have 0700 permissions. ls output: {ls_stdout}"
+		);
+	}
+
+	Ok(())
+}
+
+#[test]
+fn e2e_sync_empty_dir_permissions() -> Result<()> {
+	let dir = tempfile::tempdir()?;
+	let deep_dir = dir.path().join("a").join("b").join("c");
+	fs::create_dir_all(&deep_dir)?;
+
+	let output = biwa_cmd_tilde(&["sync"], dir.path())
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	assert!(output.status.success(), "stderr: {stderr}");
+
+	let remote_proj_dir = common::get_remote_project_dir(dir.path())?;
+	for path in ["", "/a", "/a/b", "/a/b/c"] {
+		let remote_path = format!("{remote_proj_dir}{path}");
+		let ls_output = biwa_cmd_tilde(
+			&["run", "--skip-sync", "ls", "-ld", &remote_path],
+			dir.path(),
+		)
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
 
 		let ls_stdout = String::from_utf8_lossy(&ls_output.stdout);
 		assert!(

--- a/tests/ssh_e2e_sync.rs
+++ b/tests/ssh_e2e_sync.rs
@@ -166,7 +166,9 @@ fn e2e_sync_empty_dir_created() -> Result<()> {
 			"--skip-sync",
 			"sh",
 			"-c",
-			&format!("test -d {remote_empty}"),
+			"test -d \"$1\"",
+			"--",
+			&remote_empty,
 		],
 		dir.path(),
 	)
@@ -218,7 +220,9 @@ fn e2e_sync_empty_dir_removed() -> Result<()> {
 			"--skip-sync",
 			"sh",
 			"-c",
-			&format!("test ! -e {remote_empty}"),
+			"test ! -e \"$1\"",
+			"--",
+			&remote_empty,
 		],
 		dir.path(),
 	)
@@ -258,16 +262,9 @@ fn e2e_sync_preserves_dir_when_last_file_deleted() -> Result<()> {
 		.stderr_capture()
 		.unchecked()
 		.run()?;
-	assert!(
-		second_sync.status.success(),
-		"stderr: {}",
-		String::from_utf8_lossy(&second_sync.stderr)
-	);
-	assert!(
-		String::from_utf8_lossy(&second_sync.stderr).contains("1 deleted"),
-		"stderr: {}",
-		String::from_utf8_lossy(&second_sync.stderr)
-	);
+	let stderr = String::from_utf8_lossy(&second_sync.stderr);
+	assert!(second_sync.status.success(), "stderr: {stderr}");
+	assert!(stderr.contains("1 deleted"), "stderr: {stderr}");
 
 	let remote_proj_dir = common::get_remote_project_dir(dir.path())?;
 	let remote_dir = format!("{remote_proj_dir}/dir");
@@ -279,7 +276,9 @@ fn e2e_sync_preserves_dir_when_last_file_deleted() -> Result<()> {
 			"--skip-sync",
 			"sh",
 			"-c",
-			&format!("test -d {remote_dir}"),
+			"test -d \"$1\"",
+			"--",
+			&remote_dir,
 		],
 		dir.path(),
 	)
@@ -296,7 +295,9 @@ fn e2e_sync_preserves_dir_when_last_file_deleted() -> Result<()> {
 			"--skip-sync",
 			"sh",
 			"-c",
-			&format!("test ! -e {remote_file}"),
+			"test ! -e \"$1\"",
+			"--",
+			&remote_file,
 		],
 		dir.path(),
 	)
@@ -305,6 +306,79 @@ fn e2e_sync_preserves_dir_when_last_file_deleted() -> Result<()> {
 	assert!(
 		file_output.status.success(),
 		"remote file still exists: {remote_file}"
+	);
+
+	Ok(())
+}
+
+#[test]
+fn e2e_sync_preserves_parent_dir_when_nested_dir_removed() -> Result<()> {
+	let dir = tempfile::tempdir()?;
+	let nested_dir = dir.path().join("a").join("b");
+	fs::create_dir_all(&nested_dir)?;
+
+	let first_sync = biwa_cmd_tilde(&["sync"], dir.path())
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
+	assert!(
+		first_sync.status.success(),
+		"stderr: {}",
+		String::from_utf8_lossy(&first_sync.stderr)
+	);
+
+	fs::remove_dir(&nested_dir)?;
+
+	let second_sync = biwa_cmd_tilde(&["sync"], dir.path())
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
+	let stderr = String::from_utf8_lossy(&second_sync.stderr);
+	assert!(second_sync.status.success(), "stderr: {stderr}");
+	assert!(stderr.contains("1 deleted"), "stderr: {stderr}");
+
+	let remote_proj_dir = common::get_remote_project_dir(dir.path())?;
+	let remote_parent = format!("{remote_proj_dir}/a");
+	let remote_nested = format!("{remote_proj_dir}/a/b");
+
+	let parent_output = biwa_cmd_tilde(
+		&[
+			"run",
+			"--skip-sync",
+			"sh",
+			"-c",
+			"test -d \"$1\"",
+			"--",
+			&remote_parent,
+		],
+		dir.path(),
+	)
+	.unchecked()
+	.run()?;
+	assert!(
+		parent_output.status.success(),
+		"remote parent dir missing: {remote_parent}"
+	);
+
+	let nested_output = biwa_cmd_tilde(
+		&[
+			"run",
+			"--skip-sync",
+			"sh",
+			"-c",
+			"test ! -e \"$1\"",
+			"--",
+			&remote_nested,
+		],
+		dir.path(),
+	)
+	.unchecked()
+	.run()?;
+	assert!(
+		nested_output.status.success(),
+		"remote nested dir still exists: {remote_nested}"
 	);
 
 	Ok(())
@@ -586,7 +660,9 @@ fn e2e_sync_exclude_empty_dir() -> Result<()> {
 			"--skip-sync",
 			"sh",
 			"-c",
-			&format!("test ! -e {remote_dir}"),
+			"test ! -e \"$1\"",
+			"--",
+			&remote_dir,
 		],
 		dir.path(),
 	)


### PR DESCRIPTION
## Summary
- track directory presence during SFTP sync so empty directories are created and removed alongside files
- preserve directories that still exist locally when their last synced file is deleted
- add unit, SSH e2e, and docs coverage for empty-directory sync behavior

Closes #294.

## Test plan
- [x] `cargo test --test ssh_e2e_sync`
- [x] `LINT=true mise run check`
- [x] `mise run docs:build`

Made with [Cursor](https://cursor.com)