### PR TITLE
refactor(cli): remove log config and deferred loading

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -66,13 +66,6 @@ If you need looser permissions (e.g. making a file readable by others), you must
 Storing your password in a configuration file is **not recommended** for security reasons. If you must use password authentication, prefer `password = true` for an interactive prompt or use environment variables (`BIWA_SSH_PASSWORD`).
 :::
 
-### `[log]` — Log Output Settings
-
-| Key      | Type    | Default | Description                                                     |
-| -------- | ------- | ------- | --------------------------------------------------------------- |
-| `quiet`  | boolean | `false` | Suppress biwa internal logs, only showing remote command output |
-| `silent` | boolean | `false` | Suppress all output, including remote command stdout/stderr     |
-
 ### `[env]` — Environment Variable Settings
 
 | Key              | Type           | Default    | Description                                              |

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -104,14 +104,6 @@ biwa -s run echo "Hello"
 biwa -vv run echo "Hello"
 ```
 
-You can also set these in your config:
-
-```toml
-[log]
-quiet = true   # Suppress biwa internal logs
-silent = true  # Suppress all output
-```
-
 ## Next Steps
 
 - Read about [Configuration](/configuration) options

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -104,6 +104,8 @@ biwa -s run echo "Hello"
 biwa -vv run echo "Hello"
 ```
 
+You can also set `BIWA_LOG_QUIET=true` or `BIWA_LOG_SILENT=true` in the environment for the same behavior.
+
 ## Next Steps
 
 - Read about [Configuration](/configuration) options

--- a/schema/config.json
+++ b/schema/config.json
@@ -20,14 +20,6 @@
         "pre_sync": null
       }
     },
-    "log": {
-      "description": "Logging configuration.",
-      "$ref": "#/$defs/LogConfig",
-      "default": {
-        "quiet": false,
-        "silent": false
-      }
-    },
     "ssh": {
       "description": "SSH connection configuration.",
       "$ref": "#/$defs/SshConfig",
@@ -157,22 +149,6 @@
             "string",
             "null"
           ]
-        }
-      }
-    },
-    "LogConfig": {
-      "description": "Logging configuration settings.",
-      "type": "object",
-      "properties": {
-        "quiet": {
-          "description": "Suppresses biwa internal logs; only remote command output is shown.",
-          "type": "boolean",
-          "default": false
-        },
-        "silent": {
-          "description": "Suppresses all output, including remote command stdout/stderr.",
-          "type": "boolean",
-          "default": false
         }
       }
     },

--- a/schema/fixtures/toml/full.toml
+++ b/schema/fixtures/toml/full.toml
@@ -27,7 +27,3 @@ vars = [
 forward_method = "export"
 
 [hooks]
-
-[log]
-quiet = false
-silent = false

--- a/schema/fixtures/toml/partial-log-only.toml
+++ b/schema/fixtures/toml/partial-log-only.toml
@@ -1,5 +1,0 @@
-# Partial config: only [log] section
-
-[log]
-quiet = true
-silent = false

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -89,10 +89,10 @@ pub async fn run() -> Result<()> {
 		Some(Commands::Completion(cmd)) => cmd.run()?,
 		Some(Commands::Usage(cmd)) => cmd.run()?,
 		None => {
-			let config = Config::load()?;
 			let (command, args) = cli.run_command_args.split_first().ok_or_else(|| {
 				eyre!("No command provided. Use `biwa --help` for usage information.")
 			})?;
+			let config = Config::load()?;
 			run::run_remote(
 				&config,
 				&SyncArgs::default(),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,7 +2,7 @@ use crate::Result;
 use crate::cli::sync::SyncArgs;
 use crate::config::types::Config;
 use clap::{ArgAction, Parser, Subcommand};
-use color_eyre::eyre::{bail, eyre};
+use color_eyre::eyre::eyre;
 use std::env;
 use tracing::Level;
 use tracing_subscriber::{
@@ -88,7 +88,7 @@ pub async fn run() -> Result<()> {
 		Some(Commands::Schema(cmd)) => cmd.run()?,
 		Some(Commands::Completion(cmd)) => cmd.run()?,
 		Some(Commands::Usage(cmd)) => cmd.run()?,
-		None if !cli.run_command_args.is_empty() => {
+		None => {
 			let config = Config::load()?;
 			let (command, args) = cli.run_command_args.split_first().ok_or_else(|| {
 				eyre!("No command provided. Use `biwa --help` for usage information.")
@@ -106,9 +106,6 @@ pub async fn run() -> Result<()> {
 				output_mode.silent,
 			)
 			.await?;
-		}
-		None => {
-			bail!("No command provided. Use `biwa --help` for usage information.");
 		}
 	}
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,6 +3,7 @@ use crate::cli::sync::SyncArgs;
 use crate::config::types::Config;
 use clap::{ArgAction, Parser, Subcommand};
 use color_eyre::eyre::{bail, eyre};
+use std::env;
 use tracing::Level;
 use tracing_subscriber::{
 	filter::Targets, fmt, layer::SubscriberExt as _, registry, util::SubscriberInitExt as _,
@@ -77,11 +78,12 @@ enum Commands {
 /// Main entry point for the CLI. Parses arguments and routes to the appropriate command.
 pub async fn run() -> Result<()> {
 	let cli = Cli::parse();
-	init_logging(cli.verbose, cli.quiet, cli.silent);
+	let output_mode = OutputMode::resolve(&cli);
+	init_logging(cli.verbose, output_mode);
 
 	match cli.command {
-		Some(Commands::Run(cmd)) => cmd.run(cli.quiet, cli.silent).await?,
-		Some(Commands::Sync(cmd)) => cmd.run(cli.quiet).await?,
+		Some(Commands::Run(cmd)) => cmd.run(output_mode.quiet, output_mode.silent).await?,
+		Some(Commands::Sync(cmd)) => cmd.run(output_mode.quiet).await?,
 		Some(Commands::Init(cmd)) => cmd.run()?,
 		Some(Commands::Schema(cmd)) => cmd.run()?,
 		Some(Commands::Completion(cmd)) => cmd.run()?,
@@ -100,8 +102,8 @@ pub async fn run() -> Result<()> {
 					cli_env_vars: &[],
 				},
 				config.sync.auto,
-				cli.quiet,
-				cli.silent,
+				output_mode.quiet,
+				output_mode.silent,
 			)
 			.await?;
 		}
@@ -114,8 +116,8 @@ pub async fn run() -> Result<()> {
 }
 
 /// Installs tracing subscriber when CLI flags allow internal logs.
-fn init_logging(verbose: u8, quiet: bool, silent: bool) {
-	if quiet || silent {
+fn init_logging(verbose: u8, output_mode: OutputMode) {
+	if output_mode.quiet {
 		return;
 	}
 
@@ -140,11 +142,43 @@ fn log_targets(verbose: u8) -> Targets {
 	Targets::new().with_target("biwa", log_level(verbose))
 }
 
+/// Effective output suppression mode resolved from CLI flags and env vars.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct OutputMode {
+	/// Suppress biwa internal logs, only showing remote command output.
+	quiet: bool,
+	/// Suppress all output, including remote command stdout/stderr.
+	silent: bool,
+}
+
+impl OutputMode {
+	/// Resolves output flags using CLI precedence over environment defaults.
+	fn resolve(cli: &Cli) -> Self {
+		let silent = cli.silent || env_flag_is_truthy("BIWA_LOG_SILENT");
+		let quiet = silent || cli.quiet || env_flag_is_truthy("BIWA_LOG_QUIET");
+		Self { quiet, silent }
+	}
+}
+
+/// Returns true when an environment variable is set to a truthy value.
+fn env_flag_is_truthy(name: &str) -> bool {
+	env::var(name)
+		.map(|value| {
+			matches!(
+				value.trim().to_ascii_lowercase().as_str(),
+				"1" | "true" | "yes" | "on"
+			)
+		})
+		.unwrap_or(false)
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::testing::EnvCleanup;
 	use alloc::sync::Arc;
 	use pretty_assertions::assert_eq;
+	use serial_test::serial;
 	use std::io;
 	use std::sync::Mutex;
 	use tracing::subscriber;
@@ -236,6 +270,54 @@ mod tests {
 		let cli = Cli::parse_from(["biwa", "-q", "-vv", "ls"]);
 		assert!(cli.quiet);
 		assert_eq!(cli.verbose, 2);
+	}
+
+	#[test]
+	#[serial]
+	fn output_mode_defaults_to_cli_flags_only_when_env_is_unset() {
+		let _quiet_cleanup = EnvCleanup::remove("BIWA_LOG_QUIET");
+		let _silent_cleanup = EnvCleanup::remove("BIWA_LOG_SILENT");
+
+		let cli = Cli::parse_from(["biwa", "run", "ls"]);
+		assert_eq!(
+			OutputMode::resolve(&cli),
+			OutputMode {
+				quiet: false,
+				silent: false
+			}
+		);
+	}
+
+	#[test]
+	#[serial]
+	fn output_mode_reads_log_env_vars() {
+		let _quiet_cleanup = EnvCleanup::set("BIWA_LOG_QUIET", "true");
+		let _silent_cleanup = EnvCleanup::set("BIWA_LOG_SILENT", "0");
+
+		let cli = Cli::parse_from(["biwa", "run", "ls"]);
+		assert_eq!(
+			OutputMode::resolve(&cli),
+			OutputMode {
+				quiet: true,
+				silent: false
+			}
+		);
+	}
+
+	#[test]
+	#[serial]
+	fn output_mode_silent_env_implies_quiet() {
+		let _quiet_cleanup = EnvCleanup::remove("BIWA_LOG_QUIET");
+		let _silent_cleanup = EnvCleanup::set("BIWA_LOG_SILENT", "yes");
+
+		let cli = Cli::parse_from(["biwa", "run", "ls"]);
+		assert_eq!(
+			OutputMode::resolve(&cli),
+			OutputMode {
+				quiet: true,
+				silent: true
+			}
+		);
 	}
 
 	#[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,16 +1,11 @@
 use crate::Result;
 use crate::cli::sync::SyncArgs;
 use crate::config::types::Config;
-use alloc::sync::Arc;
 use clap::{ArgAction, Parser, Subcommand};
 use color_eyre::eyre::{bail, eyre};
-use core::mem;
-use std::io;
-use std::sync::Mutex;
-use tracing::{Level, subscriber};
+use tracing::Level;
 use tracing_subscriber::{
-	filter::Targets, fmt, fmt::MakeWriter, layer::SubscriberExt as _, registry,
-	util::SubscriberInitExt as _,
+	filter::Targets, fmt, layer::SubscriberExt as _, registry, util::SubscriberInitExt as _,
 };
 
 /// Shell completion generation command.
@@ -79,116 +74,55 @@ enum Commands {
 	Usage(usage::Usage),
 }
 
-impl Commands {
-	/// Returns whether this subcommand needs runtime configuration loading.
-	const fn needs_config(&self) -> bool {
-		matches!(self, Self::Run(_) | Self::Sync(_))
-	}
-}
-
 /// Main entry point for the CLI. Parses arguments and routes to the appropriate command.
 pub async fn run() -> Result<()> {
 	let cli = Cli::parse();
+	init_logging(cli.verbose, cli.quiet, cli.silent);
 
-	if let Some(command) = cli.command.as_ref() {
-		if command.needs_config() {
-			let (config, quiet, silent) =
-				load_config_with_buffered_logs(&cli, &mut io::stderr().lock())?;
-
-			if !quiet {
-				registry()
-					.with(log_targets(cli.verbose))
-					.with(fmt::layer().pretty().without_time())
-					.init();
-			}
-
-			match cli.command.expect("command presence already checked") {
-				Commands::Run(cmd) => cmd.run(&config, quiet, silent).await?,
-				Commands::Sync(cmd) => cmd.run(&config, quiet).await?,
-				Commands::Init(_)
-				| Commands::Schema(_)
-				| Commands::Completion(_)
-				| Commands::Usage(_) => {
-					bail!("Internal error: config-free command reached config-dependent path");
-				}
-			}
-		} else {
-			match cli.command.expect("command presence already checked") {
-				Commands::Init(cmd) => cmd.run()?,
-				Commands::Schema(cmd) => cmd.run()?,
-				Commands::Completion(cmd) => cmd.run()?,
-				Commands::Usage(cmd) => cmd.run()?,
-				Commands::Run(_) | Commands::Sync(_) => {
-					bail!("Internal error: config-dependent command reached config-free path");
-				}
-			}
+	match cli.command {
+		Some(Commands::Run(cmd)) => cmd.run(cli.quiet, cli.silent).await?,
+		Some(Commands::Sync(cmd)) => cmd.run(cli.quiet).await?,
+		Some(Commands::Init(cmd)) => cmd.run()?,
+		Some(Commands::Schema(cmd)) => cmd.run()?,
+		Some(Commands::Completion(cmd)) => cmd.run()?,
+		Some(Commands::Usage(cmd)) => cmd.run()?,
+		None if !cli.run_command_args.is_empty() => {
+			let config = Config::load()?;
+			let (command, args) = cli.run_command_args.split_first().ok_or_else(|| {
+				eyre!("No command provided. Use `biwa --help` for usage information.")
+			})?;
+			run::run_remote(
+				&config,
+				&SyncArgs::default(),
+				run::RemoteCommand {
+					command,
+					command_args: args,
+					cli_env_vars: &[],
+				},
+				config.sync.auto,
+				cli.quiet,
+				cli.silent,
+			)
+			.await?;
 		}
-	} else if !cli.run_command_args.is_empty() {
-		let (config, quiet, silent) =
-			load_config_with_buffered_logs(&cli, &mut io::stderr().lock())?;
-
-		if !quiet {
-			registry()
-				.with(log_targets(cli.verbose))
-				.with(fmt::layer().pretty().without_time())
-				.init();
+		None => {
+			bail!("No command provided. Use `biwa --help` for usage information.");
 		}
-
-		let (command, args) = cli.run_command_args.split_first().ok_or_else(|| {
-			eyre!("No command provided. Use `biwa --help` for usage information.")
-		})?;
-		run::run_remote(
-			&config,
-			&SyncArgs::default(),
-			run::RemoteCommand {
-				command,
-				command_args: args,
-				cli_env_vars: &[],
-			},
-			config.sync.auto,
-			quiet,
-			silent,
-		)
-		.await?;
-	} else {
-		bail!("No command provided. Use `biwa --help` for usage information.");
 	}
+
 	Ok(())
 }
 
-/// Loads configuration while buffering any logs emitted before the global subscriber is ready.
-fn load_config_with_buffered_logs(
-	cli: &Cli,
-	stderr: &mut impl io::Write,
-) -> Result<(Config, bool, bool)> {
-	if cli.silent || cli.quiet {
-		let config = Config::load()?;
-		let silent = cli.silent || config.log.silent;
-		let quiet = silent || cli.quiet || config.log.quiet;
-		return Ok((config, quiet, silent));
+/// Installs tracing subscriber when CLI flags allow internal logs.
+fn init_logging(verbose: u8, quiet: bool, silent: bool) {
+	if quiet || silent {
+		return;
 	}
 
-	let writer = BufferedWriter::default();
-	let load_subscriber = registry().with(log_targets(cli.verbose)).with(
-		fmt::layer()
-			.pretty()
-			.without_time()
-			.with_ansi(false)
-			.with_writer(writer.clone()),
-	);
-
-	let config_result = subscriber::with_default(load_subscriber, Config::load);
-	if config_result
-		.as_ref()
-		.map_or(true, |config| !(config.log.silent || config.log.quiet))
-	{
-		writer.write_to(stderr)?;
-	}
-
-	let config = config_result?;
-	let silent = cli.silent || config.log.silent;
-	let quiet = silent || cli.quiet || config.log.quiet;
-	Ok((config, quiet, silent))
+	registry()
+		.with(log_targets(verbose))
+		.with(fmt::layer().pretty().without_time())
+		.init();
 }
 
 /// Returns the log level selected by CLI verbosity flags.
@@ -206,115 +140,47 @@ fn log_targets(verbose: u8) -> Targets {
 	Targets::new().with_target("biwa", log_level(verbose))
 }
 
-/// Shared in-memory writer for buffering load-phase logs.
-#[derive(Clone, Default)]
-struct BufferedWriter {
-	/// Shared byte buffer receiving formatted tracing output.
-	buf: Arc<Mutex<Vec<u8>>>,
-}
-
-/// Write guard that appends tracing output into the shared in-memory buffer.
-struct BufferedGuard {
-	/// Shared byte buffer receiving formatted tracing output.
-	buf: Arc<Mutex<Vec<u8>>>,
-}
-
-impl BufferedWriter {
-	#[cfg(test)]
-	fn output(&self) -> String {
-		let buf = self.buf.lock().expect("buffer lock should succeed");
-		String::from_utf8_lossy(&buf).into_owned()
-	}
-
-	/// Flushes the buffered tracing output into the provided writer.
-	fn write_to(&self, writer: &mut impl io::Write) -> io::Result<()> {
-		let bytes = {
-			let mut buf = match self.buf.lock() {
-				Ok(buf) => buf,
-				Err(_e) => return Ok(()),
-			};
-			mem::take(&mut *buf)
-		};
-
-		if !bytes.is_empty() {
-			if let Err(error) = writer.write_all(&bytes) {
-				if error.kind() != io::ErrorKind::BrokenPipe {
-					return Err(error);
-				}
-				return Ok(());
-			}
-
-			if let Err(error) = writer.flush()
-				&& error.kind() != io::ErrorKind::BrokenPipe
-			{
-				return Err(error);
-			}
-		}
-
-		Ok(())
-	}
-}
-
-impl<'a> MakeWriter<'a> for BufferedWriter {
-	type Writer = BufferedGuard;
-
-	fn make_writer(&'a self) -> Self::Writer {
-		BufferedGuard {
-			buf: Arc::clone(&self.buf),
-		}
-	}
-}
-
-impl io::Write for BufferedGuard {
-	fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-		self.buf
-			.lock()
-			.map_err(|_e| io::Error::other("failed to acquire buffer lock"))?
-			.extend_from_slice(buf);
-		Ok(buf.len())
-	}
-
-	fn flush(&mut self) -> io::Result<()> {
-		Ok(())
-	}
-}
-
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use alloc::sync::Arc;
 	use pretty_assertions::assert_eq;
-	use serial_test::serial;
-	use std::path::{Path, PathBuf};
-	use std::{env, fs};
-	use tempfile::tempdir;
+	use std::io;
+	use std::sync::Mutex;
+	use tracing::subscriber;
+	use tracing_subscriber::fmt::MakeWriter;
 
-	struct CurrentDirGuard {
-		original_dir: PathBuf,
-	}
+	#[derive(Clone, Default)]
+	struct TestWriter(Arc<Mutex<Vec<u8>>>);
 
-	impl CurrentDirGuard {
-		fn new(path: &Path) -> Result<Self> {
-			let original_dir = env::current_dir()?;
-			env::set_current_dir(path)?;
-			Ok(Self { original_dir })
+	struct TestGuard(Arc<Mutex<Vec<u8>>>);
+
+	impl TestWriter {
+		fn output(&self) -> String {
+			let buf = self.0.lock().expect("test writer lock should succeed");
+			String::from_utf8_lossy(&buf).into_owned()
 		}
 	}
 
-	impl Drop for CurrentDirGuard {
-		fn drop(&mut self) {
-			let _result = env::set_current_dir(&self.original_dir);
+	impl<'a> MakeWriter<'a> for TestWriter {
+		type Writer = TestGuard;
+
+		fn make_writer(&'a self) -> Self::Writer {
+			TestGuard(Arc::clone(&self.0))
 		}
 	}
 
-	struct BrokenPipeWriter;
-
-	impl io::Write for BrokenPipeWriter {
-		fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
-			Err(io::Error::from(io::ErrorKind::BrokenPipe))
+	impl io::Write for TestGuard {
+		fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+			self.0
+				.lock()
+				.map_err(|_e| io::Error::other("failed to acquire test writer lock"))?
+				.extend_from_slice(buf);
+			Ok(buf.len())
 		}
 
 		fn flush(&mut self) -> io::Result<()> {
-			Err(io::Error::from(io::ErrorKind::BrokenPipe))
+			Ok(())
 		}
 	}
 
@@ -373,21 +239,8 @@ mod tests {
 	}
 
 	#[test]
-	fn schema_and_usage_do_not_require_runtime_config() {
-		let schema = Cli::parse_from(["biwa", "schema"]);
-		let usage = Cli::parse_from(["biwa", "usage"]);
-		let init = Cli::parse_from(["biwa", "init"]);
-		let completion = Cli::parse_from(["biwa", "completion", "bash"]);
-
-		assert!(matches!(schema.command.as_ref(), Some(command) if !command.needs_config()));
-		assert!(matches!(usage.command.as_ref(), Some(command) if !command.needs_config()));
-		assert!(matches!(init.command.as_ref(), Some(command) if !command.needs_config()));
-		assert!(matches!(completion.command.as_ref(), Some(command) if !command.needs_config()));
-	}
-
-	#[test]
 	fn verbose_filter_only_logs_biwa_targets() {
-		let writer = BufferedWriter::default();
+		let writer = TestWriter::default();
 		let subscriber = registry().with(log_targets(3)).with(
 			fmt::layer()
 				.with_ansi(false)
@@ -406,137 +259,5 @@ mod tests {
 			!output.contains("dependency-target-log"),
 			"logs were: {output}"
 		);
-	}
-
-	#[serial]
-	#[test]
-	fn buffered_config_logs_are_flushed_when_logging_is_enabled() -> Result<()> {
-		let dir = tempdir()?;
-		fs::write(
-			dir.path().join("biwa.toml"),
-			"[ssh]\nhost = \"example.test\"\nuser = \"testuser\"\n[sync]\nremote_root = \"/absolute/path\"\n",
-		)?;
-
-		let _dir_guard = CurrentDirGuard::new(dir.path())?;
-
-		let cli = Cli {
-			command: None,
-			run_command_args: Vec::new(),
-			verbose: 0,
-			quiet: false,
-			silent: false,
-		};
-		let mut stderr = Vec::new();
-		let result = load_config_with_buffered_logs(&cli, &mut stderr);
-
-		let (_config, quiet, silent) = result?;
-		assert!(!quiet);
-		assert!(!silent);
-
-		let output = String::from_utf8(stderr)?;
-		assert!(output.contains("Absolute remote_root path detected"));
-		Ok(())
-	}
-
-	#[serial]
-	#[test]
-	fn buffered_config_logs_respect_loaded_quiet_mode() -> Result<()> {
-		let dir = tempdir()?;
-		fs::write(
-			dir.path().join("biwa.toml"),
-			"[ssh]\nhost = \"example.test\"\nuser = \"testuser\"\n[log]\nquiet = true\n[sync]\nremote_root = \"/absolute/path\"\n",
-		)?;
-
-		let _dir_guard = CurrentDirGuard::new(dir.path())?;
-
-		let cli = Cli {
-			command: None,
-			run_command_args: Vec::new(),
-			verbose: 0,
-			quiet: false,
-			silent: false,
-		};
-		let mut stderr = Vec::new();
-		let result = load_config_with_buffered_logs(&cli, &mut stderr);
-
-		let (_config, quiet, silent) = result?;
-		assert!(quiet);
-		assert!(!silent);
-		assert!(stderr.is_empty(), "logs were: {stderr:?}");
-		Ok(())
-	}
-
-	#[serial]
-	#[test]
-	fn buffered_config_logs_short_circuit_when_cli_quiet_is_enabled() -> Result<()> {
-		let dir = tempdir()?;
-		fs::write(
-			dir.path().join("biwa.toml"),
-			"[ssh]\nhost = \"example.test\"\nuser = \"testuser\"\n[sync]\nremote_root = \"/absolute/path\"\n",
-		)?;
-
-		let _dir_guard = CurrentDirGuard::new(dir.path())?;
-
-		let cli = Cli {
-			command: None,
-			run_command_args: Vec::new(),
-			verbose: 0,
-			quiet: true,
-			silent: false,
-		};
-		let mut stderr = Vec::new();
-		let (_config, quiet, silent) = load_config_with_buffered_logs(&cli, &mut stderr)?;
-
-		assert!(quiet);
-		assert!(!silent);
-		assert!(stderr.is_empty(), "logs were: {stderr:?}");
-		Ok(())
-	}
-
-	#[serial]
-	#[test]
-	fn buffered_config_logs_are_flushed_when_loading_fails() -> Result<()> {
-		let dir = tempdir()?;
-		fs::write(dir.path().join("biwa.toml"), "[sync]\nremote_root = [\n")?;
-
-		let _dir_guard = CurrentDirGuard::new(dir.path())?;
-
-		let cli = Cli {
-			command: None,
-			run_command_args: Vec::new(),
-			verbose: 2,
-			quiet: false,
-			silent: false,
-		};
-		let mut stderr = Vec::new();
-		let result = load_config_with_buffered_logs(&cli, &mut stderr);
-
-		let _error = result.expect_err("loading invalid config should fail");
-
-		let output = String::from_utf8(stderr)?;
-		assert!(
-			output.contains("Loading configuration"),
-			"logs were: {output}"
-		);
-		Ok(())
-	}
-
-	#[test]
-	fn buffered_writer_ignores_broken_pipe() -> Result<()> {
-		let writer = BufferedWriter::default();
-		let subscriber = registry().with(log_targets(0)).with(
-			fmt::layer()
-				.with_ansi(false)
-				.without_time()
-				.with_writer(writer.clone()),
-		);
-
-		subscriber::with_default(subscriber, || {
-			tracing::warn!(target: "biwa::cli::tests", "buffered warning");
-		});
-
-		let mut broken_pipe = BrokenPipeWriter;
-		writer.write_to(&mut broken_pipe)?;
-		Ok(())
 	}
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1,8 +1,8 @@
 use crate::Result;
 use crate::cli::sync::SyncArgs;
+use crate::config::types::Config;
 use crate::env_vars::parse_cli_env_vars;
 use crate::{
-	config::types::Config,
 	ssh::exec::execute_command,
 	ssh::sync::{compute_project_remote_dir, sync_project},
 };
@@ -109,9 +109,10 @@ impl Run {
 	}
 
 	/// Run the execution logic for remote command.
-	pub async fn run(self, config: &Config, quiet: bool, silent: bool) -> Result<()> {
+	pub async fn run(self, quiet: bool, silent: bool) -> Result<()> {
+		let config = Config::load()?;
 		run_remote(
-			config,
+			&config,
 			&self.sync_args,
 			RemoteCommand {
 				command: &self.command,

--- a/src/cli/snapshots/biwa__cli__init__tests__init_json.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_json.snap
@@ -12,10 +12,6 @@ expression: content
     "post_sync": null,
     "pre_sync": null
   },
-  "log": {
-    "quiet": false,
-    "silent": false
-  },
   "ssh": {
     "host": "cse.unsw.edu.au",
     "key_path": null,

--- a/src/cli/snapshots/biwa__cli__init__tests__init_json5.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_json5.snap
@@ -130,21 +130,4 @@ expression: content
     // Command to run after synchronization.
     //post_sync: ,
   },
-
-  // Logging configuration.
-  log: {
-    // Suppresses biwa internal logs; only remote command output is shown.
-    //
-    // Can also be specified via environment variable `BIWA_LOG_QUIET`.
-    //
-    // Default value: false
-    //quiet: false,
-
-    // Suppresses all output, including remote command stdout/stderr.
-    //
-    // Can also be specified via environment variable `BIWA_LOG_SILENT`.
-    //
-    // Default value: false
-    //silent: false,
-  },
 }

--- a/src/cli/snapshots/biwa__cli__init__tests__init_jsonc.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_jsonc.snap
@@ -130,21 +130,4 @@ expression: content
     // Command to run after synchronization.
     //"post_sync": ,
   },
-
-  // Logging configuration.
-  "log": {
-    // Suppresses biwa internal logs; only remote command output is shown.
-    //
-    // Can also be specified via environment variable `BIWA_LOG_QUIET`.
-    //
-    // Default value: false
-    //"quiet": false,
-
-    // Suppresses all output, including remote command stdout/stderr.
-    //
-    // Can also be specified via environment variable `BIWA_LOG_SILENT`.
-    //
-    // Default value: false
-    //"silent": false,
-  },
 }

--- a/src/cli/snapshots/biwa__cli__init__tests__init_toml.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_toml.snap
@@ -126,19 +126,3 @@ expression: content
 
 # Command to run after synchronization.
 #post_sync =
-
-# Logging configuration.
-[log]
-# Suppresses biwa internal logs; only remote command output is shown.
-#
-# Can also be specified via environment variable `BIWA_LOG_QUIET`.
-#
-# Default value: false
-#quiet = false
-
-# Suppresses all output, including remote command stdout/stderr.
-#
-# Can also be specified via environment variable `BIWA_LOG_SILENT`.
-#
-# Default value: false
-#silent = false

--- a/src/cli/snapshots/biwa__cli__init__tests__init_yaml.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_yaml.snap
@@ -125,19 +125,3 @@ hooks:
 
   # Command to run after synchronization.
   #post_sync:
-
-# Logging configuration.
-log:
-  # Suppresses biwa internal logs; only remote command output is shown.
-  #
-  # Can also be specified via environment variable `BIWA_LOG_QUIET`.
-  #
-  # Default value: false
-  #quiet: false
-
-  # Suppresses all output, including remote command stdout/stderr.
-  #
-  # Can also be specified via environment variable `BIWA_LOG_SILENT`.
-  #
-  # Default value: false
-  #silent: false

--- a/src/cli/snapshots/biwa__cli__init__tests__init_yml.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_yml.snap
@@ -125,19 +125,3 @@ hooks:
 
   # Command to run after synchronization.
   #post_sync:
-
-# Logging configuration.
-log:
-  # Suppresses biwa internal logs; only remote command output is shown.
-  #
-  # Can also be specified via environment variable `BIWA_LOG_QUIET`.
-  #
-  # Default value: false
-  #quiet: false
-
-  # Suppresses all output, including remote command stdout/stderr.
-  #
-  # Can also be specified via environment variable `BIWA_LOG_SILENT`.
-  #
-  # Default value: false
-  #silent: false

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -79,11 +79,12 @@ pub(super) struct Sync {
 
 impl Sync {
 	/// Run the sync logic.
-	pub async fn run(self, config: &Config, quiet: bool) -> Result<()> {
-		let sync_root = self.sync_args.resolve_sync_root(config)?;
+	pub async fn run(self, quiet: bool) -> Result<()> {
+		let config = Config::load()?;
+		let sync_root = self.sync_args.resolve_sync_root(&config)?;
 		let options = self.sync_args.resolve_options();
 		sync_project(
-			config,
+			&config,
 			&sync_root,
 			&options,
 			self.sync_args.remote_dir.as_deref(),

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -350,22 +350,8 @@ mod tests {
 		fs::write(dir.path().join("biwa.toml"), r#"ssh.host = "file""#)?;
 		let _cleanup_user = set_required_ssh_user_env("env-user");
 
-		// Set env var override
-		// SAFETY: This is a single-threaded test context modifying the environment for current process.
-		// `#[serial]` from `serial_test` ensures serialized execution to prevent env races.
-		unsafe {
-			env::set_var("BIWA_SSH_HOST", "env");
-		}
-		// Set env var override
-		// SAFETY: This is a single-threaded test context modifying the environment for current process.
-		// `#[serial]` from `serial_test` ensures serialized execution to prevent env races.
-		unsafe {
-			env::set_var("BIWA_SSH_PORT", "8080");
-		}
-
-		// Ensure cleanup
-		let _cleanup1 = EnvCleanup::remove("BIWA_SSH_HOST");
-		let _cleanup2 = EnvCleanup::remove("BIWA_SSH_PORT");
+		let _cleanup1 = EnvCleanup::set("BIWA_SSH_HOST", "env");
+		let _cleanup2 = EnvCleanup::set("BIWA_SSH_PORT", "8080");
 
 		let config = Config::load_internal(None, None, Some(dir.path().to_path_buf()).as_ref())?;
 
@@ -420,11 +406,7 @@ mod tests {
 	fn env_vars_can_be_loaded_from_biwa_env_vars() -> Result<()> {
 		let (_cleanup_host, _cleanup_user) = set_required_ssh_env("test-host", "test-user");
 
-		// SAFETY: This is a serialized test that mutates the process environment.
-		unsafe {
-			env::set_var("BIWA_ENV_VARS", "NODE_ENV");
-		}
-		let _cleanup = EnvCleanup::remove("BIWA_ENV_VARS");
+		let _cleanup = EnvCleanup::set("BIWA_ENV_VARS", "NODE_ENV");
 
 		let config = Config::load_internal(None, None, None)?;
 		let rules = config.env.vars.rules()?;
@@ -438,11 +420,7 @@ mod tests {
 	fn biwa_env_vars_supports_values() -> Result<()> {
 		let (_cleanup_host, _cleanup_user) = set_required_ssh_env("test-host", "test-user");
 
-		// SAFETY: This is a serialized test that mutates the process environment.
-		unsafe {
-			env::set_var("BIWA_ENV_VARS", "NODE_ENV=prod");
-		}
-		let _cleanup = EnvCleanup::remove("BIWA_ENV_VARS");
+		let _cleanup = EnvCleanup::set("BIWA_ENV_VARS", "NODE_ENV=prod");
 
 		let config = Config::load_internal(None, None, None)?;
 		let rules = config.env.vars.rules()?;
@@ -456,11 +434,7 @@ mod tests {
 	fn biwa_env_vars_supports_empty_values() -> Result<()> {
 		let (_cleanup_host, _cleanup_user) = set_required_ssh_env("test-host", "test-user");
 
-		// SAFETY: This is a serialized test that mutates the process environment.
-		unsafe {
-			env::set_var("BIWA_ENV_VARS", "NODE_ENV=");
-		}
-		let _cleanup = EnvCleanup::remove("BIWA_ENV_VARS");
+		let _cleanup = EnvCleanup::set("BIWA_ENV_VARS", "NODE_ENV=");
 
 		let config = Config::load_internal(None, None, None)?;
 		let rules = config.env.vars.rules()?;
@@ -482,11 +456,7 @@ mod tests {
 		",
 		)?;
 
-		// SAFETY: This is a serialized test that mutates the process environment.
-		unsafe {
-			env::set_var("BIWA_ENV_VARS", "API_KEY");
-		}
-		let _cleanup = EnvCleanup::remove("BIWA_ENV_VARS");
+		let _cleanup = EnvCleanup::set("BIWA_ENV_VARS", "API_KEY");
 
 		let config = Config::load_internal(None, None, Some(dir.path().to_path_buf()).as_ref())?;
 		let rules = config.env.vars.rules()?;
@@ -501,11 +471,7 @@ mod tests {
 	fn biwa_env_vars_supports_patterns() -> Result<()> {
 		let (_cleanup_host, _cleanup_user) = set_required_ssh_env("test-host", "test-user");
 
-		// SAFETY: This is a serialized test that mutates the process environment.
-		unsafe {
-			env::set_var("BIWA_ENV_VARS", "NODE_*");
-		}
-		let _cleanup = EnvCleanup::remove("BIWA_ENV_VARS");
+		let _cleanup = EnvCleanup::set("BIWA_ENV_VARS", "NODE_*");
 
 		let config = Config::load_internal(None, None, None)?;
 		assert_eq!(
@@ -845,17 +811,8 @@ mod tests {
 		let dir = tempdir()?;
 		let (_cleanup_host, _cleanup_user) = clear_required_ssh_env();
 
-		// SAFETY: This is a serialized test that mutates the process environment.
-		unsafe {
-			env::set_var("BIWA_SSH_HOST", "env-host");
-		}
-		// SAFETY: This is a serialized test that mutates the process environment.
-		unsafe {
-			env::set_var("BIWA_SSH_USER", "env-user");
-		}
-
-		let _cleanup1 = EnvCleanup::remove("BIWA_SSH_HOST");
-		let _cleanup2 = EnvCleanup::remove("BIWA_SSH_USER");
+		let _cleanup1 = EnvCleanup::set("BIWA_SSH_HOST", "env-host");
+		let _cleanup2 = EnvCleanup::set("BIWA_SSH_USER", "env-user");
 
 		let config = Config::load_internal(None, None, Some(dir.path().to_path_buf()).as_ref())?;
 

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -224,11 +224,7 @@ impl RequiredConfigPresence {
 	}
 
 	/// Marks required SSH fields that were present in a preloaded config layer.
-	#[expect(
-		clippy::missing_const_for_fn,
-		reason = "This runtime-only helper should not be coupled to const-evaluation constraints"
-	)]
-	fn observe_layer(&mut self, partial: &<Config as confique::Config>::Layer) {
+	const fn observe_layer(&mut self, partial: &<Config as confique::Config>::Layer) {
 		self.ssh_host |= partial.ssh.host.is_some();
 		self.ssh_user |= partial.ssh.user.is_some();
 	}
@@ -431,10 +427,6 @@ mod tests {
 		  "hooks": {
 		    "pre_sync": null,
 		    "post_sync": null
-		  },
-		  "log": {
-		    "quiet": false,
-		    "silent": false
 		  }
 		}
 		"#);

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -313,38 +313,21 @@ mod tests {
 	use tempfile::tempdir;
 
 	fn set_required_ssh_env(host: &str, user: &str) -> (EnvCleanup, EnvCleanup) {
-		// SAFETY: This helper is used only by `#[serial]` tests that intentionally mutate env.
-		unsafe {
-			env::set_var("BIWA_SSH_HOST", host);
-		}
-		// SAFETY: This helper is used only by `#[serial]` tests that intentionally mutate env.
-		unsafe {
-			env::set_var("BIWA_SSH_USER", user);
-		}
-
-		(EnvCleanup("BIWA_SSH_HOST"), EnvCleanup("BIWA_SSH_USER"))
+		(
+			EnvCleanup::set("BIWA_SSH_HOST", host),
+			EnvCleanup::set("BIWA_SSH_USER", user),
+		)
 	}
 
 	fn set_required_ssh_user_env(user: &str) -> EnvCleanup {
-		// SAFETY: This helper is used only by `#[serial]` tests that intentionally mutate env.
-		unsafe {
-			env::set_var("BIWA_SSH_USER", user);
-		}
-
-		EnvCleanup("BIWA_SSH_USER")
+		EnvCleanup::set("BIWA_SSH_USER", user)
 	}
 
 	fn clear_required_ssh_env() -> (EnvCleanup, EnvCleanup) {
-		// SAFETY: This helper is used only by `#[serial]` tests that intentionally mutate env.
-		unsafe {
-			env::remove_var("BIWA_SSH_HOST");
-		}
-		// SAFETY: This helper is used only by `#[serial]` tests that intentionally mutate env.
-		unsafe {
-			env::remove_var("BIWA_SSH_USER");
-		}
-
-		(EnvCleanup("BIWA_SSH_HOST"), EnvCleanup("BIWA_SSH_USER"))
+		(
+			EnvCleanup::remove("BIWA_SSH_HOST"),
+			EnvCleanup::remove("BIWA_SSH_USER"),
+		)
 	}
 
 	#[serial]
@@ -381,8 +364,8 @@ mod tests {
 		}
 
 		// Ensure cleanup
-		let _cleanup1 = EnvCleanup("BIWA_SSH_HOST");
-		let _cleanup2 = EnvCleanup("BIWA_SSH_PORT");
+		let _cleanup1 = EnvCleanup::remove("BIWA_SSH_HOST");
+		let _cleanup2 = EnvCleanup::remove("BIWA_SSH_PORT");
 
 		let config = Config::load_internal(None, None, Some(dir.path().to_path_buf()).as_ref())?;
 
@@ -441,7 +424,7 @@ mod tests {
 		unsafe {
 			env::set_var("BIWA_ENV_VARS", "NODE_ENV");
 		}
-		let _cleanup = EnvCleanup("BIWA_ENV_VARS");
+		let _cleanup = EnvCleanup::remove("BIWA_ENV_VARS");
 
 		let config = Config::load_internal(None, None, None)?;
 		let rules = config.env.vars.rules()?;
@@ -459,7 +442,7 @@ mod tests {
 		unsafe {
 			env::set_var("BIWA_ENV_VARS", "NODE_ENV=prod");
 		}
-		let _cleanup = EnvCleanup("BIWA_ENV_VARS");
+		let _cleanup = EnvCleanup::remove("BIWA_ENV_VARS");
 
 		let config = Config::load_internal(None, None, None)?;
 		let rules = config.env.vars.rules()?;
@@ -477,7 +460,7 @@ mod tests {
 		unsafe {
 			env::set_var("BIWA_ENV_VARS", "NODE_ENV=");
 		}
-		let _cleanup = EnvCleanup("BIWA_ENV_VARS");
+		let _cleanup = EnvCleanup::remove("BIWA_ENV_VARS");
 
 		let config = Config::load_internal(None, None, None)?;
 		let rules = config.env.vars.rules()?;
@@ -503,7 +486,7 @@ mod tests {
 		unsafe {
 			env::set_var("BIWA_ENV_VARS", "API_KEY");
 		}
-		let _cleanup = EnvCleanup("BIWA_ENV_VARS");
+		let _cleanup = EnvCleanup::remove("BIWA_ENV_VARS");
 
 		let config = Config::load_internal(None, None, Some(dir.path().to_path_buf()).as_ref())?;
 		let rules = config.env.vars.rules()?;
@@ -522,7 +505,7 @@ mod tests {
 		unsafe {
 			env::set_var("BIWA_ENV_VARS", "NODE_*");
 		}
-		let _cleanup = EnvCleanup("BIWA_ENV_VARS");
+		let _cleanup = EnvCleanup::remove("BIWA_ENV_VARS");
 
 		let config = Config::load_internal(None, None, None)?;
 		assert_eq!(
@@ -871,8 +854,8 @@ mod tests {
 			env::set_var("BIWA_SSH_USER", "env-user");
 		}
 
-		let _cleanup1 = EnvCleanup("BIWA_SSH_HOST");
-		let _cleanup2 = EnvCleanup("BIWA_SSH_USER");
+		let _cleanup1 = EnvCleanup::remove("BIWA_SSH_HOST");
+		let _cleanup2 = EnvCleanup::remove("BIWA_SSH_USER");
 
 		let config = Config::load_internal(None, None, Some(dir.path().to_path_buf()).as_ref())?;
 

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -140,10 +140,6 @@ pub struct Config {
 	#[config(nested)]
 	#[schemars(default)]
 	pub hooks: HooksConfig,
-	/// Logging configuration.
-	#[config(nested)]
-	#[schemars(default)]
-	pub log: LogConfig,
 }
 
 /// Password authentication configuration.
@@ -209,25 +205,6 @@ pub struct SshConfig {
 impl Default for SshConfig {
 	fn default() -> Self {
 		Config::default().ssh
-	}
-}
-
-/// Logging configuration settings.
-#[derive(confique::Config, Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct LogConfig {
-	/// Suppresses biwa internal logs; only remote command output is shown.
-	#[config(default = false, env = "BIWA_LOG_QUIET")]
-	#[schemars(default)]
-	pub quiet: bool,
-	/// Suppresses all output, including remote command stdout/stderr.
-	#[config(default = false, env = "BIWA_LOG_SILENT")]
-	#[schemars(default)]
-	pub silent: bool,
-}
-
-impl Default for LogConfig {
-	fn default() -> Self {
-		Config::default().log
 	}
 }
 

--- a/src/ssh/exec.rs
+++ b/src/ssh/exec.rs
@@ -490,7 +490,7 @@ mod tests {
 		unsafe {
 			env::set_var("NODE_ENV", "development");
 		}
-		let _cleanup = EnvCleanup("NODE_ENV");
+		let _cleanup = EnvCleanup::remove("NODE_ENV");
 		let resolved = resolve_env_vars(
 			&config,
 			&[EnvVarRule::Spec(EnvVarSpec::value(
@@ -517,7 +517,7 @@ mod tests {
 		unsafe {
 			env::set_var("BIWA_TEST_NODE_ENV", "development");
 		}
-		let _cleanup = EnvCleanup("BIWA_TEST_NODE_ENV");
+		let _cleanup = EnvCleanup::remove("BIWA_TEST_NODE_ENV");
 
 		let resolved = resolve_env_vars(
 			&config,
@@ -558,8 +558,8 @@ mod tests {
 		unsafe {
 			env::set_var("BIWA_TEST_NODE_PATH", "/tmp/biwa-test-node-path");
 		}
-		let _cleanup_env = EnvCleanup("BIWA_TEST_NODE_ENV");
-		let _cleanup_path = EnvCleanup("BIWA_TEST_NODE_PATH");
+		let _cleanup_env = EnvCleanup::remove("BIWA_TEST_NODE_ENV");
+		let _cleanup_path = EnvCleanup::remove("BIWA_TEST_NODE_PATH");
 
 		let resolved = resolve_env_vars(&config, &[])?;
 		assert_eq!(

--- a/src/ssh/exec.rs
+++ b/src/ssh/exec.rs
@@ -486,11 +486,7 @@ mod tests {
 			..Config::default()
 		};
 
-		// SAFETY: This test only mutates the current process environment.
-		unsafe {
-			env::set_var("NODE_ENV", "development");
-		}
-		let _cleanup = EnvCleanup::remove("NODE_ENV");
+		let _cleanup = EnvCleanup::set("NODE_ENV", "development");
 		let resolved = resolve_env_vars(
 			&config,
 			&[EnvVarRule::Spec(EnvVarSpec::value(
@@ -513,11 +509,7 @@ mod tests {
 	fn resolve_env_vars_keeps_explicit_cli_value_over_later_cli_pattern() -> Result<()> {
 		let config = Config::default();
 
-		// SAFETY: This test only mutates the current process environment.
-		unsafe {
-			env::set_var("BIWA_TEST_NODE_ENV", "development");
-		}
-		let _cleanup = EnvCleanup::remove("BIWA_TEST_NODE_ENV");
+		let _cleanup = EnvCleanup::set("BIWA_TEST_NODE_ENV", "development");
 
 		let resolved = resolve_env_vars(
 			&config,
@@ -550,16 +542,8 @@ mod tests {
 			..Config::default()
 		};
 
-		// SAFETY: This test only mutates the current process environment.
-		unsafe {
-			env::set_var("BIWA_TEST_NODE_ENV", "development");
-		}
-		// SAFETY: This test only mutates the current process environment.
-		unsafe {
-			env::set_var("BIWA_TEST_NODE_PATH", "/tmp/biwa-test-node-path");
-		}
-		let _cleanup_env = EnvCleanup::remove("BIWA_TEST_NODE_ENV");
-		let _cleanup_path = EnvCleanup::remove("BIWA_TEST_NODE_PATH");
+		let _cleanup_env = EnvCleanup::set("BIWA_TEST_NODE_ENV", "development");
+		let _cleanup_path = EnvCleanup::set("BIWA_TEST_NODE_PATH", "/tmp/biwa-test-node-path");
 
 		let resolved = resolve_env_vars(&config, &[])?;
 		assert_eq!(

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -6,6 +6,30 @@ use std::env;
 /// Ensures clean-up even if the test panics.
 pub struct EnvCleanup(pub &'static str);
 
+impl EnvCleanup {
+	/// Sets an environment variable for the duration of a test.
+	#[must_use]
+	pub fn set(name: &'static str, value: &str) -> Self {
+		// SAFETY: Tests using this helper must be annotated with `#[serial]`
+		// (from the `serial_test` crate) to prevent concurrent env mutation.
+		unsafe {
+			env::set_var(name, value);
+		}
+		Self(name)
+	}
+
+	/// Removes an environment variable for the duration of a test.
+	#[must_use]
+	pub fn remove(name: &'static str) -> Self {
+		// SAFETY: Tests using this helper must be annotated with `#[serial]`
+		// (from the `serial_test` crate) to prevent concurrent env mutation.
+		unsafe {
+			env::remove_var(name);
+		}
+		Self(name)
+	}
+}
+
 impl Drop for EnvCleanup {
 	fn drop(&mut self) {
 		// SAFETY: Tests using this guard must be annotated with `#[serial]`

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,41 +1,105 @@
 /// Shared test utilities — only compiled in `cfg(test)` contexts.
 use std::env;
+use std::ffi::OsString;
 
-/// RAII guard that removes an environment variable when dropped.
+/// RAII guard that restores the previous environment variable state when dropped.
 ///
 /// Ensures clean-up even if the test panics.
-pub struct EnvCleanup(pub &'static str);
+pub struct EnvCleanup {
+	name: &'static str,
+	previous: Option<OsString>,
+}
 
 impl EnvCleanup {
 	/// Sets an environment variable for the duration of a test.
 	#[must_use]
 	pub fn set(name: &'static str, value: &str) -> Self {
+		let previous = env::var_os(name);
 		// SAFETY: Tests using this helper must be annotated with `#[serial]`
 		// (from the `serial_test` crate) to prevent concurrent env mutation.
 		unsafe {
 			env::set_var(name, value);
 		}
-		Self(name)
+		Self { name, previous }
 	}
 
 	/// Removes an environment variable for the duration of a test.
 	#[must_use]
 	pub fn remove(name: &'static str) -> Self {
+		let previous = env::var_os(name);
 		// SAFETY: Tests using this helper must be annotated with `#[serial]`
 		// (from the `serial_test` crate) to prevent concurrent env mutation.
 		unsafe {
 			env::remove_var(name);
 		}
-		Self(name)
+		Self { name, previous }
 	}
 }
 
 impl Drop for EnvCleanup {
 	fn drop(&mut self) {
-		// SAFETY: Tests using this guard must be annotated with `#[serial]`
-		// (from the `serial_test` crate) to prevent concurrent env mutation.
-		unsafe {
-			env::remove_var(self.0);
+		if let Some(previous) = &self.previous {
+			// SAFETY: Tests using this guard must be annotated with `#[serial]`
+			// (from the `serial_test` crate) to prevent concurrent env mutation.
+			unsafe {
+				env::set_var(self.name, previous);
+			}
+		} else {
+			// SAFETY: Tests using this guard must be annotated with `#[serial]`
+			// (from the `serial_test` crate) to prevent concurrent env mutation.
+			unsafe {
+				env::remove_var(self.name);
+			}
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use pretty_assertions::assert_eq;
+	use serial_test::serial;
+
+	#[test]
+	#[serial]
+	fn env_cleanup_restores_previous_value() {
+		// SAFETY: This test is `#[serial]` and restores env via `EnvCleanup`.
+		unsafe {
+			env::set_var("BIWA_TEST_ENV_CLEANUP", "before");
+		}
+
+		{
+			let _cleanup = EnvCleanup::set("BIWA_TEST_ENV_CLEANUP", "after");
+			assert_eq!(env::var("BIWA_TEST_ENV_CLEANUP").as_deref(), Ok("after"));
+		}
+
+		assert_eq!(env::var("BIWA_TEST_ENV_CLEANUP").as_deref(), Ok("before"));
+
+		// SAFETY: This test is `#[serial]`.
+		unsafe {
+			env::remove_var("BIWA_TEST_ENV_CLEANUP");
+		}
+	}
+
+	#[test]
+	#[serial]
+	fn env_cleanup_restores_missing_value_after_remove() {
+		// SAFETY: This test is `#[serial]`.
+		unsafe {
+			env::remove_var("BIWA_TEST_ENV_CLEANUP");
+		}
+
+		{
+			let _cleanup = EnvCleanup::remove("BIWA_TEST_ENV_CLEANUP");
+			assert_eq!(
+				env::var("BIWA_TEST_ENV_CLEANUP"),
+				Err(env::VarError::NotPresent)
+			);
+		}
+
+		assert_eq!(
+			env::var("BIWA_TEST_ENV_CLEANUP"),
+			Err(env::VarError::NotPresent)
+		);
 	}
 }

--- a/tests/ssh_e2e_run.rs
+++ b/tests/ssh_e2e_run.rs
@@ -25,17 +25,12 @@ fn biwa_process(args: &[&str]) -> Command {
 
 #[test]
 fn e2e_run_command() -> Result<()> {
-	let output = biwa_cmd(&[
-		"--quiet",
-		"run",
-		"--skip-sync",
-		"echo",
-		"hello e2e from biwa",
-	])
-	.stdout_capture()
-	.stderr_capture()
-	.unchecked()
-	.run()?;
+	let output = biwa_cmd(&["run", "--skip-sync", "echo", "hello e2e from biwa"])
+		.env("BIWA_LOG_QUIET", "true")
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
 
 	let stdout = String::from_utf8_lossy(&output.stdout);
 

--- a/tests/ssh_e2e_run.rs
+++ b/tests/ssh_e2e_run.rs
@@ -25,12 +25,17 @@ fn biwa_process(args: &[&str]) -> Command {
 
 #[test]
 fn e2e_run_command() -> Result<()> {
-	let output = biwa_cmd(&["run", "--skip-sync", "echo", "hello e2e from biwa"])
-		.env("BIWA_LOG_QUIET", "true")
-		.stdout_capture()
-		.stderr_capture()
-		.unchecked()
-		.run()?;
+	let output = biwa_cmd(&[
+		"--quiet",
+		"run",
+		"--skip-sync",
+		"echo",
+		"hello e2e from biwa",
+	])
+	.stdout_capture()
+	.stderr_capture()
+	.unchecked()
+	.run()?;
 
 	let stdout = String::from_utf8_lossy(&output.stdout);
 
@@ -42,6 +47,7 @@ fn e2e_run_command() -> Result<()> {
 #[test]
 fn e2e_run_stdout_stderr() -> Result<()> {
 	let output = biwa_cmd(&[
+		"--quiet",
 		"run",
 		"--skip-sync",
 		"--",
@@ -49,7 +55,6 @@ fn e2e_run_stdout_stderr() -> Result<()> {
 		"-c",
 		"echo 'out'; echo 'err' >&2",
 	])
-	.env("BIWA_LOG_QUIET", "true")
 	.stdout_capture()
 	.stderr_capture()
 	.unchecked()
@@ -67,6 +72,7 @@ fn e2e_run_stdout_stderr() -> Result<()> {
 #[test]
 fn e2e_run_streaming() -> Result<()> {
 	let mut reader = biwa_cmd(&[
+		"--quiet",
 		"run",
 		"--skip-sync",
 		"--",
@@ -74,7 +80,6 @@ fn e2e_run_streaming() -> Result<()> {
 		"-c",
 		"echo 'start'; sleep 0.5; echo 'end'",
 	])
-	.env("BIWA_LOG_QUIET", "true")
 	.reader()?;
 
 	let mut buf_reader = BufReader::new(&mut reader);
@@ -149,10 +154,7 @@ fn e2e_run_silent_large_output() -> Result<()> {
 		"-c",
 		&command,
 	]);
-	child
-		.env("BIWA_LOG_QUIET", "true")
-		.stdout(Stdio::piped())
-		.stderr(Stdio::piped());
+	child.stdout(Stdio::piped()).stderr(Stdio::piped());
 	let mut child = child.spawn()?;
 
 	let deadline = Instant::now() + Duration::from_secs(20);
@@ -189,11 +191,18 @@ fn e2e_run_silent_large_output() -> Result<()> {
 
 #[test]
 fn e2e_run_exit_code() -> Result<()> {
-	let output = biwa_cmd(&["run", "--skip-sync", "--", "bash", "-c", "exit 42"])
-		.env("BIWA_LOG_QUIET", "true")
-		.stderr_capture()
-		.unchecked()
-		.run()?;
+	let output = biwa_cmd(&[
+		"--quiet",
+		"run",
+		"--skip-sync",
+		"--",
+		"bash",
+		"-c",
+		"exit 42",
+	])
+	.stderr_capture()
+	.unchecked()
+	.run()?;
 
 	assert!(!output.status.success());
 
@@ -207,8 +216,7 @@ fn e2e_run_exit_code() -> Result<()> {
 
 #[test]
 fn e2e_run_remote_dir() -> Result<()> {
-	let output = biwa_cmd(&["run", "-d", "/tmp", "pwd"])
-		.env("BIWA_LOG_QUIET", "true")
+	let output = biwa_cmd(&["--quiet", "run", "-d", "/tmp", "pwd"])
 		.stdout_capture()
 		.stderr_capture()
 		.unchecked()
@@ -223,8 +231,7 @@ fn e2e_run_remote_dir() -> Result<()> {
 
 #[test]
 fn e2e_run_remote_dir_tilde() -> Result<()> {
-	let home_output = biwa_cmd(&["run", "--skip-sync", "sh", "-c", "echo $HOME"])
-		.env("BIWA_LOG_QUIET", "true")
+	let home_output = biwa_cmd(&["--quiet", "run", "--skip-sync", "sh", "-c", "echo $HOME"])
 		.stdout_capture()
 		.stderr_capture()
 		.unchecked()
@@ -233,8 +240,7 @@ fn e2e_run_remote_dir_tilde() -> Result<()> {
 		.trim()
 		.to_owned();
 
-	let output = biwa_cmd(&["run", "-d", "~", "pwd"])
-		.env("BIWA_LOG_QUIET", "true")
+	let output = biwa_cmd(&["--quiet", "run", "-d", "~", "pwd"])
 		.stdout_capture()
 		.stderr_capture()
 		.unchecked()
@@ -250,6 +256,7 @@ fn e2e_run_remote_dir_tilde() -> Result<()> {
 #[test]
 fn e2e_run_env_forward_from_flag() -> Result<()> {
 	let output = biwa_cmd(&[
+		"--quiet",
 		"run",
 		"--skip-sync",
 		"--env",
@@ -258,7 +265,6 @@ fn e2e_run_env_forward_from_flag() -> Result<()> {
 		"-c",
 		"echo $NODE_ENV",
 	])
-	.env("BIWA_LOG_QUIET", "true")
 	.env("NODE_ENV", "development")
 	.stdout_capture()
 	.stderr_capture()
@@ -276,6 +282,7 @@ fn e2e_run_env_forward_from_flag() -> Result<()> {
 #[test]
 fn e2e_run_env_literal_from_flag() -> Result<()> {
 	let output = biwa_cmd(&[
+		"--quiet",
 		"run",
 		"--skip-sync",
 		"--env",
@@ -284,7 +291,6 @@ fn e2e_run_env_literal_from_flag() -> Result<()> {
 		"-c",
 		"echo $NODE_ENV",
 	])
-	.env("BIWA_LOG_QUIET", "true")
 	.stdout_capture()
 	.stderr_capture()
 	.unchecked()
@@ -298,6 +304,7 @@ fn e2e_run_env_literal_from_flag() -> Result<()> {
 #[test]
 fn e2e_run_env_literal_empty_from_flag() -> Result<()> {
 	let output = biwa_cmd(&[
+		"--quiet",
 		"run",
 		"--skip-sync",
 		"--env",
@@ -306,7 +313,6 @@ fn e2e_run_env_literal_empty_from_flag() -> Result<()> {
 		"-c",
 		"if [ \"${NODE_ENV+x}\" = x ]; then printf 'set:%s' \"$NODE_ENV\"; else printf missing; fi",
 	])
-	.env("BIWA_LOG_QUIET", "true")
 	.stdout_capture()
 	.stderr_capture()
 	.unchecked()
@@ -320,6 +326,7 @@ fn e2e_run_env_literal_empty_from_flag() -> Result<()> {
 #[test]
 fn e2e_run_env_forward_empty_from_flag() -> Result<()> {
 	let output = biwa_cmd(&[
+		"--quiet",
 		"run",
 		"--skip-sync",
 		"--env",
@@ -328,7 +335,6 @@ fn e2e_run_env_forward_empty_from_flag() -> Result<()> {
 		"-c",
 		"if [ \"${NODE_ENV+x}\" = x ]; then printf 'set:%s' \"$NODE_ENV\"; else printf missing; fi",
 	])
-	.env("BIWA_LOG_QUIET", "true")
 	.env("NODE_ENV", "")
 	.stdout_capture()
 	.stderr_capture()
@@ -343,6 +349,7 @@ fn e2e_run_env_forward_empty_from_flag() -> Result<()> {
 #[test]
 fn e2e_run_env_wildcard_and_negation_from_flag() -> Result<()> {
 	let output = biwa_cmd(&[
+		"--quiet",
 		"run",
 		"--skip-sync",
 		"--env",
@@ -353,7 +360,6 @@ fn e2e_run_env_wildcard_and_negation_from_flag() -> Result<()> {
 		"-c",
 		"printf '%s|' \"$NODE_ENV\"; if [ -n \"$NODE_PATH\" ]; then printf present; else printf missing; fi",
 	])
-	.env("BIWA_LOG_QUIET", "true")
 	.env("NODE_ENV", "development")
 	.env("NODE_PATH", "/tmp/node")
 	.stdout_capture()
@@ -373,15 +379,13 @@ fn e2e_run_env_wildcard_and_negation_from_flag() -> Result<()> {
 #[test]
 fn e2e_implicit_run_same_working_dir_as_explicit_run() -> Result<()> {
 	// Disable auto-sync so both commands just resolve and use the same project dir without syncing.
-	let explicit = biwa_cmd(&["run", "--skip-sync", "pwd"])
-		.env("BIWA_LOG_QUIET", "true")
+	let explicit = biwa_cmd(&["--quiet", "run", "--skip-sync", "pwd"])
 		.env("BIWA_SYNC_AUTO", "false")
 		.stdout_capture()
 		.stderr_capture()
 		.unchecked()
 		.run()?;
-	let implicit = biwa_cmd(&["pwd"])
-		.env("BIWA_LOG_QUIET", "true")
+	let implicit = biwa_cmd(&["--quiet", "pwd"])
 		.env("BIWA_SYNC_AUTO", "false")
 		.stdout_capture()
 		.stderr_capture()
@@ -412,8 +416,7 @@ fn e2e_implicit_run_same_working_dir_as_explicit_run() -> Result<()> {
 #[test]
 fn e2e_implicit_run_command_executes_in_resolved_dir() -> Result<()> {
 	// Implicit run should run in the resolved project dir, not remote home.
-	let output = biwa_cmd(&["pwd"])
-		.env("BIWA_LOG_QUIET", "true")
+	let output = biwa_cmd(&["--quiet", "pwd"])
 		.env("BIWA_SYNC_AUTO", "false")
 		.stdout_capture()
 		.stderr_capture()


### PR DESCRIPTION
## Summary
- remove the `[log]` config section from the config types, schema, fixtures, docs, and init snapshots
- move runtime config loading into `run` and `sync`, and simplify the CLI entrypoint to rely only on CLI `--quiet` and `--silent`
- remove the deferred buffered config loader path and make the required-config observer const

## Testing
- cargo fmt --all
- cargo clippy --all-targets -- --deny warnings
- cargo test init_generate -- --nocapture
- cargo test config::load::tests::snapshot -- --nocapture
- cargo test e2e_run_command -- --nocapture
- cargo test e2e_implicit_run_same_working_dir_as_explicit_run -- --nocapture
- cargo test e2e_run_config_from_schema_fixture -- --nocapture

## Notes
- `LINT=true mise run check` still fails on the existing `zizmor` workflow-template error for `env.GITHUB_TOKEN`, unrelated to this change.