### PR TITLE
fix(cli): buffer configuration load logs

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -136,8 +136,15 @@ fn load_config_with_buffered_logs(
 	cli: &Cli,
 	stderr: &mut impl io::Write,
 ) -> Result<(Config, bool, bool)> {
+	if cli.silent || cli.quiet {
+		let config = Config::load()?;
+		let silent = cli.silent || config.log.silent;
+		let quiet = silent || cli.quiet || config.log.quiet;
+		return Ok((config, quiet, silent));
+	}
+
 	let writer = BufferedWriter::default();
-	let subscriber = registry().with(log_targets(cli.verbose)).with(
+	let load_subscriber = registry().with(log_targets(cli.verbose)).with(
 		fmt::layer()
 			.pretty()
 			.without_time()
@@ -145,10 +152,10 @@ fn load_config_with_buffered_logs(
 			.with_writer(writer.clone()),
 	);
 
-	let config_result = subscriber::with_default(subscriber, Config::load);
+	let config_result = subscriber::with_default(load_subscriber, Config::load);
 	let should_flush = config_result
 		.as_ref()
-		.map_or(!(cli.silent || cli.quiet), |config| !is_quiet(cli, config));
+		.is_ok_and(|config| !is_quiet(cli, config));
 
 	if should_flush {
 		writer.write_to(stderr)?;
@@ -400,6 +407,33 @@ mod tests {
 		let result = load_config_with_buffered_logs(&cli, &mut stderr);
 
 		let (_config, quiet, silent) = result?;
+		assert!(quiet);
+		assert!(!silent);
+		assert!(stderr.is_empty(), "logs were: {stderr:?}");
+		Ok(())
+	}
+
+	#[serial]
+	#[test]
+	fn buffered_config_logs_short_circuit_when_cli_quiet_is_enabled() -> Result<()> {
+		let dir = tempdir()?;
+		fs::write(
+			dir.path().join("biwa.toml"),
+			"[sync]\nremote_root = \"/absolute/path\"\n",
+		)?;
+
+		let _dir_guard = CurrentDirGuard::new(dir.path())?;
+
+		let cli = Cli {
+			command: None,
+			run_command_args: Vec::new(),
+			verbose: 0,
+			quiet: true,
+			silent: false,
+		};
+		let mut stderr = Vec::new();
+		let (_config, quiet, silent) = load_config_with_buffered_logs(&cli, &mut stderr)?;
+
 		assert!(quiet);
 		assert!(!silent);
 		assert!(stderr.is_empty(), "logs were: {stderr:?}");

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -154,8 +154,8 @@ fn load_config_with_buffered_logs(
 
 	let config_result = subscriber::with_default(load_subscriber, Config::load);
 	let should_flush = config_result.as_ref().is_ok_and(|config| {
-		let silent = cli.silent || config.log.silent;
-		let quiet = silent || cli.quiet || config.log.quiet;
+		let silent = config.log.silent;
+		let quiet = silent || config.log.quiet;
 		!quiet
 	});
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -155,7 +155,7 @@ fn load_config_with_buffered_logs(
 	let config_result = subscriber::with_default(load_subscriber, Config::load);
 	if config_result
 		.as_ref()
-		.is_ok_and(|config| !(config.log.silent || config.log.quiet))
+		.map_or(true, |config| !(config.log.silent || config.log.quiet))
 	{
 		writer.write_to(stderr)?;
 	}
@@ -430,6 +430,34 @@ mod tests {
 		assert!(quiet);
 		assert!(!silent);
 		assert!(stderr.is_empty(), "logs were: {stderr:?}");
+		Ok(())
+	}
+
+	#[serial]
+	#[test]
+	fn buffered_config_logs_are_flushed_when_loading_fails() -> Result<()> {
+		let dir = tempdir()?;
+		fs::write(dir.path().join("biwa.toml"), "[sync]\nremote_root = [\n")?;
+
+		let _dir_guard = CurrentDirGuard::new(dir.path())?;
+
+		let cli = Cli {
+			command: None,
+			run_command_args: Vec::new(),
+			verbose: 2,
+			quiet: false,
+			silent: false,
+		};
+		let mut stderr = Vec::new();
+		let result = load_config_with_buffered_logs(&cli, &mut stderr);
+
+		let _error = result.expect_err("loading invalid config should fail");
+
+		let output = String::from_utf8(stderr)?;
+		assert!(
+			output.contains("Loading configuration"),
+			"logs were: {output}"
+		);
 		Ok(())
 	}
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,6 +4,7 @@ use crate::config::types::Config;
 use alloc::sync::Arc;
 use clap::{ArgAction, Parser, Subcommand};
 use color_eyre::eyre::{bail, eyre};
+use core::mem;
 use std::io;
 use std::sync::Mutex;
 use tracing::{Level, subscriber};
@@ -202,11 +203,13 @@ impl BufferedWriter {
 
 	/// Flushes the buffered tracing output into the provided writer.
 	fn write_to(&self, writer: &mut impl io::Write) -> io::Result<()> {
-		let bytes = self
-			.buf
-			.lock()
-			.map_err(|_e| io::Error::other("failed to acquire buffer lock"))?
-			.clone();
+		let bytes = {
+			let mut buf = self
+				.buf
+				.lock()
+				.map_err(|_e| io::Error::other("failed to acquire buffer lock"))?;
+			mem::take(&mut *buf)
+		};
 
 		if !bytes.is_empty() {
 			writer.write_all(&bytes)?;
@@ -246,8 +249,27 @@ mod tests {
 	use super::*;
 	use pretty_assertions::assert_eq;
 	use serial_test::serial;
+	use std::path::{Path, PathBuf};
 	use std::{env, fs};
 	use tempfile::tempdir;
+
+	struct CurrentDirGuard {
+		original_dir: PathBuf,
+	}
+
+	impl CurrentDirGuard {
+		fn new(path: &Path) -> Result<Self> {
+			let original_dir = env::current_dir()?;
+			env::set_current_dir(path)?;
+			Ok(Self { original_dir })
+		}
+	}
+
+	impl Drop for CurrentDirGuard {
+		fn drop(&mut self) {
+			let _result = env::set_current_dir(&self.original_dir);
+		}
+	}
 
 	#[test]
 	fn cli_run_subcommand() {
@@ -335,8 +357,7 @@ mod tests {
 			"[sync]\nremote_root = \"/absolute/path\"\n",
 		)?;
 
-		let original_dir = env::current_dir()?;
-		env::set_current_dir(dir.path())?;
+		let _dir_guard = CurrentDirGuard::new(dir.path())?;
 
 		let cli = Cli {
 			command: None,
@@ -347,8 +368,6 @@ mod tests {
 		};
 		let mut stderr = Vec::new();
 		let result = load_config_with_buffered_logs(&cli, &mut stderr);
-
-		env::set_current_dir(original_dir)?;
 
 		let (_config, quiet, silent) = result?;
 		assert!(!quiet);
@@ -368,8 +387,7 @@ mod tests {
 			"[log]\nquiet = true\n[sync]\nremote_root = \"/absolute/path\"\n",
 		)?;
 
-		let original_dir = env::current_dir()?;
-		env::set_current_dir(dir.path())?;
+		let _dir_guard = CurrentDirGuard::new(dir.path())?;
 
 		let cli = Cli {
 			command: None,
@@ -380,8 +398,6 @@ mod tests {
 		};
 		let mut stderr = Vec::new();
 		let result = load_config_with_buffered_logs(&cli, &mut stderr);
-
-		env::set_current_dir(original_dir)?;
 
 		let (_config, quiet, silent) = result?;
 		assert!(quiet);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -153,13 +153,10 @@ fn load_config_with_buffered_logs(
 	);
 
 	let config_result = subscriber::with_default(load_subscriber, Config::load);
-	let should_flush = config_result.as_ref().is_ok_and(|config| {
-		let silent = config.log.silent;
-		let quiet = silent || config.log.quiet;
-		!quiet
-	});
-
-	if should_flush {
+	if config_result
+		.as_ref()
+		.is_ok_and(|config| !(config.log.silent || config.log.quiet))
+	{
 		writer.write_to(stderr)?;
 	}
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -136,7 +136,7 @@ fn load_config_with_buffered_logs(
 	stderr: &mut impl io::Write,
 ) -> Result<(Config, bool, bool)> {
 	let writer = BufferedWriter::default();
-	let subscriber = registry().with(
+	let subscriber = registry().with(log_targets(cli.verbose)).with(
 		fmt::layer()
 			.pretty()
 			.without_time()

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,11 +1,15 @@
 use crate::Result;
 use crate::cli::sync::SyncArgs;
 use crate::config::types::Config;
+use alloc::sync::Arc;
 use clap::{ArgAction, Parser, Subcommand};
 use color_eyre::eyre::{bail, eyre};
-use tracing::Level;
+use std::io;
+use std::sync::Mutex;
+use tracing::{Level, subscriber};
 use tracing_subscriber::{
-	filter::Targets, fmt, layer::SubscriberExt as _, registry, util::SubscriberInitExt as _,
+	filter::Targets, fmt, fmt::MakeWriter, layer::SubscriberExt as _, registry,
+	util::SubscriberInitExt as _,
 };
 
 /// Shell completion generation command.
@@ -92,21 +96,11 @@ impl Commands {
 pub async fn run() -> Result<()> {
 	let cli = Cli::parse();
 
-	let config = Config::load()?;
-	let silent = cli.silent || config.log.silent;
-	let quiet = silent || cli.quiet || config.log.quiet;
+	let (config, quiet, silent) = load_config_with_buffered_logs(&cli, &mut io::stderr().lock())?;
 
 	if !quiet {
-		let log_level = match cli.verbose {
-			0 => Level::WARN,
-			1 => Level::INFO,
-			2 => Level::DEBUG,
-			_ => Level::TRACE,
-		};
-
-		let log_targets = Targets::new().with_target("biwa", log_level);
 		registry()
-			.with(log_targets)
+			.with(log_targets(cli.verbose))
 			.with(fmt::layer().pretty().without_time())
 			.init();
 	}
@@ -136,54 +130,124 @@ pub async fn run() -> Result<()> {
 	Ok(())
 }
 
+/// Loads configuration while buffering any logs emitted before the global subscriber is ready.
+fn load_config_with_buffered_logs(
+	cli: &Cli,
+	stderr: &mut impl io::Write,
+) -> Result<(Config, bool, bool)> {
+	let writer = BufferedWriter::default();
+	let subscriber = registry().with(log_targets(cli.verbose)).with(
+		fmt::layer()
+			.pretty()
+			.without_time()
+			.with_ansi(false)
+			.with_writer(writer.clone()),
+	);
+
+	let config_result = subscriber::with_default(subscriber, Config::load);
+	let should_flush = config_result
+		.as_ref()
+		.map_or(!(cli.silent || cli.quiet), |config| !is_quiet(cli, config));
+
+	if should_flush {
+		writer.write_to(stderr)?;
+	}
+
+	let config = config_result?;
+	let silent = cli.silent || config.log.silent;
+	let quiet = silent || cli.quiet || config.log.quiet;
+	Ok((config, quiet, silent))
+}
+
+/// Returns the effective internal logging suppression mode.
+const fn is_quiet(cli: &Cli, config: &Config) -> bool {
+	let silent = cli.silent || config.log.silent;
+	silent || cli.quiet || config.log.quiet
+}
+
+/// Returns the log level selected by CLI verbosity flags.
+const fn log_level(verbose: u8) -> Level {
+	match verbose {
+		0 => Level::WARN,
+		1 => Level::INFO,
+		2 => Level::DEBUG,
+		_ => Level::TRACE,
+	}
+}
+
+/// Returns the target filter used for internal biwa logs.
+fn log_targets(verbose: u8) -> Targets {
+	Targets::new().with_target("biwa", log_level(verbose))
+}
+
+/// Shared in-memory writer for buffering load-phase logs.
+#[derive(Clone, Default)]
+struct BufferedWriter {
+	/// Shared byte buffer receiving formatted tracing output.
+	buf: Arc<Mutex<Vec<u8>>>,
+}
+
+/// Write guard that appends tracing output into the shared in-memory buffer.
+struct BufferedGuard {
+	/// Shared byte buffer receiving formatted tracing output.
+	buf: Arc<Mutex<Vec<u8>>>,
+}
+
+impl BufferedWriter {
+	#[cfg(test)]
+	fn output(&self) -> String {
+		let buf = self.buf.lock().expect("buffer lock should succeed");
+		String::from_utf8_lossy(&buf).into_owned()
+	}
+
+	/// Flushes the buffered tracing output into the provided writer.
+	fn write_to(&self, writer: &mut impl io::Write) -> io::Result<()> {
+		let bytes = self
+			.buf
+			.lock()
+			.map_err(|_e| io::Error::other("failed to acquire buffer lock"))?
+			.clone();
+
+		if !bytes.is_empty() {
+			writer.write_all(&bytes)?;
+			writer.flush()?;
+		}
+
+		Ok(())
+	}
+}
+
+impl<'a> MakeWriter<'a> for BufferedWriter {
+	type Writer = BufferedGuard;
+
+	fn make_writer(&'a self) -> Self::Writer {
+		BufferedGuard {
+			buf: Arc::clone(&self.buf),
+		}
+	}
+}
+
+impl io::Write for BufferedGuard {
+	fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+		self.buf
+			.lock()
+			.map_err(|_e| io::Error::other("failed to acquire buffer lock"))?
+			.extend_from_slice(buf);
+		Ok(buf.len())
+	}
+
+	fn flush(&mut self) -> io::Result<()> {
+		Ok(())
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use alloc::sync::Arc;
 	use pretty_assertions::assert_eq;
-	use std::{io, sync::Mutex};
-	use tracing::subscriber;
-	use tracing_subscriber::fmt::MakeWriter;
-
-	#[derive(Clone, Default)]
-	struct SharedWriter {
-		buf: Arc<Mutex<Vec<u8>>>,
-	}
-
-	struct SharedGuard {
-		buf: Arc<Mutex<Vec<u8>>>,
-	}
-
-	impl SharedWriter {
-		fn output(&self) -> String {
-			let buf = self.buf.lock().expect("buffer lock should succeed");
-			String::from_utf8_lossy(&buf).into_owned()
-		}
-	}
-
-	impl<'a> MakeWriter<'a> for SharedWriter {
-		type Writer = SharedGuard;
-
-		fn make_writer(&'a self) -> Self::Writer {
-			SharedGuard {
-				buf: Arc::clone(&self.buf),
-			}
-		}
-	}
-
-	impl io::Write for SharedGuard {
-		fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-			self.buf
-				.lock()
-				.map_err(|_e| io::Error::other("failed to acquire buffer lock"))?
-				.extend_from_slice(buf);
-			Ok(buf.len())
-		}
-
-		fn flush(&mut self) -> io::Result<()> {
-			Ok(())
-		}
-	}
+	use serial_test::serial;
+	use std::{env, fs};
+	use tempfile::tempdir;
 
 	#[test]
 	fn cli_run_subcommand() {
@@ -241,15 +305,13 @@ mod tests {
 
 	#[test]
 	fn verbose_filter_only_logs_biwa_targets() {
-		let writer = SharedWriter::default();
-		let subscriber = registry()
-			.with(Targets::new().with_target("biwa", Level::TRACE))
-			.with(
-				fmt::layer()
-					.with_ansi(false)
-					.without_time()
-					.with_writer(writer.clone()),
-			);
+		let writer = BufferedWriter::default();
+		let subscriber = registry().with(log_targets(3)).with(
+			fmt::layer()
+				.with_ansi(false)
+				.without_time()
+				.with_writer(writer.clone()),
+		);
 
 		subscriber::with_default(subscriber, || {
 			tracing::info!(target: "biwa::cli::tests", "biwa-target-log");
@@ -262,5 +324,69 @@ mod tests {
 			!output.contains("dependency-target-log"),
 			"logs were: {output}"
 		);
+	}
+
+	#[serial]
+	#[test]
+	fn buffered_config_logs_are_flushed_when_logging_is_enabled() -> Result<()> {
+		let dir = tempdir()?;
+		fs::write(
+			dir.path().join("biwa.toml"),
+			"[sync]\nremote_root = \"/absolute/path\"\n",
+		)?;
+
+		let original_dir = env::current_dir()?;
+		env::set_current_dir(dir.path())?;
+
+		let cli = Cli {
+			command: None,
+			run_command_args: Vec::new(),
+			verbose: 0,
+			quiet: false,
+			silent: false,
+		};
+		let mut stderr = Vec::new();
+		let result = load_config_with_buffered_logs(&cli, &mut stderr);
+
+		env::set_current_dir(original_dir)?;
+
+		let (_config, quiet, silent) = result?;
+		assert!(!quiet);
+		assert!(!silent);
+
+		let output = String::from_utf8(stderr)?;
+		assert!(output.contains("Absolute remote_root path detected"));
+		Ok(())
+	}
+
+	#[serial]
+	#[test]
+	fn buffered_config_logs_respect_loaded_quiet_mode() -> Result<()> {
+		let dir = tempdir()?;
+		fs::write(
+			dir.path().join("biwa.toml"),
+			"[log]\nquiet = true\n[sync]\nremote_root = \"/absolute/path\"\n",
+		)?;
+
+		let original_dir = env::current_dir()?;
+		env::set_current_dir(dir.path())?;
+
+		let cli = Cli {
+			command: None,
+			run_command_args: Vec::new(),
+			verbose: 0,
+			quiet: false,
+			silent: false,
+		};
+		let mut stderr = Vec::new();
+		let result = load_config_with_buffered_logs(&cli, &mut stderr);
+
+		env::set_current_dir(original_dir)?;
+
+		let (_config, quiet, silent) = result?;
+		assert!(quiet);
+		assert!(!silent);
+		assert!(stderr.is_empty(), "logs were: {stderr:?}");
+		Ok(())
 	}
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -204,16 +204,26 @@ impl BufferedWriter {
 	/// Flushes the buffered tracing output into the provided writer.
 	fn write_to(&self, writer: &mut impl io::Write) -> io::Result<()> {
 		let bytes = {
-			let mut buf = self
-				.buf
-				.lock()
-				.map_err(|_e| io::Error::other("failed to acquire buffer lock"))?;
+			let mut buf = match self.buf.lock() {
+				Ok(buf) => buf,
+				Err(_e) => return Ok(()),
+			};
 			mem::take(&mut *buf)
 		};
 
 		if !bytes.is_empty() {
-			writer.write_all(&bytes)?;
-			writer.flush()?;
+			if let Err(error) = writer.write_all(&bytes) {
+				if error.kind() != io::ErrorKind::BrokenPipe {
+					return Err(error);
+				}
+				return Ok(());
+			}
+
+			if let Err(error) = writer.flush()
+				&& error.kind() != io::ErrorKind::BrokenPipe
+			{
+				return Err(error);
+			}
 		}
 
 		Ok(())
@@ -268,6 +278,18 @@ mod tests {
 	impl Drop for CurrentDirGuard {
 		fn drop(&mut self) {
 			let _result = env::set_current_dir(&self.original_dir);
+		}
+	}
+
+	struct BrokenPipeWriter;
+
+	impl io::Write for BrokenPipeWriter {
+		fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+			Err(io::Error::from(io::ErrorKind::BrokenPipe))
+		}
+
+		fn flush(&mut self) -> io::Result<()> {
+			Err(io::Error::from(io::ErrorKind::BrokenPipe))
 		}
 	}
 
@@ -458,6 +480,25 @@ mod tests {
 			output.contains("Loading configuration"),
 			"logs were: {output}"
 		);
+		Ok(())
+	}
+
+	#[test]
+	fn buffered_writer_ignores_broken_pipe() -> Result<()> {
+		let writer = BufferedWriter::default();
+		let subscriber = registry().with(log_targets(0)).with(
+			fmt::layer()
+				.with_ansi(false)
+				.without_time()
+				.with_writer(writer.clone()),
+		);
+
+		subscriber::with_default(subscriber, || {
+			tracing::warn!(target: "biwa::cli::tests", "buffered warning");
+		});
+
+		let mut broken_pipe = BrokenPipeWriter;
+		writer.write_to(&mut broken_pipe)?;
 		Ok(())
 	}
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -153,9 +153,11 @@ fn load_config_with_buffered_logs(
 	);
 
 	let config_result = subscriber::with_default(load_subscriber, Config::load);
-	let should_flush = config_result
-		.as_ref()
-		.is_ok_and(|config| !is_quiet(cli, config));
+	let should_flush = config_result.as_ref().is_ok_and(|config| {
+		let silent = cli.silent || config.log.silent;
+		let quiet = silent || cli.quiet || config.log.quiet;
+		!quiet
+	});
 
 	if should_flush {
 		writer.write_to(stderr)?;
@@ -165,12 +167,6 @@ fn load_config_with_buffered_logs(
 	let silent = cli.silent || config.log.silent;
 	let quiet = silent || cli.quiet || config.log.quiet;
 	Ok((config, quiet, silent))
-}
-
-/// Returns the effective internal logging suppression mode.
-const fn is_quiet(cli: &Cli, config: &Config) -> bool {
-	let silent = cli.silent || config.log.silent;
-	silent || cli.quiet || config.log.quiet
 }
 
 /// Returns the log level selected by CLI verbosity flags.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -136,7 +136,7 @@ fn load_config_with_buffered_logs(
 	stderr: &mut impl io::Write,
 ) -> Result<(Config, bool, bool)> {
 	let writer = BufferedWriter::default();
-	let subscriber = registry().with(log_targets(cli.verbose)).with(
+	let subscriber = registry().with(
 		fmt::layer()
 			.pretty()
 			.without_time()


### PR DESCRIPTION
## Summary
- buffer tracing output emitted during `Config::load()` before the global subscriber is initialized
- flush buffered load-phase logs only when the final CLI/config quiet settings allow it
- add CLI tests covering warning flushes and suppression via loaded config

## Testing
- cargo test cli::tests -- --nocapture
- LINT=true mise run check:clippy

Closes #380