### PR TITLE
refactor(ssh): replace async-ssh2-tokio with custom russh client wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,19 +152,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-ssh2-tokio"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bedb4cd98079c0ec1a23af90ed3383f8ba794894ed05c486451b06121a9db2b1"
-dependencies = [
- "log",
- "russh",
- "russh-sftp",
- "thiserror 2.0.18",
- "tokio",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,7 +208,6 @@ dependencies = [
 name = "biwa"
 version = "0.1.0"
 dependencies = [
- "async-ssh2-tokio",
  "bytes",
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ categories = ["command-line-utilities"]
 include = ["/README.md", "/src/**/*.rs"]
 
 [dependencies]
-async-ssh2-tokio = "=0.12.2"
 bytes = "=1.11.1"
 clap = { version = "=4.6.0", features = ["derive"] }
 color-eyre = "=0.6.5"

--- a/src/ssh/auth.rs
+++ b/src/ssh/auth.rs
@@ -1,7 +1,7 @@
 use crate::Result;
 use crate::config::types::Config;
 use crate::config::types::PasswordConfig;
-use async_ssh2_tokio::client::AuthMethod;
+use crate::ssh::client::auth::Method;
 use color_eyre::eyre::bail;
 use dialoguer::Password;
 use russh::keys::{Error as RusshKeysError, load_secret_key};
@@ -19,7 +19,7 @@ const DEFAULT_KEY_PATHS: &[&str] = &["~/.ssh/id_ed25519", "~/.ssh/id_rsa"];
 /// 2. Explicit password (`ssh.password = "..."` or `ssh.password = true` for prompt)
 /// 3. Default key file discovery (`~/.ssh/id_ed25519`, `~/.ssh/id_rsa`)
 /// 4. SSH Agent (fallback for zero-config users)
-pub(super) fn resolve_auth(config: &Config) -> Result<AuthMethod> {
+pub(super) fn resolve_auth(config: &Config) -> Result<Method> {
 	let ssh = &config.ssh;
 
 	// 1. Explicit key_path (paths are already resolved natively by confique)
@@ -35,14 +35,14 @@ pub(super) fn resolve_auth(config: &Config) -> Result<AuthMethod> {
 	match &ssh.password {
 		PasswordConfig::Value(password) => {
 			info!("Using password authentication from config");
-			return Ok(AuthMethod::with_password(password));
+			return Ok(Method::with_password(password));
 		}
 		PasswordConfig::Interactive(true) => {
 			info!("Prompting for password (ssh.password = true)");
 			let password = Password::new()
 				.with_prompt(format!("Password for {}@{}", ssh.user, ssh.host))
 				.interact()?;
-			return Ok(AuthMethod::with_password(&password));
+			return Ok(Method::with_password(&password));
 		}
 		PasswordConfig::Interactive(false) => {
 			debug!("Password authentication disabled");
@@ -58,7 +58,7 @@ pub(super) fn resolve_auth(config: &Config) -> Result<AuthMethod> {
 	// 4. SSH Agent as last resort (for zero-config users)
 	if try_agent(env::var("SSH_AUTH_SOCK").ok().as_deref()) {
 		info!("Using SSH agent authentication");
-		return Ok(AuthMethod::with_agent());
+		return Ok(Method::with_agent());
 	}
 
 	bail!(
@@ -68,7 +68,7 @@ pub(super) fn resolve_auth(config: &Config) -> Result<AuthMethod> {
 }
 
 /// Load an SSH key from the given path, prompting for a passphrase if needed.
-fn load_key(path: &Path) -> Result<AuthMethod> {
+fn load_key(path: &Path) -> Result<Method> {
 	let path_str = path.to_string_lossy();
 	match load_secret_key(path_str.as_ref(), None) {
 		Err(RusshKeysError::KeyIsEncrypted) => {
@@ -76,15 +76,12 @@ fn load_key(path: &Path) -> Result<AuthMethod> {
 			let passphrase = Password::new()
 				.with_prompt(format!("Passphrase for {}", path.display()))
 				.interact()?;
-			Ok(AuthMethod::with_key_file(
-				path_str.as_ref(),
-				Some(&passphrase),
-			))
+			Ok(Method::with_key_file(path_str.as_ref(), Some(&passphrase)))
 		}
 		_ => {
 			// If it succeeds, or fails with any other error (e.g. invalid format),
 			// we let the actual SSH connection attempt handle it and report the error.
-			Ok(AuthMethod::with_key_file(path_str.as_ref(), None))
+			Ok(Method::with_key_file(path_str.as_ref(), None))
 		}
 	}
 }
@@ -145,7 +142,7 @@ mod tests {
 		config.ssh.key_path = Some(key_file);
 
 		let method = resolve_auth(&config)?;
-		assert_matches!(method, AuthMethod::PrivateKeyFile { .. });
+		assert_matches!(method, Method::PrivateKeyFile { .. });
 		Ok(())
 	}
 
@@ -188,7 +185,7 @@ mod tests {
 		let mut config = Config::default();
 		config.ssh.password = PasswordConfig::Value("secret".to_owned());
 		let method = resolve_auth(&config)?;
-		assert_matches!(method, AuthMethod::Password(_));
+		assert_matches!(method, Method::Password(_));
 		Ok(())
 	}
 
@@ -201,10 +198,7 @@ mod tests {
 		// Without explicit password, it may fall back to agent or key, or fail
 		// — but it must not use Password auth (password = false means skip password)
 		if let Ok(method) = result {
-			assert_matches!(
-				method,
-				AuthMethod::PrivateKeyFile { .. } | AuthMethod::Agent
-			);
+			assert_matches!(method, Method::PrivateKeyFile { .. } | Method::Agent);
 		}
 	}
 }

--- a/src/ssh/client/auth.rs
+++ b/src/ssh/client/auth.rs
@@ -1,11 +1,26 @@
 use crate::Result;
 use alloc::sync::Arc;
-use color_eyre::eyre::{Context as _, bail};
+use color_eyre::eyre::{Context as _, Report};
+use core::error::Error as StdError;
 use core::fmt;
 use russh::client::{Handle, Handler};
 use russh::keys::agent::client::AgentClient;
 use russh::keys::{PrivateKeyWithHashAlg, load_secret_key};
 use std::path::{Path, PathBuf};
+
+/// Marker error for SSH authentication failures.
+///
+/// Returned from [`authenticate`] so callers can detect auth failures without matching error strings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AuthenticationFailed;
+
+impl fmt::Display for AuthenticationFailed {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.write_str("SSH authentication failed")
+	}
+}
+
+impl StdError for AuthenticationFailed {}
 
 /// An authentication token.
 ///
@@ -72,7 +87,8 @@ pub(super) async fn authenticate<H: Handler>(
 		Method::Password(password) => {
 			let is_authenticated = handle.authenticate_password(username, password).await?;
 			if !is_authenticated.success() {
-				bail!("Password authentication failed");
+				return Err(Report::from(AuthenticationFailed))
+					.wrap_err("Password authentication failed");
 			}
 		}
 		Method::PrivateKeyFile {
@@ -91,7 +107,8 @@ pub(super) async fn authenticate<H: Handler>(
 				.await?;
 
 			if !is_authenticated.success() {
-				bail!("Key authentication failed");
+				return Err(Report::from(AuthenticationFailed))
+					.wrap_err("Key authentication failed");
 			}
 		}
 		Method::Agent => {
@@ -104,7 +121,8 @@ pub(super) async fn authenticate<H: Handler>(
 				.wrap_err("Failed to request identities from agent")?;
 
 			if identities.is_empty() {
-				bail!("SSH agent has no identities");
+				return Err(Report::from(AuthenticationFailed))
+					.wrap_err("SSH agent has no identities");
 			}
 
 			let mut authenticated = false;
@@ -120,7 +138,8 @@ pub(super) async fn authenticate<H: Handler>(
 			}
 
 			if !authenticated {
-				bail!("Agent authentication failed");
+				return Err(Report::from(AuthenticationFailed))
+					.wrap_err("Agent authentication failed");
 			}
 		}
 	}

--- a/src/ssh/client/auth.rs
+++ b/src/ssh/client/auth.rs
@@ -1,0 +1,128 @@
+use crate::Result;
+use alloc::sync::Arc;
+use color_eyre::eyre::{Context as _, bail};
+use core::fmt;
+use russh::client::{Handle, Handler};
+use russh::keys::agent::client::AgentClient;
+use russh::keys::{PrivateKeyWithHashAlg, load_secret_key};
+use std::path::{Path, PathBuf};
+
+/// An authentication token.
+///
+/// Used when creating a `Client` for authentication.
+#[derive(Clone, PartialEq, Eq)]
+pub enum Method {
+	/// Password authentication.
+	Password(String),
+	/// Private key file authentication.
+	PrivateKeyFile {
+		/// Path to the private key file.
+		key_file_path: PathBuf,
+		/// Optional passphrase for the private key.
+		key_pass: Option<String>,
+	},
+	/// SSH Agent authentication.
+	Agent,
+}
+
+impl Method {
+	/// Creates a password authentication method.
+	pub fn with_password<S: Into<String>>(password: S) -> Self {
+		Self::Password(password.into())
+	}
+
+	/// Creates a private key file authentication method.
+	pub fn with_key_file<T: AsRef<Path>>(key_file_path: T, passphrase: Option<&str>) -> Self {
+		Self::PrivateKeyFile {
+			key_file_path: key_file_path.as_ref().to_path_buf(),
+			key_pass: passphrase.map(str::to_string),
+		}
+	}
+
+	/// Creates an SSH agent authentication method.
+	pub const fn with_agent() -> Self {
+		Self::Agent
+	}
+}
+
+impl fmt::Debug for Method {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			Self::Password(_) => f.debug_tuple("Password").field(&"***").finish(),
+			Self::PrivateKeyFile {
+				key_file_path,
+				key_pass,
+			} => f
+				.debug_struct("PrivateKeyFile")
+				.field("key_file_path", key_file_path)
+				.field("key_pass", &key_pass.as_ref().map(|_| "***"))
+				.finish(),
+			Self::Agent => write!(f, "Agent"),
+		}
+	}
+}
+
+/// Authenticate a connected handle using the given method.
+pub(super) async fn authenticate<H: Handler>(
+	handle: &mut Handle<H>,
+	username: &str,
+	auth: Method,
+) -> Result<()> {
+	match auth {
+		Method::Password(password) => {
+			let is_authenticated = handle.authenticate_password(username, password).await?;
+			if !is_authenticated.success() {
+				bail!("Password authentication failed");
+			}
+		}
+		Method::PrivateKeyFile {
+			key_file_path,
+			key_pass,
+		} => {
+			let cprivk = load_secret_key(key_file_path, key_pass.as_deref())
+				.wrap_err("Failed to load secret key")?;
+
+			let hash_alg = handle.best_supported_rsa_hash().await?.flatten();
+			let is_authenticated = handle
+				.authenticate_publickey(
+					username,
+					PrivateKeyWithHashAlg::new(Arc::new(cprivk), hash_alg),
+				)
+				.await?;
+
+			if !is_authenticated.success() {
+				bail!("Key authentication failed");
+			}
+		}
+		Method::Agent => {
+			let mut agent = AgentClient::connect_env()
+				.await
+				.wrap_err("Failed to connect to SSH agent")?;
+			let identities = agent
+				.request_identities()
+				.await
+				.wrap_err("Failed to request identities from agent")?;
+
+			if identities.is_empty() {
+				bail!("SSH agent has no identities");
+			}
+
+			let mut authenticated = false;
+			let hash_alg = handle.best_supported_rsa_hash().await?.flatten();
+			for identity in identities {
+				let is_auth = handle
+					.authenticate_publickey_with(username, identity, hash_alg, &mut agent)
+					.await;
+				if is_auth.is_ok_and(|res| res.success()) {
+					authenticated = true;
+					break;
+				}
+			}
+
+			if !authenticated {
+				bail!("Agent authentication failed");
+			}
+		}
+	}
+	Ok(())
+}

--- a/src/ssh/client/execute.rs
+++ b/src/ssh/client/execute.rs
@@ -1,7 +1,7 @@
 use crate::Result;
 use color_eyre::eyre::{Context as _, bail};
 use russh::client::Msg;
-use russh::{Channel, ChannelMsg};
+use russh::{Channel, ChannelMsg, Sig};
 
 /// Result of a remote command execution.
 pub struct CommandExecutedResult {
@@ -11,6 +11,50 @@ pub struct CommandExecutedResult {
 	pub stderr: String,
 	/// Exit status code.
 	pub exit_status: u32,
+}
+
+/// Maps a remote [`Sig`] to a synthetic non-zero exit code (POSIX-style `128 + signal`).
+const fn exit_status_from_signal(sig: &Sig) -> u32 {
+	match sig {
+		Sig::HUP => 129,
+		Sig::INT => 130,
+		Sig::QUIT => 131,
+		Sig::ILL => 132,
+		Sig::ABRT => 134,
+		Sig::FPE => 136,
+		Sig::KILL => 137,
+		Sig::USR1 => 138,
+		Sig::SEGV => 139,
+		Sig::ALRM => 142,
+		Sig::PIPE => 141,
+		Sig::TERM => 143,
+		Sig::Custom(_) => 128,
+	}
+}
+
+/// Waits for the SSH server to accept or reject a channel request.
+pub async fn await_channel_confirmation(
+	channel: &mut Channel<Msg>,
+	request_name: &str,
+) -> Result<()> {
+	loop {
+		match channel.wait().await {
+			Some(ChannelMsg::Success) => {
+				break;
+			}
+			Some(ChannelMsg::Failure) => {
+				bail!("SSH server rejected {request_name}");
+			}
+			Some(_message) => {
+				// Ignore unrelated channel messages and keep waiting for Success/Failure.
+			}
+			None => {
+				bail!("SSH channel closed before {request_name} confirmation was received");
+			}
+		}
+	}
+
+	Ok(())
 }
 
 /// Execute a command and collect its stdout, stderr, and exit status.
@@ -26,12 +70,14 @@ pub(super) async fn execute(
 		.await
 		.wrap_err("Failed to exec command")?;
 
+	await_channel_confirmation(channel, &format!("exec request for `{command}`")).await?;
+
 	let mut exit_status = None;
 
 	while let Some(msg) = channel.wait().await {
 		#[expect(
 			clippy::wildcard_enum_match_arm,
-			reason = "We only care about stdout, stderr, and exit status"
+			reason = "We only care about stdout, stderr, exit status, and exit signal"
 		)]
 		match msg {
 			ChannelMsg::Data { data } => {
@@ -46,6 +92,9 @@ pub(super) async fn execute(
 				exit_status: status,
 			} => {
 				exit_status = Some(status);
+			}
+			ChannelMsg::ExitSignal { signal_name, .. } => {
+				exit_status = Some(exit_status_from_signal(&signal_name));
 			}
 			_ => {}
 		}

--- a/src/ssh/client/execute.rs
+++ b/src/ssh/client/execute.rs
@@ -1,0 +1,63 @@
+use crate::Result;
+use color_eyre::eyre::{Context as _, bail};
+use russh::client::Msg;
+use russh::{Channel, ChannelMsg};
+
+/// Result of a remote command execution.
+pub struct CommandExecutedResult {
+	/// Standard output.
+	pub stdout: String,
+	/// Standard error.
+	pub stderr: String,
+	/// Exit status code.
+	pub exit_status: u32,
+}
+
+/// Execute a command and collect its stdout, stderr, and exit status.
+pub(super) async fn execute(
+	channel: &mut Channel<Msg>,
+	command: &str,
+) -> Result<CommandExecutedResult> {
+	let mut stdout_buffer = vec![];
+	let mut stderr_buffer = vec![];
+
+	channel
+		.exec(true, command)
+		.await
+		.wrap_err("Failed to exec command")?;
+
+	let mut exit_status = None;
+
+	while let Some(msg) = channel.wait().await {
+		#[expect(
+			clippy::wildcard_enum_match_arm,
+			reason = "We only care about stdout, stderr, and exit status"
+		)]
+		match msg {
+			ChannelMsg::Data { data } => {
+				stdout_buffer.extend_from_slice(&data);
+			}
+			ChannelMsg::ExtendedData { data, ext } => {
+				if ext == 1 {
+					stderr_buffer.extend_from_slice(&data);
+				}
+			}
+			ChannelMsg::ExitStatus {
+				exit_status: status,
+			} => {
+				exit_status = Some(status);
+			}
+			_ => {}
+		}
+	}
+
+	if let Some(status) = exit_status {
+		Ok(CommandExecutedResult {
+			stdout: String::from_utf8_lossy(&stdout_buffer).into_owned(),
+			stderr: String::from_utf8_lossy(&stderr_buffer).into_owned(),
+			exit_status: status,
+		})
+	} else {
+		bail!("Command did not return exit status")
+	}
+}

--- a/src/ssh/client/mod.rs
+++ b/src/ssh/client/mod.rs
@@ -1,0 +1,110 @@
+/// Authentication types.
+pub mod auth;
+/// Command execution.
+pub mod execute;
+
+use self::auth::{Method, authenticate};
+use self::execute::execute;
+
+use crate::Result;
+use alloc::sync::Arc;
+use color_eyre::eyre::{Context as _, Report};
+use core::fmt::Debug;
+use core::result::Result as CoreResult;
+use russh::Channel;
+use russh::client::{Config, Handle, Handler, Msg, connect as russh_connect};
+use russh::keys::PublicKey;
+use tokio::net::ToSocketAddrs;
+use tokio::net::lookup_host;
+
+/// Handler for the SSH client.
+struct ClientHandler;
+
+impl Handler for ClientHandler {
+	type Error = Report;
+
+	async fn check_server_key(
+		&mut self,
+		_server_public_key: &PublicKey,
+	) -> CoreResult<bool, Self::Error> {
+		// TODO(#409): Implement proper host key verification
+		tracing::debug!("skipping server key verification");
+		Ok(true)
+	}
+}
+
+/// An SSH client.
+#[derive(Clone)]
+pub struct Client {
+	/// The active SSH connection handle.
+	connection_handle: Arc<Handle<ClientHandler>>,
+}
+
+impl Client {
+	/// Connect to a remote SSH server.
+	pub async fn connect<T: ToSocketAddrs + Debug + Send + Sync>(
+		addr: T,
+		username: &str,
+		auth: Method,
+	) -> Result<Self> {
+		let config = Arc::new(Config::default());
+
+		let socket_addrs = lookup_host(&addr)
+			.await
+			.wrap_err("Failed to resolve addresses")?;
+
+		let mut connect_res = None;
+		let mut last_err: Option<Report> = None;
+
+		for socket_addr in socket_addrs {
+			let handler = ClientHandler;
+			match russh_connect(Arc::clone(&config), socket_addr, handler).await {
+				Ok(h) => {
+					connect_res = Some(h);
+					break;
+				}
+				Err(e) => {
+					tracing::debug!(error = %e, %socket_addr, "Connection failed, trying next address");
+					last_err = Some(e);
+				}
+			}
+		}
+
+		let Some(mut handle) = connect_res else {
+			match last_err {
+				Some(err) => {
+					return Err(err.wrap_err(
+						format!("Could not connect to any address for {addr:?}")
+					));
+				}
+				None => {
+					return Err(color_eyre::eyre::eyre!(
+						"Could not connect: no addresses resolved for {addr:?}"
+					));
+				}
+			}
+		};
+
+		let username = username.to_owned();
+
+		authenticate(&mut handle, &username, auth).await?;
+
+		Ok(Self {
+			connection_handle: Arc::new(handle),
+		})
+	}
+
+	/// Open a new SSH channel.
+	pub async fn get_channel(&self) -> Result<Channel<Msg>> {
+		self.connection_handle
+			.channel_open_session()
+			.await
+			.wrap_err("Failed to open channel")
+	}
+
+	/// Execute a command and collect its stdout, stderr, and exit status.
+	pub async fn execute(&self, command: &str) -> Result<execute::CommandExecutedResult> {
+		let mut channel = self.get_channel().await?;
+		execute(&mut channel, command).await
+	}
+}

--- a/src/ssh/client/mod.rs
+++ b/src/ssh/client/mod.rs
@@ -73,9 +73,9 @@ impl Client {
 		let Some(mut handle) = connect_res else {
 			match last_err {
 				Some(err) => {
-					return Err(err.wrap_err(
-						format!("Could not connect to any address for {addr:?}")
-					));
+					return Err(
+						err.wrap_err(format!("Could not connect to any address for {addr:?}"))
+					);
 				}
 				None => {
 					return Err(color_eyre::eyre::eyre!(

--- a/src/ssh/exec.rs
+++ b/src/ssh/exec.rs
@@ -6,8 +6,8 @@ use crate::env_vars::{
 	EnvForwardMethod, EnvVarRule, EnvVarSource, is_environment_dependent_env_var,
 	local_env_var_names, resolve_env_var_rules,
 };
+use crate::ssh::client::Client;
 use crate::ui::create_spinner;
-use async_ssh2_tokio::client::{Client, ServerCheckMethod};
 use bytes::Bytes;
 use color_eyre::eyre::{Context as _, bail};
 use console::style;
@@ -70,12 +70,17 @@ pub(super) async fn connect(config: &Config, quiet: bool) -> Result<Client> {
 			(ssh.host.as_str(), ssh.port),
 			ssh.user.as_str(),
 			auth_method.clone(),
-			ServerCheckMethod::NoCheck,
 		)
 		.await
 		{
 			Ok(c) => break c,
 			Err(e) if retries > 0 => {
+				let err_msg = e.to_string();
+				if err_msg.contains("authentication failed") || err_msg.contains("has no identities") {
+					return Err(e).wrap_err_with(|| {
+						format!("Failed to authenticate as {}@{}", ssh.user, ssh.host)
+					});
+				}
 				debug!(
 					error = %e,
 					retry_delay_ms = delay.as_millis(),

--- a/src/ssh/exec.rs
+++ b/src/ssh/exec.rs
@@ -7,11 +7,14 @@ use crate::env_vars::{
 	local_env_var_names, resolve_env_var_rules,
 };
 use crate::ssh::client::Client;
+use crate::ssh::client::auth::AuthenticationFailed;
+use crate::ssh::client::execute::await_channel_confirmation;
 use crate::ui::create_spinner;
 use bytes::Bytes;
-use color_eyre::eyre::{Context as _, bail};
+use color_eyre::eyre::{Context as _, Report, bail};
 use console::style;
 use core::time::Duration;
+use indicatif::ProgressBar;
 use russh::{Channel, ChannelMsg, Pty, client::Msg};
 use std::env;
 use std::io::{Error as IoError, IsTerminal as _, Read as _, stdin as std_stdin};
@@ -23,6 +26,23 @@ use tokio_stream::StreamExt as _;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::io::StreamReader;
 use tracing::{debug, info, warn};
+
+/// Clears the spinner on drop so early returns and errors do not leave a stuck spinner.
+struct SpinnerGuard(Option<ProgressBar>);
+
+impl Drop for SpinnerGuard {
+	fn drop(&mut self) {
+		if let Some(s) = self.0.take() {
+			s.finish_and_clear();
+		}
+	}
+}
+
+/// Returns true when `report` includes the structured authentication failure marker (including
+/// context added via `wrap_err`).
+fn report_is_authentication_failure(report: &Report) -> bool {
+	report.downcast_ref::<AuthenticationFailed>().is_some()
+}
 
 /// Resolved environment variable to send remotely.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -62,6 +82,8 @@ pub(super) async fn connect(config: &Config, quiet: bool) -> Result<Client> {
 		)))
 	};
 
+	let _spinner_cleanup = SpinnerGuard(spinner);
+
 	let mut retries = 3_usize;
 	let mut delay = Duration::from_millis(500);
 
@@ -75,10 +97,7 @@ pub(super) async fn connect(config: &Config, quiet: bool) -> Result<Client> {
 		{
 			Ok(c) => break c,
 			Err(e) if retries > 0 => {
-				let err_msg = e.to_string();
-				if err_msg.contains("authentication failed")
-					|| err_msg.contains("has no identities")
-				{
+				if report_is_authentication_failure(&e) {
 					return Err(e).wrap_err_with(|| {
 						format!("Failed to authenticate as {}@{}", ssh.user, ssh.host)
 					});
@@ -104,7 +123,6 @@ pub(super) async fn connect(config: &Config, quiet: bool) -> Result<Client> {
 		}
 	};
 
-	spinner.as_ref().inspect(|s| s.finish_and_clear());
 	info!(
 		host = %ssh.host,
 		port = ssh.port,
@@ -511,28 +529,6 @@ async fn execute_with_forward_method(
 	}
 }
 
-/// Waits for the SSH server to accept or reject a channel request.
-async fn await_channel_confirmation(channel: &mut Channel<Msg>, request_name: &str) -> Result<()> {
-	loop {
-		match channel.wait().await {
-			Some(ChannelMsg::Success) => {
-				break;
-			}
-			Some(ChannelMsg::Failure) => {
-				bail!("SSH server rejected {request_name}");
-			}
-			Some(_message) => {
-				// Ignore unrelated channel messages and keep waiting for Success/Failure.
-			}
-			None => {
-				bail!("SSH channel closed before {request_name} confirmation was received");
-			}
-		}
-	}
-
-	Ok(())
-}
-
 /// Streams SSH channel stdout/stderr into local output buffers until exit.
 async fn stream_channel_output(
 	mut channel: Channel<Msg>,
@@ -613,9 +609,17 @@ mod tests {
 	use super::*;
 	use crate::config::types::EnvConfig;
 	use crate::env_vars::{EnvForwardMethod, EnvVarRule, EnvVarSelector, EnvVarSpec, EnvVars};
+	use crate::ssh::client::auth::AuthenticationFailed;
 	use crate::testing::EnvCleanup;
+	use color_eyre::eyre::Report;
 	use pretty_assertions::assert_eq;
 	use serial_test::serial;
+
+	#[test]
+	fn report_is_authentication_failure_detects_wrapped_auth_error() {
+		let report = Report::from(AuthenticationFailed).wrap_err("Password authentication failed");
+		assert!(super::report_is_authentication_failure(&report));
+	}
 
 	#[test]
 	fn build_command_no_args() {

--- a/src/ssh/exec.rs
+++ b/src/ssh/exec.rs
@@ -76,7 +76,9 @@ pub(super) async fn connect(config: &Config, quiet: bool) -> Result<Client> {
 			Ok(c) => break c,
 			Err(e) if retries > 0 => {
 				let err_msg = e.to_string();
-				if err_msg.contains("authentication failed") || err_msg.contains("has no identities") {
+				if err_msg.contains("authentication failed")
+					|| err_msg.contains("has no identities")
+				{
 					return Err(e).wrap_err_with(|| {
 						format!("Failed to authenticate as {}@{}", ssh.user, ssh.host)
 					});

--- a/src/ssh/mod.rs
+++ b/src/ssh/mod.rs
@@ -1,5 +1,8 @@
 /// SSH authentication processing.
 pub mod auth;
+/// SSH Client wrapper.
+pub mod client;
+
 /// Remote command execution handling.
 pub mod exec;
 /// SSH file synchronization.

--- a/src/ssh/sync.rs
+++ b/src/ssh/sync.rs
@@ -607,9 +607,10 @@ async fn create_remote_directories(
 }
 
 /// Uploads a file to a remote SFTP server using an existing session.
-/// We provide our own upload method because `async-ssh2-tokio`'s `upload_file`
-/// creates a new channel for every file and does not allow specifying file attributes (like permissions)
-/// atomically on creation, leading to race conditions where sensitive files might be readable.
+///
+/// We provide our own upload method so we can set file attributes atomically on
+/// creation (`open_with_flags_and_attributes`), avoiding races where sensitive
+/// files might be briefly world-readable.
 async fn upload_file(
 	sftp: &SftpSession,
 	local_path: &Path,

--- a/src/ssh/sync.rs
+++ b/src/ssh/sync.rs
@@ -1,8 +1,8 @@
 use super::exec::connect;
 use crate::Result;
 use crate::config::types::{Config, SftpPermissions, SyncEngine};
+use crate::ssh::client::Client;
 use crate::ui::create_spinner;
-use async_ssh2_tokio::client::Client;
 use color_eyre::eyre::{Context as _, ContextCompat as _, bail};
 use console::style;
 use core::mem::take;


### PR DESCRIPTION
## Description

Removes the `async-ssh2-tokio` dependency by implementing a custom, tailored wrapper directly over `russh`. This effectively reduces our dependency tree size, limits external abstractions, and gives us more control over the SSH client implementation.

## Changes
* Created a lightweight `Client` wrapper in `src/ssh/client.rs` leveraging existing `russh` components.
* Updated `exec.rs`, `sync.rs`, and `auth.rs` to use the new local `Client`.
* Removed `async-ssh2-tokio` from `Cargo.toml` and lockfiles.
* Ensured all E2E tests continue to pass with identical behavior mapping.