### PR TITLE
perf(ssh): reuse single SSH connection for sync and run

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -3,7 +3,7 @@ use crate::cli::sync::SyncArgs;
 use crate::config::types::Config;
 use crate::env_vars::parse_cli_env_vars;
 use crate::{
-	ssh::exec::execute_command,
+	ssh::exec::{connect, execute_command},
 	ssh::sync::{compute_project_remote_dir, sync_project},
 };
 use clap::Args;
@@ -62,9 +62,12 @@ pub(super) async fn run_remote(
 ) -> Result<()> {
 	let sync_root = sync_args.resolve_sync_root(config)?;
 
+	let client = connect(config, quiet || silent).await?;
+
 	if should_sync {
 		let options = sync_args.resolve_options();
 		sync_project(
+			&client,
 			config,
 			&sync_root,
 			&options,
@@ -84,6 +87,7 @@ pub(super) async fn run_remote(
 	};
 
 	execute_command(
+		&client,
 		config,
 		remote_command.command,
 		remote_command.command_args,
@@ -95,7 +99,6 @@ pub(super) async fn run_remote(
 	.await?;
 	Ok(())
 }
-
 impl Run {
 	/// Determines whether synchronization should be performed before running the command.
 	const fn should_sync(&self, config_sync_auto: bool) -> bool {

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -3,7 +3,7 @@ use crate::cli::sync::SyncArgs;
 use crate::config::types::Config;
 use crate::env_vars::parse_cli_env_vars;
 use crate::{
-	ssh::exec::{connect, execute_command},
+	ssh::exec::{ExecuteCommandOptions, connect, execute_command},
 	ssh::sync::{compute_project_remote_dir, sync_project},
 };
 use clap::Args;
@@ -86,15 +86,18 @@ pub(super) async fn run_remote(
 		&computed_working_dir
 	};
 
+	let cli_env_vars = parse_cli_env_vars(remote_command.cli_env_vars)?;
 	execute_command(
 		&client,
 		config,
-		remote_command.command,
-		remote_command.command_args,
-		&parse_cli_env_vars(remote_command.cli_env_vars)?,
-		Some(working_dir),
-		quiet,
-		silent,
+		ExecuteCommandOptions {
+			command: remote_command.command,
+			args: remote_command.command_args,
+			cli_env_vars: &cli_env_vars,
+			working_dir: Some(working_dir),
+			quiet,
+			silent,
+		},
 	)
 	.await?;
 	Ok(())

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -1,5 +1,6 @@
 use crate::Result;
 use crate::config::types::Config;
+use crate::ssh::exec::connect;
 use crate::ssh::sync::{Options, sync_project};
 use clap::Args;
 use std::env;
@@ -83,7 +84,9 @@ impl Sync {
 		let config = Config::load()?;
 		let sync_root = self.sync_args.resolve_sync_root(&config)?;
 		let options = self.sync_args.resolve_options();
+		let client = connect(&config, quiet).await?;
 		sync_project(
+			&client,
 			&config,
 			&sync_root,
 			&options,

--- a/src/ssh/exec.rs
+++ b/src/ssh/exec.rs
@@ -69,7 +69,8 @@ struct RunCommandOptions<'a> {
 }
 
 /// Connect to the SSH server using the resolved authentication method.
-pub async fn connect(config: &Config, quiet: bool) -> Result<Client> {
+#[expect(clippy::redundant_pub_crate, reason = "Preferred by reviewer")]
+pub(crate) async fn connect(config: &Config, quiet: bool) -> Result<Client> {
 	let auth_method = resolve_auth(config)?;
 	let ssh = &config.ssh;
 
@@ -407,44 +408,51 @@ async fn run_command(
 	Ok(exit_status)
 }
 
+/// Options for remote command execution.
+pub struct ExecuteCommandOptions<'a> {
+	/// The command to run.
+	pub command: &'a str,
+	/// The arguments for the command.
+	pub args: &'a [String],
+	/// CLI-provided environment variables.
+	pub cli_env_vars: &'a [EnvVarRule],
+	/// Remote working directory to enter before running the command.
+	pub working_dir: Option<&'a str>,
+	/// Suppresses local progress output when true.
+	pub quiet: bool,
+	/// Suppresses forwarded remote stdout/stderr when true.
+	pub silent: bool,
+}
+
 /// Execute a command on the remote host via SSH.
 ///
 /// If `working_dir` is set, the command executes inside that remote directory.
 /// Returns the exit code of the remote command.
-#[expect(
-	clippy::too_many_arguments,
-	reason = "Internal execution helper with many settings"
-)]
 pub async fn execute_command(
 	client: &Client,
 	config: &Config,
-	command: &str,
-	args: &[String],
-	cli_env_vars: &[EnvVarRule],
-	working_dir: Option<&str>,
-	quiet: bool,
-	silent: bool,
+	options: ExecuteCommandOptions<'_>,
 ) -> Result<u32> {
 	info!(
-		command,
-		args_count = args.len(),
-		has_working_dir = working_dir.is_some(),
-		quiet,
-		silent,
+		command = options.command,
+		args_count = options.args.len(),
+		has_working_dir = options.working_dir.is_some(),
+		quiet = options.quiet,
+		silent = options.silent,
 		"Starting remote command execution"
 	);
-	let full_command = build_command(command, args);
-	let env_vars = resolve_env_vars(config, cli_env_vars)?;
+	let full_command = build_command(options.command, options.args);
+	let env_vars = resolve_env_vars(config, options.cli_env_vars)?;
 	run_command(
 		client,
 		&full_command,
 		&env_vars,
 		&config.env.forward_method,
 		RunCommandOptions {
-			working_dir,
+			working_dir: options.working_dir,
 			umask: &config.ssh.umask,
-			quiet,
-			silent,
+			quiet: options.quiet,
+			silent: options.silent,
 		},
 	)
 	.await

--- a/src/ssh/exec.rs
+++ b/src/ssh/exec.rs
@@ -69,7 +69,7 @@ struct RunCommandOptions<'a> {
 }
 
 /// Connect to the SSH server using the resolved authentication method.
-pub(super) async fn connect(config: &Config, quiet: bool) -> Result<Client> {
+pub async fn connect(config: &Config, quiet: bool) -> Result<Client> {
 	let auth_method = resolve_auth(config)?;
 	let ssh = &config.ssh;
 
@@ -411,7 +411,12 @@ async fn run_command(
 ///
 /// If `working_dir` is set, the command executes inside that remote directory.
 /// Returns the exit code of the remote command.
+#[expect(
+	clippy::too_many_arguments,
+	reason = "Internal execution helper with many settings"
+)]
 pub async fn execute_command(
+	client: &Client,
 	config: &Config,
 	command: &str,
 	args: &[String],
@@ -428,11 +433,10 @@ pub async fn execute_command(
 		silent,
 		"Starting remote command execution"
 	);
-	let client = connect(config, quiet || silent).await?;
 	let full_command = build_command(command, args);
 	let env_vars = resolve_env_vars(config, cli_env_vars)?;
 	run_command(
-		&client,
+		client,
 		&full_command,
 		&env_vars,
 		&config.env.forward_method,

--- a/src/ssh/sync.rs
+++ b/src/ssh/sync.rs
@@ -1,4 +1,3 @@
-use super::exec::connect;
 use crate::Result;
 use crate::config::types::{Config, SftpPermissions, SyncEngine};
 use crate::ssh::client::Client;
@@ -782,6 +781,7 @@ async fn apply_sync_actions(
 /// Synchronizes a project to a remote server.
 #[expect(clippy::module_name_repetitions, reason = "No better name exists")]
 pub async fn sync_project(
+	client: &Client,
 	config: &Config,
 	project_root: &Path,
 	options: &Options,
@@ -792,12 +792,12 @@ pub async fn sync_project(
 		bail!("Only SFTP sync engine is currently supported");
 	}
 	info!(
-		project_root = %project_root.display(),
-		force = options.force,
-		include_patterns = options.include.len(),
-		exclude_patterns = options.exclude.len(),
-		has_remote_override = remote_dir_override.is_some(),
-		"Starting project synchronization"
+			project_root = %project_root.display(),
+			force = options.force,
+			include_patterns = options.include.len(),
+			exclude_patterns = options.exclude.len(),
+			has_remote_override = remote_dir_override.is_some(),
+			"Starting project synchronization"
 	);
 
 	let unique_project_name = compute_unique_project_name(project_root)?;
@@ -817,8 +817,6 @@ pub async fn sync_project(
 	);
 	ensure_sync_file_limit(local_state.files.len(), config.sync.sftp.max_files_to_sync)?;
 
-	let client = connect(config, quiet).await?;
-
 	let spinner = if quiet {
 		None
 	} else {
@@ -837,7 +835,7 @@ pub async fn sync_project(
 		String::from,
 	);
 
-	let remote_state = fetch_remote_state(&client, config, &remote_dir).await?;
+	let remote_state = fetch_remote_state(client, config, &remote_dir).await?;
 	debug!(
 		remote_dir = %remote_dir,
 		remote_directories = remote_state.directories.len(),
@@ -861,7 +859,7 @@ pub async fn sync_project(
 	);
 
 	apply_sync_actions(
-		&client,
+		client,
 		config,
 		SyncTarget {
 			project_root,


### PR DESCRIPTION
Resolves #383 by extracting the SSH client instantiation to the top of the command lifecycles in `biwa run` and `biwa sync`, and passing a shared `&Client` to `sync_project` and `execute_command`. This prevents establishing a second SSH connection after the sync phase during execution.