### PR TITLE
fix(run): forward stdin to remote commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,29 +171,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
-dependencies = [
- "aws-lc-sys",
- "untrusted 0.7.1",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,8 +343,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -478,15 +453,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "cmake"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "color-eyre"
@@ -849,12 +815,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,12 +996,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1533,19 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
-
-[[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
@@ -2498,7 +2442,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -2565,7 +2509,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b4d036bb45d7bbe99dbfef4ec60eaeb614708d22ff107124272f8ef6b54548"
 dependencies = [
  "aes",
- "aws-lc-rs",
  "bitflags",
  "block-padding",
  "byteorder",
@@ -3362,14 +3305,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
+version = "0.25.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
 dependencies = [
  "indexmap",
  "toml_datetime 1.0.1+spec-1.1.0",
  "toml_parser",
- "winnow 0.7.15",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -3517,12 +3460,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -4155,15 +4092,15 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -4278,18 +4215,18 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,11 @@ ignore = "=0.4.25"
 indicatif = "=0.18.4"
 itertools = "=0.14.0"
 json5 = "=1.3.1"
-russh = "=0.55.0"
+russh = { version = "=0.55.0", default-features = false, features = [
+	"flate2",
+	"ring",
+	"rsa"
+] }
 russh-sftp = "=2.1.1"
 schemars = "=1.2.1"
 serde = { version = "=1.0.228", features = ["derive"] }

--- a/deny.toml
+++ b/deny.toml
@@ -25,7 +25,6 @@ allow = [
 	"BSD-3-Clause",
 	"ISC",
 	"CC0-1.0",
-	"OpenSSL"
 ]
 unused-allowed-license = "deny"
 unused-license-exception = "deny"
@@ -48,7 +47,6 @@ skip = [
 	{ name = "toml", version = "*" },
 	{ name = "toml_datetime", version = "*" },
 	{ name = "unicode-width", version = "*" },
-	{ name = "untrusted", version = "*" },
 	{ name = "winnow", version = "*" },
 ]
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -98,7 +98,9 @@ printf 'Hello from stdin\n' | biwa run --skip-sync cat
 ```
 
 ::: tip Current Limitation
-stdin forwarding currently applies to redirected input such as pipes, here-docs, and files. When stdin is an interactive terminal, biwa does not forward it yet, because it also does not allocate a remote PTY. For fully interactive terminal programs, use `ssh` directly for now.
+`biwa run` forwards both redirected stdin and interactive terminal stdin. When your local stdin is a TTY, biwa also requests a remote PTY so simple interactive commands work without waiting for local EOF.
+
+Interactive support is still partial, though: biwa does not currently provide full terminal emulation such as raw mode, window resize propagation, or signal forwarding like `Ctrl-C`. For complex full-screen or highly interactive programs, use `ssh` directly for the most reliable behavior.
 :::
 
 ## Log Output

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -91,11 +91,15 @@ If you're in a project directory, biwa will automatically sync your local files 
 
 ## Piping Input
 
-`biwa run` forwards local stdin to the remote command, so piping and simple interactive input work as expected:
+`biwa run` forwards redirected local stdin to the remote command, so piping works as expected:
 
 ```bash
 printf 'Hello from stdin\n' | biwa run --skip-sync cat
 ```
+
+::: tip Current Limitation
+stdin forwarding currently applies to redirected input such as pipes, here-docs, and files. When stdin is an interactive terminal, biwa does not forward it yet, because it also does not allocate a remote PTY. For fully interactive terminal programs, use `ssh` directly for now.
+:::
 
 ## Log Output
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -89,6 +89,14 @@ biwa run give cs1521 lab02
 If you're in a project directory, biwa will automatically sync your local files to the remote server before executing commands.
 :::
 
+## Piping Input
+
+`biwa run` forwards local stdin to the remote command, so piping and simple interactive input work as expected:
+
+```bash
+printf 'Hello from stdin\n' | biwa run --skip-sync cat
+```
+
 ## Log Output
 
 By default, biwa shows internal logs (connection status, etc.) alongside remote command output. You can control this:

--- a/src/ssh/exec.rs
+++ b/src/ssh/exec.rs
@@ -15,6 +15,7 @@ use core::time::Duration;
 use russh::{Channel, ChannelMsg, Pty, client::Msg};
 use std::env;
 use std::io::{Error as IoError, IsTerminal as _, Read as _, stdin as std_stdin};
+use std::thread;
 use tokio::io::{copy, sink, stderr, stdout};
 use tokio::sync::mpsc;
 use tokio::time::sleep;
@@ -32,8 +33,8 @@ struct ResolvedEnvVar {
 	value: String,
 }
 
-/// Optional stdin forwarding state for a remote command.
-type StdinForwarding = Option<mpsc::Receiver<Option<Vec<u8>>>>;
+/// Receiver carrying stdin chunks or an EOF marker for a remote command.
+type StdinReceiver = mpsc::Receiver<Option<Vec<u8>>>;
 
 /// Static execution settings reused across remote command helpers.
 struct RunCommandOptions<'a> {
@@ -168,24 +169,20 @@ fn resolve_env_vars(config: &Config, cli_env_vars: &[EnvVarRule]) -> Result<Vec<
 }
 
 /// Spawns a task that forwards local stdin into a channel for the remote SSH command.
-fn spawn_stdin_forwarder() -> mpsc::Receiver<Option<Vec<u8>>> {
+fn spawn_stdin_forwarder() -> StdinReceiver {
 	let (stdin_tx, stdin_rx) = mpsc::channel(32);
 
-	std::thread::spawn(move || {
+	thread::spawn(move || {
 		let mut local_stdin = std_stdin();
 		let mut buffer = vec![0_u8; 8 * 1024];
 
 		loop {
 			match local_stdin.read(&mut buffer) {
 				Ok(bytes_read) if bytes_read > 0 => {
-					let Some(chunk) = buffer.get(..bytes_read).map(<[u8]>::to_vec) else {
-						debug!(
-							bytes_read,
-							buffer_len = buffer.len(),
-							"tokio stdin returned an out-of-bounds read length"
-						);
-						break;
-					};
+					let chunk = buffer
+						.get(..bytes_read)
+						.expect("stdin read length must not exceed the buffer length")
+						.to_vec();
 
 					if stdin_tx.blocking_send(Some(chunk)).is_err() {
 						break;
@@ -207,8 +204,8 @@ fn spawn_stdin_forwarder() -> mpsc::Receiver<Option<Vec<u8>>> {
 }
 
 /// Initializes stdin forwarding for the remote command.
-fn prepare_stdin_forwarding() -> StdinForwarding {
-	Some(spawn_stdin_forwarder())
+fn prepare_stdin_forwarding() -> StdinReceiver {
+	spawn_stdin_forwarder()
 }
 
 /// Returns whether local stdin is an interactive terminal.
@@ -248,6 +245,18 @@ async fn request_terminal_pty(channel: &mut Channel<Msg>) -> Result<()> {
 		.await
 		.wrap_err("Failed to request SSH PTY")?;
 	await_channel_confirmation(channel, "SSH PTY request").await
+}
+
+/// I/O streams and stdin mode shared by both SSH environment forwarding paths.
+struct ExecuteCommandStreams {
+	/// Buffered remote stdout sink.
+	stdout_tx: mpsc::Sender<Vec<u8>>,
+	/// Buffered remote stderr sink.
+	stderr_tx: mpsc::Sender<Vec<u8>>,
+	/// Local stdin receiver, or `None` once EOF has been forwarded.
+	stdin_rx: Option<StdinReceiver>,
+	/// Whether local stdin is attached to a terminal.
+	stdin_is_terminal: bool,
 }
 
 /// Run a pre-built command string on an already-connected SSH client.
@@ -318,7 +327,7 @@ async fn run_command(
 	let stdout_stream = ReceiverStream::new(stdout_rx).map(|b| Ok::<_, IoError>(Bytes::from(b)));
 	let stderr_stream = ReceiverStream::new(stderr_rx).map(|b| Ok::<_, IoError>(Bytes::from(b)));
 	let stdin_is_terminal = stdin_is_terminal();
-	let stdin_rx = prepare_stdin_forwarding();
+	let stdin_rx = Some(prepare_stdin_forwarding());
 
 	let mut stdout_reader = StreamReader::new(stdout_stream);
 	let mut stderr_reader = StreamReader::new(stderr_stream);
@@ -328,10 +337,12 @@ async fn run_command(
 		&effective_command,
 		env_vars,
 		forward_method,
-		stdout_tx,
-		stderr_tx,
-		stdin_rx,
-		stdin_is_terminal,
+		ExecuteCommandStreams {
+			stdout_tx,
+			stderr_tx,
+			stdin_rx,
+			stdin_is_terminal,
+		},
 	);
 
 	let stdout_task = async {
@@ -416,11 +427,15 @@ async fn execute_with_forward_method(
 	command: &str,
 	env_vars: &[ResolvedEnvVar],
 	forward_method: &EnvForwardMethod,
-	stdout_tx: mpsc::Sender<Vec<u8>>,
-	stderr_tx: mpsc::Sender<Vec<u8>>,
-	stdin_rx: Option<mpsc::Receiver<Option<Vec<u8>>>>,
-	stdin_is_terminal: bool,
+	streams: ExecuteCommandStreams,
 ) -> Result<u32> {
+	let ExecuteCommandStreams {
+		stdout_tx,
+		stderr_tx,
+		stdin_rx,
+		stdin_is_terminal,
+	} = streams;
+
 	match forward_method {
 		EnvForwardMethod::Export => {
 			let mut channel = client

--- a/src/ssh/exec.rs
+++ b/src/ssh/exec.rs
@@ -12,12 +12,11 @@ use bytes::Bytes;
 use color_eyre::eyre::{Context as _, bail};
 use console::style;
 use core::time::Duration;
-use russh::{Channel, ChannelMsg, client::Msg};
+use russh::{Channel, ChannelMsg, Pty, client::Msg};
 use std::env;
-use std::io::{Error as IoError, IsTerminal as _, stdin as std_stdin};
-use tokio::io::{AsyncReadExt as _, copy, sink, stderr, stdin, stdout};
+use std::io::{Error as IoError, IsTerminal as _, Read as _, stdin as std_stdin};
+use tokio::io::{copy, sink, stderr, stdout};
 use tokio::sync::mpsc;
-use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tokio_stream::StreamExt as _;
 use tokio_stream::wrappers::ReceiverStream;
@@ -34,10 +33,7 @@ struct ResolvedEnvVar {
 }
 
 /// Optional stdin forwarding state for a remote command.
-type StdinForwarding = (
-	Option<mpsc::Receiver<Option<Vec<u8>>>>,
-	Option<JoinHandle<()>>,
-);
+type StdinForwarding = Option<mpsc::Receiver<Option<Vec<u8>>>>;
 
 /// Static execution settings reused across remote command helpers.
 struct RunCommandOptions<'a> {
@@ -172,15 +168,15 @@ fn resolve_env_vars(config: &Config, cli_env_vars: &[EnvVarRule]) -> Result<Vec<
 }
 
 /// Spawns a task that forwards local stdin into a channel for the remote SSH command.
-fn spawn_stdin_forwarder() -> (mpsc::Receiver<Option<Vec<u8>>>, JoinHandle<()>) {
+fn spawn_stdin_forwarder() -> mpsc::Receiver<Option<Vec<u8>>> {
 	let (stdin_tx, stdin_rx) = mpsc::channel(32);
 
-	let stdin_task = tokio::spawn(async move {
-		let mut local_stdin = stdin();
+	std::thread::spawn(move || {
+		let mut local_stdin = std_stdin();
 		let mut buffer = vec![0_u8; 8 * 1024];
 
 		loop {
-			match local_stdin.read(&mut buffer).await {
+			match local_stdin.read(&mut buffer) {
 				Ok(bytes_read) if bytes_read > 0 => {
 					let Some(chunk) = buffer.get(..bytes_read).map(<[u8]>::to_vec) else {
 						debug!(
@@ -191,7 +187,7 @@ fn spawn_stdin_forwarder() -> (mpsc::Receiver<Option<Vec<u8>>>, JoinHandle<()>) 
 						break;
 					};
 
-					if stdin_tx.send(Some(chunk)).await.is_err() {
+					if stdin_tx.blocking_send(Some(chunk)).is_err() {
 						break;
 					}
 				}
@@ -200,29 +196,58 @@ fn spawn_stdin_forwarder() -> (mpsc::Receiver<Option<Vec<u8>>>, JoinHandle<()>) 
 						debug!(%error, "Failed to read local stdin for remote command");
 					}
 
-					drop(stdin_tx.send(None).await);
+					drop(stdin_tx.blocking_send(None));
 					break;
 				}
 			}
 		}
 	});
 
-	(stdin_rx, stdin_task)
+	stdin_rx
 }
 
-/// Returns whether stdin should be forwarded to the remote command.
-fn should_forward_stdin() -> bool {
-	!std_stdin().is_terminal()
-}
-
-/// Initializes stdin forwarding when local stdin is redirected.
+/// Initializes stdin forwarding for the remote command.
 fn prepare_stdin_forwarding() -> StdinForwarding {
-	if should_forward_stdin() {
-		let (stdin_rx, stdin_task) = spawn_stdin_forwarder();
-		(Some(stdin_rx), Some(stdin_task))
-	} else {
-		(None, None)
-	}
+	Some(spawn_stdin_forwarder())
+}
+
+/// Returns whether local stdin is an interactive terminal.
+fn stdin_is_terminal() -> bool {
+	std_stdin().is_terminal()
+}
+
+/// Returns the terminal type to advertise to the SSH server.
+fn local_terminal_type() -> String {
+	env::var("TERM")
+		.ok()
+		.filter(|term| !term.trim().is_empty())
+		.unwrap_or_else(|| "xterm".to_owned())
+}
+
+/// Reads a positive terminal dimension from the environment or falls back to a default.
+fn terminal_dimension(var_name: &str, default: u32) -> u32 {
+	env::var(var_name)
+		.ok()
+		.and_then(|value| value.parse::<u32>().ok())
+		.filter(|value| *value > 0)
+		.unwrap_or(default)
+}
+
+/// Requests an interactive PTY for terminal-backed stdin so commands can complete without EOF.
+async fn request_terminal_pty(channel: &mut Channel<Msg>) -> Result<()> {
+	channel
+		.request_pty(
+			true,
+			&local_terminal_type(),
+			terminal_dimension("COLUMNS", 80),
+			terminal_dimension("LINES", 24),
+			0,
+			0,
+			&[(Pty::ECHO, 0)],
+		)
+		.await
+		.wrap_err("Failed to request SSH PTY")?;
+	await_channel_confirmation(channel, "SSH PTY request").await
 }
 
 /// Run a pre-built command string on an already-connected SSH client.
@@ -292,7 +317,8 @@ async fn run_command(
 
 	let stdout_stream = ReceiverStream::new(stdout_rx).map(|b| Ok::<_, IoError>(Bytes::from(b)));
 	let stderr_stream = ReceiverStream::new(stderr_rx).map(|b| Ok::<_, IoError>(Bytes::from(b)));
-	let (stdin_rx, stdin_task) = prepare_stdin_forwarding();
+	let stdin_is_terminal = stdin_is_terminal();
+	let stdin_rx = prepare_stdin_forwarding();
 
 	let mut stdout_reader = StreamReader::new(stdout_stream);
 	let mut stderr_reader = StreamReader::new(stderr_stream);
@@ -305,6 +331,7 @@ async fn run_command(
 		stdout_tx,
 		stderr_tx,
 		stdin_rx,
+		stdin_is_terminal,
 	);
 
 	let stdout_task = async {
@@ -324,9 +351,6 @@ async fn run_command(
 	};
 
 	let (exit_status, (), ()) = tokio::join!(exec_future, stdout_task, stderr_task);
-	if let Some(stdin_task) = stdin_task {
-		stdin_task.abort();
-	}
 	let exit_status = exit_status.wrap_err("Failed to execute remote command")?;
 
 	debug!(exit_status, "Remote command completed");
@@ -395,6 +419,7 @@ async fn execute_with_forward_method(
 	stdout_tx: mpsc::Sender<Vec<u8>>,
 	stderr_tx: mpsc::Sender<Vec<u8>>,
 	stdin_rx: Option<mpsc::Receiver<Option<Vec<u8>>>>,
+	stdin_is_terminal: bool,
 ) -> Result<u32> {
 	match forward_method {
 		EnvForwardMethod::Export => {
@@ -403,11 +428,15 @@ async fn execute_with_forward_method(
 				.await
 				.wrap_err("Failed to open SSH session channel")?;
 
+			if stdin_is_terminal {
+				request_terminal_pty(&mut channel).await?;
+			}
+
 			channel
 				.exec(true, command)
 				.await
 				.wrap_err("Failed to execute remote command")?;
-			await_exec_confirmation(&mut channel).await?;
+			await_channel_confirmation(&mut channel, "remote command exec request").await?;
 
 			stream_channel_output(channel, stdout_tx, stderr_tx, stdin_rx).await
 		}
@@ -416,6 +445,10 @@ async fn execute_with_forward_method(
 				.get_channel()
 				.await
 				.wrap_err("Failed to open SSH session channel")?;
+
+			if stdin_is_terminal {
+				request_terminal_pty(&mut channel).await?;
+			}
 
 			for env_var in env_vars {
 				channel
@@ -449,28 +482,28 @@ async fn execute_with_forward_method(
 				.exec(true, command)
 				.await
 				.wrap_err("Failed to execute remote command")?;
-			await_exec_confirmation(&mut channel).await?;
+			await_channel_confirmation(&mut channel, "remote command exec request").await?;
 
 			stream_channel_output(channel, stdout_tx, stderr_tx, stdin_rx).await
 		}
 	}
 }
 
-/// Waits for the SSH server to accept or reject the exec request.
-async fn await_exec_confirmation(channel: &mut Channel<Msg>) -> Result<()> {
+/// Waits for the SSH server to accept or reject a channel request.
+async fn await_channel_confirmation(channel: &mut Channel<Msg>, request_name: &str) -> Result<()> {
 	loop {
 		match channel.wait().await {
 			Some(ChannelMsg::Success) => {
 				break;
 			}
 			Some(ChannelMsg::Failure) => {
-				bail!("SSH server rejected remote command exec request");
+				bail!("SSH server rejected {request_name}");
 			}
 			Some(_message) => {
 				// Ignore unrelated channel messages and keep waiting for Success/Failure.
 			}
 			None => {
-				bail!("SSH channel closed before remote command exec confirmation was received");
+				bail!("SSH channel closed before {request_name} confirmation was received");
 			}
 		}
 	}
@@ -531,7 +564,16 @@ async fn stream_channel_output(
 				}
 				Some(ChannelMsg::ExitStatus {
 					exit_status: status,
-				}) => exit_status = Some(status),
+				}) => {
+					exit_status = Some(status);
+					if stdin_rx.is_some() {
+						channel
+							.eof()
+							.await
+							.wrap_err("Failed to send stdin EOF after remote command exit")?;
+						stdin_rx = None;
+					}
+				}
 				Some(_) => {}
 				None => break,
 			}

--- a/src/ssh/exec.rs
+++ b/src/ssh/exec.rs
@@ -14,7 +14,7 @@ use console::style;
 use core::time::Duration;
 use russh::{Channel, ChannelMsg, client::Msg};
 use std::env;
-use std::io::Error as IoError;
+use std::io::{Error as IoError, IsTerminal as _, stdin as std_stdin};
 use tokio::io::{AsyncReadExt as _, copy, sink, stderr, stdin, stdout};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -32,6 +32,12 @@ struct ResolvedEnvVar {
 	/// Concrete value to send to the remote process.
 	value: String,
 }
+
+/// Optional stdin forwarding state for a remote command.
+type StdinForwarding = (
+	Option<mpsc::Receiver<Option<Vec<u8>>>>,
+	Option<JoinHandle<()>>,
+);
 
 /// Static execution settings reused across remote command helpers.
 struct RunCommandOptions<'a> {
@@ -204,6 +210,21 @@ fn spawn_stdin_forwarder() -> (mpsc::Receiver<Option<Vec<u8>>>, JoinHandle<()>) 
 	(stdin_rx, stdin_task)
 }
 
+/// Returns whether stdin should be forwarded to the remote command.
+fn should_forward_stdin() -> bool {
+	!std_stdin().is_terminal()
+}
+
+/// Initializes stdin forwarding when local stdin is redirected.
+fn prepare_stdin_forwarding() -> StdinForwarding {
+	if should_forward_stdin() {
+		let (stdin_rx, stdin_task) = spawn_stdin_forwarder();
+		(Some(stdin_rx), Some(stdin_task))
+	} else {
+		(None, None)
+	}
+}
+
 /// Run a pre-built command string on an already-connected SSH client.
 ///
 /// Returns the remote exit code, printing stdout/stderr as they arrive
@@ -271,7 +292,7 @@ async fn run_command(
 
 	let stdout_stream = ReceiverStream::new(stdout_rx).map(|b| Ok::<_, IoError>(Bytes::from(b)));
 	let stderr_stream = ReceiverStream::new(stderr_rx).map(|b| Ok::<_, IoError>(Bytes::from(b)));
-	let (stdin_rx, stdin_task) = spawn_stdin_forwarder();
+	let (stdin_rx, stdin_task) = prepare_stdin_forwarding();
 
 	let mut stdout_reader = StreamReader::new(stdout_stream);
 	let mut stderr_reader = StreamReader::new(stderr_stream);
@@ -283,7 +304,7 @@ async fn run_command(
 		forward_method,
 		stdout_tx,
 		stderr_tx,
-		Some(stdin_rx),
+		stdin_rx,
 	);
 
 	let stdout_task = async {
@@ -303,7 +324,9 @@ async fn run_command(
 	};
 
 	let (exit_status, (), ()) = tokio::join!(exec_future, stdout_task, stderr_task);
-	stdin_task.abort();
+	if let Some(stdin_task) = stdin_task {
+		stdin_task.abort();
+	}
 	let exit_status = exit_status.wrap_err("Failed to execute remote command")?;
 
 	debug!(exit_status, "Remote command completed");

--- a/src/ssh/exec.rs
+++ b/src/ssh/exec.rs
@@ -582,10 +582,12 @@ async fn stream_channel_output(
 				}) => {
 					exit_status = Some(status);
 					if stdin_rx.is_some() {
-						channel
-							.eof()
-							.await
-							.wrap_err("Failed to send stdin EOF after remote command exit")?;
+						if let Err(error) = channel.eof().await {
+							debug!(
+								%error,
+								"Ignoring stdin EOF send failure after remote command exit"
+							);
+						}
 						stdin_rx = None;
 					}
 				}

--- a/src/ssh/exec.rs
+++ b/src/ssh/exec.rs
@@ -11,7 +11,6 @@ use async_ssh2_tokio::client::{Client, ServerCheckMethod};
 use bytes::Bytes;
 use color_eyre::eyre::{Context as _, bail};
 use console::style;
-use core::future::pending;
 use core::time::Duration;
 use russh::{Channel, ChannelMsg, client::Msg};
 use std::env;
@@ -167,7 +166,7 @@ fn resolve_env_vars(config: &Config, cli_env_vars: &[EnvVarRule]) -> Result<Vec<
 }
 
 /// Spawns a task that forwards local stdin into a channel for the remote SSH command.
-fn spawn_stdin_forwarder() -> (mpsc::Receiver<Vec<u8>>, JoinHandle<()>) {
+fn spawn_stdin_forwarder() -> (mpsc::Receiver<Option<Vec<u8>>>, JoinHandle<()>) {
 	let (stdin_tx, stdin_rx) = mpsc::channel(32);
 
 	let stdin_task = tokio::spawn(async move {
@@ -176,13 +175,7 @@ fn spawn_stdin_forwarder() -> (mpsc::Receiver<Vec<u8>>, JoinHandle<()>) {
 
 		loop {
 			match local_stdin.read(&mut buffer).await {
-				Ok(0) => {
-					if stdin_tx.send(Vec::new()).await.is_ok() {
-						pending::<()>().await;
-					}
-					break;
-				}
-				Ok(bytes_read) => {
+				Ok(bytes_read) if bytes_read > 0 => {
 					let Some(chunk) = buffer.get(..bytes_read).map(<[u8]>::to_vec) else {
 						debug!(
 							bytes_read,
@@ -192,15 +185,16 @@ fn spawn_stdin_forwarder() -> (mpsc::Receiver<Vec<u8>>, JoinHandle<()>) {
 						break;
 					};
 
-					if stdin_tx.send(chunk).await.is_err() {
+					if stdin_tx.send(Some(chunk)).await.is_err() {
 						break;
 					}
 				}
-				Err(error) => {
-					debug!(%error, "Failed to read local stdin for remote command");
-					if stdin_tx.send(Vec::new()).await.is_ok() {
-						pending::<()>().await;
+				result => {
+					if let Err(error) = result {
+						debug!(%error, "Failed to read local stdin for remote command");
 					}
+
+					drop(stdin_tx.send(None).await);
 					break;
 				}
 			}
@@ -377,13 +371,23 @@ async fn execute_with_forward_method(
 	forward_method: &EnvForwardMethod,
 	stdout_tx: mpsc::Sender<Vec<u8>>,
 	stderr_tx: mpsc::Sender<Vec<u8>>,
-	stdin_rx: Option<mpsc::Receiver<Vec<u8>>>,
+	stdin_rx: Option<mpsc::Receiver<Option<Vec<u8>>>>,
 ) -> Result<u32> {
 	match forward_method {
-		EnvForwardMethod::Export => client
-			.execute_io(command, stdout_tx, Some(stderr_tx), stdin_rx, false, None)
-			.await
-			.wrap_err("Failed to execute remote command"),
+		EnvForwardMethod::Export => {
+			let mut channel = client
+				.get_channel()
+				.await
+				.wrap_err("Failed to open SSH session channel")?;
+
+			channel
+				.exec(true, command)
+				.await
+				.wrap_err("Failed to execute remote command")?;
+			await_exec_confirmation(&mut channel).await?;
+
+			stream_channel_output(channel, stdout_tx, stderr_tx, stdin_rx).await
+		}
 		EnvForwardMethod::Setenv => {
 			let mut channel = client
 				.get_channel()
@@ -422,30 +426,33 @@ async fn execute_with_forward_method(
 				.exec(true, command)
 				.await
 				.wrap_err("Failed to execute remote command")?;
-
-			// Wait for confirmation that the exec request itself was accepted/rejected.
-			loop {
-				match channel.wait().await {
-					Some(ChannelMsg::Success) => {
-						break;
-					}
-					Some(ChannelMsg::Failure) => {
-						bail!("SSH server rejected remote command exec request");
-					}
-					Some(_message) => {
-						// Ignore unrelated channel messages and keep waiting for Success/Failure.
-					}
-					None => {
-						bail!(
-							"SSH channel closed before remote command exec confirmation was received"
-						);
-					}
-				}
-			}
+			await_exec_confirmation(&mut channel).await?;
 
 			stream_channel_output(channel, stdout_tx, stderr_tx, stdin_rx).await
 		}
 	}
+}
+
+/// Waits for the SSH server to accept or reject the exec request.
+async fn await_exec_confirmation(channel: &mut Channel<Msg>) -> Result<()> {
+	loop {
+		match channel.wait().await {
+			Some(ChannelMsg::Success) => {
+				break;
+			}
+			Some(ChannelMsg::Failure) => {
+				bail!("SSH server rejected remote command exec request");
+			}
+			Some(_message) => {
+				// Ignore unrelated channel messages and keep waiting for Success/Failure.
+			}
+			None => {
+				bail!("SSH channel closed before remote command exec confirmation was received");
+			}
+		}
+	}
+
+	Ok(())
 }
 
 /// Streams SSH channel stdout/stderr into local output buffers until exit.
@@ -453,7 +460,7 @@ async fn stream_channel_output(
 	mut channel: Channel<Msg>,
 	stdout_tx: mpsc::Sender<Vec<u8>>,
 	stderr_tx: mpsc::Sender<Vec<u8>>,
-	mut stdin_rx: Option<mpsc::Receiver<Vec<u8>>>,
+	mut stdin_rx: Option<mpsc::Receiver<Option<Vec<u8>>>>,
 ) -> Result<u32> {
 	let mut exit_status = None;
 
@@ -472,18 +479,18 @@ async fn stream_channel_output(
 
 		tokio::select! {
 			Some(input) = recv_stdin => {
-				if let Some(input) = input {
-					if input.is_empty() {
-						channel.eof().await.wrap_err("Failed to send stdin EOF to remote command")?;
-						stdin_rx = None;
-					} else {
+				match input {
+					Some(Some(input)) => {
 						channel
 							.data(input.as_slice())
 							.await
 							.wrap_err("Failed to forward local stdin to remote command")?;
 					}
-				} else {
-					stdin_rx = None;
+					Some(None) => {
+						channel.eof().await.wrap_err("Failed to send stdin EOF to remote command")?;
+						stdin_rx = None;
+					}
+					None => stdin_rx = None,
 				}
 			}
 			msg = channel.wait() => match msg {

--- a/src/ssh/exec.rs
+++ b/src/ssh/exec.rs
@@ -11,12 +11,14 @@ use async_ssh2_tokio::client::{Client, ServerCheckMethod};
 use bytes::Bytes;
 use color_eyre::eyre::{Context as _, bail};
 use console::style;
+use core::future::pending;
 use core::time::Duration;
 use russh::{Channel, ChannelMsg, client::Msg};
 use std::env;
 use std::io::Error as IoError;
-use tokio::io::{copy, sink, stderr, stdout};
+use tokio::io::{AsyncReadExt as _, copy, sink, stderr, stdin, stdout};
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tokio_stream::StreamExt as _;
 use tokio_stream::wrappers::ReceiverStream;
@@ -164,6 +166,50 @@ fn resolve_env_vars(config: &Config, cli_env_vars: &[EnvVarRule]) -> Result<Vec<
 		.collect()
 }
 
+/// Spawns a task that forwards local stdin into a channel for the remote SSH command.
+fn spawn_stdin_forwarder() -> (mpsc::Receiver<Vec<u8>>, JoinHandle<()>) {
+	let (stdin_tx, stdin_rx) = mpsc::channel(32);
+
+	let stdin_task = tokio::spawn(async move {
+		let mut local_stdin = stdin();
+		let mut buffer = vec![0_u8; 8 * 1024];
+
+		loop {
+			match local_stdin.read(&mut buffer).await {
+				Ok(0) => {
+					if stdin_tx.send(Vec::new()).await.is_ok() {
+						pending::<()>().await;
+					}
+					break;
+				}
+				Ok(bytes_read) => {
+					let Some(chunk) = buffer.get(..bytes_read).map(<[u8]>::to_vec) else {
+						debug!(
+							bytes_read,
+							buffer_len = buffer.len(),
+							"tokio stdin returned an out-of-bounds read length"
+						);
+						break;
+					};
+
+					if stdin_tx.send(chunk).await.is_err() {
+						break;
+					}
+				}
+				Err(error) => {
+					debug!(%error, "Failed to read local stdin for remote command");
+					if stdin_tx.send(Vec::new()).await.is_ok() {
+						pending::<()>().await;
+					}
+					break;
+				}
+			}
+		}
+	});
+
+	(stdin_rx, stdin_task)
+}
+
 /// Run a pre-built command string on an already-connected SSH client.
 ///
 /// Returns the remote exit code, printing stdout/stderr as they arrive
@@ -231,6 +277,7 @@ async fn run_command(
 
 	let stdout_stream = ReceiverStream::new(stdout_rx).map(|b| Ok::<_, IoError>(Bytes::from(b)));
 	let stderr_stream = ReceiverStream::new(stderr_rx).map(|b| Ok::<_, IoError>(Bytes::from(b)));
+	let (stdin_rx, stdin_task) = spawn_stdin_forwarder();
 
 	let mut stdout_reader = StreamReader::new(stdout_stream);
 	let mut stderr_reader = StreamReader::new(stderr_stream);
@@ -242,6 +289,7 @@ async fn run_command(
 		forward_method,
 		stdout_tx,
 		stderr_tx,
+		Some(stdin_rx),
 	);
 
 	let stdout_task = async {
@@ -261,6 +309,7 @@ async fn run_command(
 	};
 
 	let (exit_status, (), ()) = tokio::join!(exec_future, stdout_task, stderr_task);
+	stdin_task.abort();
 	let exit_status = exit_status.wrap_err("Failed to execute remote command")?;
 
 	debug!(exit_status, "Remote command completed");
@@ -328,10 +377,11 @@ async fn execute_with_forward_method(
 	forward_method: &EnvForwardMethod,
 	stdout_tx: mpsc::Sender<Vec<u8>>,
 	stderr_tx: mpsc::Sender<Vec<u8>>,
+	stdin_rx: Option<mpsc::Receiver<Vec<u8>>>,
 ) -> Result<u32> {
 	match forward_method {
 		EnvForwardMethod::Export => client
-			.execute_io(command, stdout_tx, Some(stderr_tx), None, false, None)
+			.execute_io(command, stdout_tx, Some(stderr_tx), stdin_rx, false, None)
 			.await
 			.wrap_err("Failed to execute remote command"),
 		EnvForwardMethod::Setenv => {
@@ -393,7 +443,7 @@ async fn execute_with_forward_method(
 				}
 			}
 
-			stream_channel_output(channel, stdout_tx, stderr_tx).await
+			stream_channel_output(channel, stdout_tx, stderr_tx, stdin_rx).await
 		}
 	}
 }
@@ -403,28 +453,58 @@ async fn stream_channel_output(
 	mut channel: Channel<Msg>,
 	stdout_tx: mpsc::Sender<Vec<u8>>,
 	stderr_tx: mpsc::Sender<Vec<u8>>,
+	mut stdin_rx: Option<mpsc::Receiver<Vec<u8>>>,
 ) -> Result<u32> {
 	let mut exit_status = None;
 
+	#[expect(
+		clippy::integer_division_remainder_used,
+		reason = "tokio::select! macro expansion triggers this lint spuriously"
+	)]
 	loop {
-		match channel.wait().await {
-			Some(ChannelMsg::Data { data }) => {
-				stdout_tx
-					.send(data.to_vec())
-					.await
-					.wrap_err("Failed to forward remote stdout")?;
+		let recv_stdin = async {
+			if let Some(receiver) = stdin_rx.as_mut() {
+				Some(receiver.recv().await)
+			} else {
+				None
 			}
-			Some(ChannelMsg::ExtendedData { data, ext: 1 }) => {
-				stderr_tx
-					.send(data.to_vec())
-					.await
-					.wrap_err("Failed to forward remote stderr")?;
+		};
+
+		tokio::select! {
+			Some(input) = recv_stdin => {
+				if let Some(input) = input {
+					if input.is_empty() {
+						channel.eof().await.wrap_err("Failed to send stdin EOF to remote command")?;
+						stdin_rx = None;
+					} else {
+						channel
+							.data(input.as_slice())
+							.await
+							.wrap_err("Failed to forward local stdin to remote command")?;
+					}
+				} else {
+					stdin_rx = None;
+				}
 			}
-			Some(ChannelMsg::ExitStatus {
-				exit_status: status,
-			}) => exit_status = Some(status),
-			Some(_) => {}
-			None => break,
+			msg = channel.wait() => match msg {
+				Some(ChannelMsg::Data { data }) => {
+					stdout_tx
+						.send(data.to_vec())
+						.await
+						.wrap_err("Failed to forward remote stdout")?;
+				}
+				Some(ChannelMsg::ExtendedData { data, ext: 1 }) => {
+					stderr_tx
+						.send(data.to_vec())
+						.await
+						.wrap_err("Failed to forward remote stderr")?;
+				}
+				Some(ChannelMsg::ExitStatus {
+					exit_status: status,
+				}) => exit_status = Some(status),
+				Some(_) => {}
+				None => break,
+			}
 		}
 	}
 

--- a/tasks.toml
+++ b/tasks.toml
@@ -55,7 +55,8 @@ run = "pinact run --verify {% if env.LINT is defined %}--check{% endif %}"
 description = "Run pinact to pin/check pinned GitHub Actions dependencies in workflows."
 
 ["check:zizmor"]
-run = "{% if env.GITHUB_TOKEN is defined %}GH_TOKEN=\"$GITHUB_TOKEN\" {% elif env.GH_TOKEN is defined %}GH_TOKEN=\"$GH_TOKEN\" {% endif %}zizmor --pedantic {% if env.LINT is undefined %}--fix{% endif %} ."
+run = "zizmor --pedantic {% if env.LINT is undefined %}--fix{% endif %} ."
+env.GH_TOKEN = "{{ env.GITHUB_TOKEN }}"
 description = "Run Zizmor to check GitHub Actions workflows."
 
 ["check:yamllint"]

--- a/tasks.toml
+++ b/tasks.toml
@@ -55,8 +55,7 @@ run = "pinact run --verify {% if env.LINT is defined %}--check{% endif %}"
 description = "Run pinact to pin/check pinned GitHub Actions dependencies in workflows."
 
 ["check:zizmor"]
-run = "zizmor --pedantic {% if env.LINT is undefined %}--fix{% endif %} ."
-env.GH_TOKEN = "{{ env.GITHUB_TOKEN }}"
+run = "{% if env.GITHUB_TOKEN is defined %}GH_TOKEN=\"$GITHUB_TOKEN\" {% elif env.GH_TOKEN is defined %}GH_TOKEN=\"$GH_TOKEN\" {% endif %}zizmor --pedantic {% if env.LINT is undefined %}--fix{% endif %} ."
 description = "Run Zizmor to check GitHub Actions workflows."
 
 ["check:yamllint"]

--- a/tests/ssh_e2e_run.rs
+++ b/tests/ssh_e2e_run.rs
@@ -95,6 +95,47 @@ fn e2e_run_streaming() -> Result<()> {
 }
 
 #[test]
+fn e2e_run_forwards_stdin() -> Result<()> {
+	let output = biwa_cmd(&["--quiet", "run", "--skip-sync", "cat"])
+		.stdin_bytes("hello from stdin\n")
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
+
+	assert!(output.status.success());
+	pretty_assertions::assert_eq!(
+		String::from_utf8_lossy(&output.stdout),
+		"hello from stdin\n"
+	);
+	Ok(())
+}
+
+#[test]
+fn e2e_run_forwards_stdin_with_setenv_forward_method() -> Result<()> {
+	let dir = tempfile::tempdir()?;
+	fs::write(
+		dir.path().join("biwa.toml"),
+		"[env]\nforward_method = \"setenv\"\n",
+	)?;
+
+	let output = biwa_cmd(&["--quiet", "run", "--skip-sync", "cat"])
+		.dir(dir.path())
+		.stdin_bytes("hello from stdin via setenv\n")
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
+
+	assert!(output.status.success());
+	pretty_assertions::assert_eq!(
+		String::from_utf8_lossy(&output.stdout),
+		"hello from stdin via setenv\n"
+	);
+	Ok(())
+}
+
+#[test]
 fn e2e_run_quiet() -> Result<()> {
 	let output = biwa_cmd(&["--quiet", "run", "--skip-sync", "echo", "hello quiet"])
 		.stdout_capture()

--- a/tests/ssh_e2e_run.rs
+++ b/tests/ssh_e2e_run.rs
@@ -156,6 +156,66 @@ sys.exit(proc.returncode)
 }
 
 #[test]
+fn e2e_run_forwards_tty_stdin() -> Result<()> {
+	let python = format!(
+		r#"import os, pty, select, subprocess, sys
+master, slave = pty.openpty()
+try:
+    proc = subprocess.Popen(
+        [{biwa_path:?}, "--quiet", "run", "--skip-sync", "cat"],
+        stdin=slave,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=os.environ.copy(),
+    )
+finally:
+    os.close(slave)
+
+os.write(master, b"hello from tty stdin\n")
+ready, _, _ = select.select([proc.stdout], [], [], 10)
+if not ready:
+    proc.kill()
+    out, err = proc.communicate()
+    sys.stderr.write("timed out while waiting for biwa to echo tty stdin\n")
+    sys.stderr.buffer.write(out)
+    sys.stderr.buffer.write(err)
+    sys.exit(124)
+
+line = proc.stdout.readline()
+sys.stdout.buffer.write(line)
+proc.kill()
+_, err = proc.communicate()
+sys.stderr.buffer.write(err)
+if line.replace(b"\r\n", b"\n") != b"hello from tty stdin\n":
+    sys.stderr.write(f"unexpected stdout line: {{line!r}}\n")
+    sys.exit(1)
+sys.exit(0)
+"#,
+		biwa_path = env!("CARGO_BIN_EXE_biwa")
+	);
+
+	let output = Command::new("python3")
+		.arg("-c")
+		.arg(&python)
+		.env("BIWA_SSH_HOST", "127.0.0.1")
+		.env("BIWA_SSH_PORT", "2222")
+		.env("BIWA_SSH_USER", "testuser")
+		.env("BIWA_SSH_PASSWORD", "password123")
+		.output()?;
+
+	assert!(
+		output.status.success(),
+		"stderr: {}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	pretty_assertions::assert_eq!(
+		String::from_utf8_lossy(&output.stdout).replace("\r\n", "\n"),
+		"hello from tty stdin\n"
+	);
+	Ok(())
+}
+
+#[test]
 fn e2e_run_forwards_stdin() -> Result<()> {
 	let output = biwa_cmd(&["--quiet", "run", "--skip-sync", "cat"])
 		.stdin_bytes("hello from stdin\n")

--- a/tests/ssh_e2e_run.rs
+++ b/tests/ssh_e2e_run.rs
@@ -10,7 +10,17 @@ mod common;
 use color_eyre::eyre::{WrapErr as _, eyre};
 use common::{Result, biwa_cmd};
 use rstest::rstest;
-use std::{ffi::OsStr, fs, path::PathBuf, process::Command, process::Stdio, thread, time::Instant};
+use std::{
+	env, ffi::OsStr, fs, path::PathBuf, process::Command, process::Stdio, thread, time::Instant,
+};
+
+fn e2e_timeout_secs() -> u64 {
+	env::var("BIWA_E2E_TIMEOUT_SECS")
+		.ok()
+		.and_then(|value| value.parse::<u64>().ok())
+		.filter(|value| *value > 0)
+		.unwrap_or(10)
+}
 
 fn biwa_process(args: &[&str]) -> Command {
 	let mut command = Command::new(env!("CARGO_BIN_EXE_biwa"));
@@ -96,6 +106,7 @@ fn e2e_run_streaming() -> Result<()> {
 
 #[test]
 fn e2e_run_with_tty_stdin_exits_without_waiting_for_input() -> Result<()> {
+	let timeout_secs = e2e_timeout_secs();
 	let python = format!(
 		r#"import os, pty, subprocess, sys, time
 master, slave = pty.openpty()
@@ -110,7 +121,7 @@ try:
 finally:
     os.close(slave)
 
-deadline = time.time() + 5
+deadline = time.time() + {timeout_secs}
 while proc.poll() is None and time.time() < deadline:
     time.sleep(0.05)
 
@@ -128,7 +139,8 @@ sys.stdout.buffer.write(out)
 sys.stderr.buffer.write(err)
 sys.exit(proc.returncode)
 "#,
-		biwa_path = env!("CARGO_BIN_EXE_biwa")
+		biwa_path = env!("CARGO_BIN_EXE_biwa"),
+		timeout_secs = timeout_secs,
 	);
 
 	let output = Command::new("python3")
@@ -157,6 +169,7 @@ sys.exit(proc.returncode)
 
 #[test]
 fn e2e_run_forwards_tty_stdin() -> Result<()> {
+	let timeout_secs = e2e_timeout_secs();
 	let python = format!(
 		r#"import os, pty, select, subprocess, sys
 master, slave = pty.openpty()
@@ -172,7 +185,7 @@ finally:
     os.close(slave)
 
 os.write(master, b"hello from tty stdin\n")
-ready, _, _ = select.select([proc.stdout], [], [], 10)
+ready, _, _ = select.select([proc.stdout], [], [], {timeout_secs})
 if not ready:
     proc.kill()
     out, err = proc.communicate()
@@ -191,7 +204,8 @@ if line.replace(b"\r\n", b"\n") != b"hello from tty stdin\n":
     sys.exit(1)
 sys.exit(0)
 "#,
-		biwa_path = env!("CARGO_BIN_EXE_biwa")
+		biwa_path = env!("CARGO_BIN_EXE_biwa"),
+		timeout_secs = timeout_secs,
 	);
 
 	let output = Command::new("python3")

--- a/tests/ssh_e2e_run.rs
+++ b/tests/ssh_e2e_run.rs
@@ -95,6 +95,67 @@ fn e2e_run_streaming() -> Result<()> {
 }
 
 #[test]
+fn e2e_run_with_tty_stdin_exits_without_waiting_for_input() -> Result<()> {
+	let python = format!(
+		r#"import os, pty, subprocess, sys, time
+master, slave = pty.openpty()
+try:
+    proc = subprocess.Popen(
+        [{biwa_path:?}, "--quiet", "run", "--skip-sync", "pwd"],
+        stdin=slave,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=os.environ.copy(),
+    )
+finally:
+    os.close(slave)
+
+deadline = time.time() + 5
+while proc.poll() is None and time.time() < deadline:
+    time.sleep(0.05)
+
+if proc.poll() is None:
+    proc.kill()
+    out, err = proc.communicate()
+    sys.stderr.write("timed out while waiting for biwa to exit\n")
+    sys.stderr.buffer.write(out)
+    sys.stderr.buffer.write(err)
+    sys.exit(124)
+
+os.close(master)
+out, err = proc.communicate()
+sys.stdout.buffer.write(out)
+sys.stderr.buffer.write(err)
+sys.exit(proc.returncode)
+"#,
+		biwa_path = env!("CARGO_BIN_EXE_biwa")
+	);
+
+	let output = Command::new("python3")
+		.arg("-c")
+		.arg(&python)
+		.env("BIWA_SSH_HOST", "127.0.0.1")
+		.env("BIWA_SSH_PORT", "2222")
+		.env("BIWA_SSH_USER", "testuser")
+		.env("BIWA_SSH_PASSWORD", "password123")
+		.output()?;
+
+	assert!(
+		output.status.success(),
+		"stderr: {}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	assert!(
+		String::from_utf8_lossy(&output.stdout)
+			.trim()
+			.contains(".cache/biwa/projects/"),
+		"stdout: {}",
+		String::from_utf8_lossy(&output.stdout)
+	);
+	Ok(())
+}
+
+#[test]
 fn e2e_run_forwards_stdin() -> Result<()> {
 	let output = biwa_cmd(&["--quiet", "run", "--skip-sync", "cat"])
 		.stdin_bytes("hello from stdin\n")


### PR DESCRIPTION
## Summary
- forward local stdin to remote commands in both SSH execution paths
- add e2e coverage for piped stdin with the default and setenv forward methods
- document stdin forwarding in the getting started guide

Closes #264.

## Validation
- cargo test --test ssh_e2e_run
- cargo clippy --all-targets -- --deny warnings
- LINT=true mise run check *(fails only in existing `zizmor` task: missing `env.GITHUB_TOKEN` while rendering a workflow template)*