### PR TITLE
refactor(config): move check_remote_root to config validation phase

### DIFF
--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -6,7 +6,7 @@ use confique::Config as _;
 use std::fs::canonicalize;
 use std::path::{Path, PathBuf};
 use std::{env, fs};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 impl Config {
 	/// Loads the configuration based on global, user, and project-local paths.
@@ -109,6 +109,7 @@ impl Config {
 		}
 
 		let config = builder.load()?;
+		config.validate();
 
 		Ok(config)
 	}
@@ -161,6 +162,19 @@ impl Config {
 
 		// NOTE: remote_root is intentionally NOT resolved here because it is a remote SSH path.
 		// Tilde expansion and relative path resolution should happen on the remote server, not locally.
+	}
+
+	/// Runs post-load validation checks on the configuration.
+	///
+	/// This performs structural/semantic checks that go beyond what deserialization
+	/// can enforce (e.g. warning about absolute remote paths).
+	fn validate(&self) {
+		if self.sync.remote_root.is_absolute() {
+			warn!(
+				"Absolute remote_root path detected: {}. It is recommended to use a relative path starting with '~'.",
+				self.sync.remote_root.display()
+			);
+		}
 	}
 
 	/// Returns a string template of the default configuration for the specific format.

--- a/src/ssh/sync.rs
+++ b/src/ssh/sync.rs
@@ -106,16 +106,6 @@ fn path_matches_globset(globset: &GlobSet, path: &Path, is_dir: bool) -> bool {
 	is_dir && globset.is_match(format!("{path}/"))
 }
 
-/// Checks if the remote root path is absolute and prints a warning.
-pub(super) fn check_remote_root(remote_root: &Path) {
-	if remote_root.is_absolute() {
-		warn!(
-			"Absolute remote_root path detected: {}. It is recommended to use a relative path starting with '~'.",
-			remote_root.display()
-		);
-	}
-}
-
 /// Shell-quotes a remote path while preserving home directory expansion.
 ///
 /// If the path starts with `~/`, the `~` is replaced with `$HOME` and placed
@@ -808,8 +798,6 @@ pub async fn sync_project(
 		has_remote_override = remote_dir_override.is_some(),
 		"Starting project synchronization"
 	);
-
-	check_remote_root(&config.sync.remote_root);
 
 	let unique_project_name = compute_unique_project_name(project_root)?;
 


### PR DESCRIPTION
## Summary

Move the absolute `remote_root` path warning from sync execution (`sync_project` in `ssh/sync.rs`) to a `Config::validate()` method called immediately after loading the configuration in `config/load.rs`.

This is a more appropriate location since the check validates the configuration's structure/validity rather than being a sync concern.

## Changes

- **`src/config/load.rs`**: Added `Config::validate()` method that warns about absolute `remote_root` paths. Called right after `builder.load()`.
- **`src/ssh/sync.rs`**: Removed `check_remote_root` function and its call site in `sync_project`.

Closes #293