### PR TITLE
refactor(sync): extract path helpers

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,9 +1,9 @@
 use crate::Result;
 use crate::cli::sync::SyncArgs;
 use crate::config::types::Config;
+use crate::env_flag;
 use clap::{ArgAction, Parser, Subcommand};
 use color_eyre::eyre::eyre;
-use std::env;
 use tracing::Level;
 use tracing_subscriber::{
 	filter::Targets, fmt, layer::SubscriberExt as _, registry, util::SubscriberInitExt as _,
@@ -151,20 +151,10 @@ struct OutputMode {
 impl OutputMode {
 	/// Resolves output flags using CLI precedence over environment defaults.
 	fn resolve(cli: &Cli) -> Self {
-		let silent = cli.silent || env_flag_is_truthy("BIWA_LOG_SILENT");
-		let quiet = silent || cli.quiet || env_flag_is_truthy("BIWA_LOG_QUIET");
+		let silent = cli.silent || env_flag::is_truthy("BIWA_LOG_SILENT");
+		let quiet = silent || cli.quiet || env_flag::is_truthy("BIWA_LOG_QUIET");
 		Self { quiet, silent }
 	}
-}
-
-/// Returns true when an environment variable is set to a truthy value.
-fn env_flag_is_truthy(name: &str) -> bool {
-	env::var(name).is_ok_and(|value| {
-		matches!(
-			value.trim().to_ascii_lowercase().as_str(),
-			"1" | "true" | "yes" | "on"
-		)
-	})
 }
 
 #[cfg(test)]

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -5,7 +5,7 @@ use crate::ssh::sync::{Options, sync_project};
 use clap::Args;
 use std::env;
 use std::fs::canonicalize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Arguments for synchronization.
 #[derive(Args, Debug, Default, Clone)]
@@ -46,27 +46,43 @@ impl SyncArgs {
 
 	/// Resolve the sync options.
 	pub fn resolve_options(&self) -> Options {
-		let cwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-		let cwd = canonicalize(&cwd).unwrap_or(cwd);
-		let cwd_str = cwd.to_string_lossy().into_owned();
-		let cwd_str = cwd_str.trim_end_matches('/');
-
-		let make_absolute = |p: &String| {
-			if p.starts_with('/') {
-				p.clone()
-			} else {
-				format!("{cwd_str}/{}", p.trim_start_matches('/'))
-			}
-		};
-		let exclude = self.exclude.iter().map(make_absolute).collect::<Vec<_>>();
-		let include = self.include.iter().map(make_absolute).collect::<Vec<_>>();
+		let cwd = canonical_current_dir();
 
 		Options {
 			force: self.force,
-			exclude,
-			include,
+			exclude: absolutize_patterns(&self.exclude, &cwd),
+			include: absolutize_patterns(&self.include, &cwd),
 		}
 	}
+}
+
+/// Returns the canonical current directory, falling back to `.` if needed.
+fn canonical_current_dir() -> PathBuf {
+	let cwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+	canonicalize(&cwd).unwrap_or(cwd)
+}
+
+/// Converts relative include/exclude patterns into absolute paths.
+fn absolutize_patterns(patterns: &[String], base_dir: &Path) -> Vec<String> {
+	let base_dir = trim_trailing_slash(base_dir);
+	patterns
+		.iter()
+		.map(|pattern| absolutize_pattern(pattern, &base_dir))
+		.collect()
+}
+
+/// Converts one sync pattern into an absolute path if it is relative.
+fn absolutize_pattern(pattern: &str, base_dir: &str) -> String {
+	if pattern.starts_with('/') {
+		pattern.to_owned()
+	} else {
+		format!("{base_dir}/{}", pattern.trim_start_matches('/'))
+	}
+}
+
+/// Returns a displayable path without a trailing slash.
+fn trim_trailing_slash(path: &Path) -> String {
+	path.to_string_lossy().trim_end_matches('/').to_owned()
 }
 
 /// Synchronize local project files to the remote server.
@@ -125,6 +141,17 @@ mod tests {
 		assert_eq!(
 			options.include,
 			vec!["/abs/include".to_owned(), format!("{cwd_str}/rel/include")]
+		);
+	}
+
+	#[test]
+	fn absolutize_patterns_preserves_absolute_entries() {
+		assert_eq!(
+			absolutize_patterns(
+				&["/abs/path".to_owned(), "relative/path".to_owned()],
+				Path::new("/project"),
+			),
+			vec!["/abs/path".to_owned(), "/project/relative/path".to_owned()]
 		);
 	}
 }

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -600,10 +600,26 @@ mod tests {
 
 	#[rstest]
 	#[serial]
-	#[case::toml("ssh.host = 'toml'\nssh.user = 'user'", "toml", "toml")]
-	#[case::json(r#"{ "ssh": { "host": "json", "user": "user" } }"#, "json", "json")]
-	#[case::json5("{ ssh: { host: 'json5', user: 'user' } }", "json5", "json5")]
-	#[case::yaml("ssh:\n  host: yaml\n  user: user", "yaml", "yaml")]
+	#[case::toml(
+		"ssh.host = 'toml'\nssh.user = 'user'\nhooks.pre_sync = 'toml'",
+		"toml",
+		"toml"
+	)]
+	#[case::json(
+		r#"{ "ssh": { "host": "json", "user": "user" }, "hooks": { "pre_sync": "json" } }"#,
+		"json",
+		"json"
+	)]
+	#[case::json5(
+		"{ ssh: { host: 'json5', user: 'user' }, hooks: { pre_sync: 'json5' } }",
+		"json5",
+		"json5"
+	)]
+	#[case::yaml(
+		"ssh:\n  host: yaml\n  user: user\nhooks:\n  pre_sync: yaml",
+		"yaml",
+		"yaml"
+	)]
 	fn format_extensions(
 		#[case] content: &str,
 		#[case] ext: &str,
@@ -614,7 +630,7 @@ mod tests {
 		fs::write(&file_path, content)?;
 
 		let config = Config::load_internal(None, None, Some(dir.path().to_path_buf()).as_ref())?;
-		assert_eq!(config.ssh.host, expected);
+		assert_eq!(config.hooks.pre_sync.as_deref(), Some(expected));
 		Ok(())
 	}
 

--- a/src/env_flag.rs
+++ b/src/env_flag.rs
@@ -1,0 +1,49 @@
+use std::env;
+
+/// Returns true when an environment variable is set to a truthy value.
+pub fn is_truthy(name: &str) -> bool {
+	env::var(name).is_ok_and(|value| value_is_truthy(&value))
+}
+
+/// Returns true for accepted truthy flag values.
+fn value_is_truthy(value: &str) -> bool {
+	matches!(
+		value.trim().to_ascii_lowercase().as_str(),
+		"1" | "true" | "yes" | "on"
+	)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::testing::EnvCleanup;
+	use serial_test::serial;
+
+	#[test]
+	#[serial]
+	fn is_truthy_reads_truthy_values() {
+		let _cleanup = EnvCleanup::set("BIWA_DEBUG_ERROR_REPORT", " yes ");
+		assert!(is_truthy("BIWA_DEBUG_ERROR_REPORT"));
+	}
+
+	#[test]
+	#[serial]
+	fn is_truthy_defaults_to_false_when_missing() {
+		let _cleanup = EnvCleanup::remove("BIWA_DEBUG_ERROR_REPORT");
+		assert!(!is_truthy("BIWA_DEBUG_ERROR_REPORT"));
+	}
+
+	#[test]
+	fn recognizes_truthy_values() {
+		for value in ["1", "true", "TRUE", " yes ", "on"] {
+			assert!(value_is_truthy(value));
+		}
+	}
+
+	#[test]
+	fn rejects_non_truthy_values() {
+		for value in ["", "0", "false", "off", "no", "truth"] {
+			assert!(!value_is_truthy(value));
+		}
+	}
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,8 @@ pub type Result<T> = color_eyre::Result<T>;
 mod cli;
 /// Configuration loading and definitions.
 mod config;
+/// Environment flag parsing.
+mod env_flag;
 /// Environment variable parsing and forward.
 mod env_vars;
 /// SSH execution logic.
@@ -36,11 +38,11 @@ mod testing;
 mod ui;
 
 use color_eyre::{Report, config::HookBuilder};
-use std::{env, process::ExitCode};
+use std::process::ExitCode;
 
 #[tokio::main]
 async fn main() -> ExitCode {
-	let debug_error_report = env_flag_is_truthy("BIWA_DEBUG_ERROR_REPORT");
+	let debug_error_report = env_flag::is_truthy("BIWA_DEBUG_ERROR_REPORT");
 
 	if let Err(error) = install_error_hooks(debug_error_report) {
 		eprintln!("{error}");
@@ -96,16 +98,6 @@ fn print_error(error: &Report, debug_error_report: bool) {
 	}
 }
 
-/// Returns true when an environment variable is set to a truthy value.
-fn env_flag_is_truthy(name: &str) -> bool {
-	env::var(name).is_ok_and(|value| {
-		matches!(
-			value.trim().to_ascii_lowercase().as_str(),
-			"1" | "true" | "yes" | "on"
-		)
-	})
-}
-
 #[cfg(test)]
 #[ctor::ctor]
 fn init_test_env() {
@@ -114,25 +106,4 @@ fn init_test_env() {
 		reason = "Multiple tests may attempt to initialize the global error handler."
 	)]
 	color_eyre::install().ok();
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-	use crate::testing::EnvCleanup;
-	use serial_test::serial;
-
-	#[test]
-	#[serial]
-	fn env_flag_is_truthy_reads_truthy_values() {
-		let _cleanup = EnvCleanup::set("BIWA_DEBUG_ERROR_REPORT", " yes ");
-		assert!(env_flag_is_truthy("BIWA_DEBUG_ERROR_REPORT"));
-	}
-
-	#[test]
-	#[serial]
-	fn env_flag_is_truthy_defaults_to_false_when_missing() {
-		let _cleanup = EnvCleanup::remove("BIWA_DEBUG_ERROR_REPORT");
-		assert!(!env_flag_is_truthy("BIWA_DEBUG_ERROR_REPORT"));
-	}
 }

--- a/src/ssh/mod.rs
+++ b/src/ssh/mod.rs
@@ -7,3 +7,5 @@ pub mod client;
 pub mod exec;
 /// SSH file synchronization.
 pub mod sync;
+/// Helpers shared by SSH synchronization modules.
+mod sync_paths;

--- a/src/ssh/sync.rs
+++ b/src/ssh/sync.rs
@@ -1,12 +1,15 @@
+#[cfg(test)]
+use super::sync_paths::{MAX_REMOTE_MKDIR_COMMAND_LEN, compute_remote_path};
+use super::sync_paths::{
+	build_mkdir_commands, collect_leaf_directories, parse_remote_path, resolve_sftp_path,
+};
 use crate::Result;
 use crate::config::types::{Config, SftpPermissions, SyncEngine};
 use crate::ssh::client::Client;
 use crate::ui::create_spinner;
-use color_eyre::eyre::{Context as _, ContextCompat as _, bail};
+use color_eyre::eyre::{Context as _, bail};
 use console::style;
-use core::mem::take;
 use core::result::Result as CoreResult;
-use gethostname::gethostname;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use ignore::WalkBuilder;
 use indicatif::ProgressBar;
@@ -26,8 +29,18 @@ use tracing::{debug, info, warn};
 
 /// Separator emitted by the remote sync-state script before file hash lines.
 const REMOTE_FILE_MARKER: &str = "__BIWA_FILE_HASHES__";
-/// Conservative upper bound for a batched remote `mkdir -p` command.
-const MAX_REMOTE_MKDIR_COMMAND_LEN: usize = 4096;
+
+/// Computes the remote directory path for a given project.
+///
+/// This is the directory where synced files are stored on the remote server.
+pub fn compute_project_remote_dir(config: &Config, project_root: &Path) -> Result<String> {
+	super::sync_paths::compute_project_remote_dir(config, project_root)
+}
+
+/// Shell-quotes a remote path while preserving home directory expansion.
+pub(super) fn shell_quote_path(path: &str) -> String {
+	super::sync_paths::shell_quote_path(path)
+}
 
 /// Statistics for a synchronization operation.
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -104,24 +117,6 @@ fn path_matches_globset(globset: &GlobSet, path: &Path, is_dir: bool) -> bool {
 	}
 
 	is_dir && globset.is_match(format!("{path}/"))
-}
-
-/// Shell-quotes a remote path while preserving home directory expansion.
-///
-/// If the path starts with `~/`, the `~` is replaced with `$HOME` and placed
-/// outside the quotes so the shell can expand it. Otherwise, the entire path
-/// is quoted with `shell_words::quote`.
-pub(super) fn shell_quote_path(path: &str) -> String {
-	if path == "~" || path == "$HOME" {
-		return "\"$HOME\"".to_owned();
-	}
-	if let Some(rest) = path
-		.strip_prefix("~/")
-		.or_else(|| path.strip_prefix("$HOME/"))
-	{
-		return format!("\"$HOME\"/{}", shell_words::quote(rest));
-	}
-	shell_words::quote(path).into_owned()
 }
 
 /// A wrapper around a hasher that implements `std::io::Write`.
@@ -247,68 +242,6 @@ fn collect_local_state(
 	}
 
 	Ok(state)
-}
-
-/// Computes the absolute remote path for a given local file.
-pub(super) fn compute_remote_path(
-	remote_root: &Path,
-	project_name: &str,
-	relative: &Path,
-) -> String {
-	let mut path = remote_root.to_string_lossy().into_owned();
-	if !path.ends_with('/') {
-		path.push('/');
-	}
-	path.push_str(project_name);
-
-	let rel_str = relative.to_string_lossy();
-	if !rel_str.is_empty() {
-		if !path.ends_with('/') && !rel_str.starts_with('/') {
-			path.push('/');
-		}
-		path.push_str(&rel_str);
-	}
-	path
-}
-
-/// Computes a unique project name based on the hostname and project root's canonical path.
-fn compute_unique_project_name(project_root: &Path) -> Result<String> {
-	let project_name = project_root
-		.file_name()
-		.wrap_err("Invalid project root directory")?
-		.to_string_lossy()
-		.into_owned();
-
-	// Create a unique hash based on the hostname and absolute path to prevent
-	// collisions between projects with the same name across machines.
-	let mut hasher = Sha256::new();
-	hasher.update(gethostname().to_string_lossy().as_bytes());
-	hasher.update([0]);
-	hasher.update(
-		project_root
-			.canonicalize()
-			.wrap_err("Failed to canonicalize project root")?
-			.to_string_lossy()
-			.as_bytes(),
-	);
-	let hash_hex = hex::encode(hasher.finalize());
-	#[expect(
-		clippy::string_slice,
-		reason = "Hex encoded strings are strictly ASCII, slicing is safe"
-	)]
-	Ok(format!("{}-{}", project_name, &hash_hex[..8]))
-}
-
-/// Computes the remote directory path for a given project.
-///
-/// This is the directory where synced files are stored on the remote server.
-pub fn compute_project_remote_dir(config: &Config, project_root: &Path) -> Result<String> {
-	let unique_project_name = compute_unique_project_name(project_root)?;
-	Ok(compute_remote_path(
-		&config.sync.remote_root,
-		&unique_project_name,
-		Path::new(""),
-	))
 }
 
 /// Extends a directory set with parent directories implied by local files.
@@ -458,51 +391,6 @@ fn ensure_sync_file_limit(file_count: usize, max_files_to_sync: usize) -> Result
 	Ok(())
 }
 
-/// SFTP naturally resolves paths not starting with `/` relative to the user's home directory.
-/// It does NOT expand `~/` or `$HOME/` like a shell would. Therefore, we strip them so SFTP
-/// looks in the home directory instead of looking for literal `~` or `$HOME` folders.
-fn resolve_sftp_path(remote_path: &str) -> &str {
-	remote_path
-		.strip_prefix("~/")
-		.or_else(|| remote_path.strip_prefix("$HOME/"))
-		.unwrap_or_else(|| {
-			if remote_path == "~" || remote_path == "$HOME" {
-				"."
-			} else {
-				remote_path
-			}
-		})
-}
-
-/// Returns whether `candidate` is nested beneath `ancestor`.
-fn is_nested_directory(candidate: &str, ancestor: &str) -> bool {
-	candidate != ancestor && Path::new(candidate).starts_with(ancestor)
-}
-
-/// Reduces a directory set to its deepest leaf paths.
-fn collect_leaf_directories(paths: &[String]) -> Vec<String> {
-	let mut sorted = paths.to_vec();
-	sorted.sort_unstable_by(|left, right| {
-		let left_depth = left.bytes().filter(|byte| *byte == b'/').count();
-		let right_depth = right.bytes().filter(|byte| *byte == b'/').count();
-		right_depth.cmp(&left_depth).then_with(|| left.cmp(right))
-	});
-
-	let mut leaves = Vec::new();
-	for path in sorted {
-		if leaves
-			.iter()
-			.any(|existing: &String| is_nested_directory(existing, &path))
-		{
-			continue;
-		}
-		leaves.push(path);
-	}
-
-	leaves.sort_unstable();
-	leaves
-}
-
 /// Deletes remote directories one-by-one over the existing SFTP session.
 async fn delete_remote_directories(
 	sftp: &SftpSession,
@@ -545,41 +433,6 @@ fn collect_directories_to_create(actions: &SyncActions) -> Vec<String> {
 	let mut directories = directories.into_iter().collect::<Vec<_>>();
 	directories.sort_unstable();
 	collect_leaf_directories(&directories)
-}
-
-/// Splits directory creation into bounded `mkdir -p` batches.
-fn build_mkdir_commands(umask: &str, remote_dir: &str, relative_paths: &[String]) -> Vec<String> {
-	if relative_paths.is_empty() {
-		return Vec::new();
-	}
-
-	let prefix = format!("umask {umask} && mkdir -p --");
-	let mut commands = Vec::new();
-	let mut current = prefix.clone();
-
-	for quoted_path in relative_paths
-		.iter()
-		.map(|path| format!("{remote_dir}/{path}"))
-		.map(|path| shell_quote_path(&path))
-	{
-		let projected_len = current
-			.len()
-			.saturating_add(1)
-			.saturating_add(quoted_path.len());
-		if current.len() > prefix.len() && projected_len > MAX_REMOTE_MKDIR_COMMAND_LEN {
-			commands.push(take(&mut current));
-			current.clone_from(&prefix);
-		}
-
-		current.push(' ');
-		current.push_str(&quoted_path);
-	}
-
-	if current.len() > prefix.len() {
-		commands.push(current);
-	}
-
-	commands
 }
 
 /// Creates remote directories with the configured umask.
@@ -805,8 +658,6 @@ pub async fn sync_project(
 			"Starting project synchronization"
 	);
 
-	let unique_project_name = compute_unique_project_name(project_root)?;
-
 	let local_state = {
 		let project_root = project_root.to_path_buf();
 		let exclude = config.sync.exclude.clone();
@@ -828,17 +679,10 @@ pub async fn sync_project(
 		Some(create_spinner("Synchronizing files...".to_owned()))
 	};
 
-	// Compute remote directory base
-	let remote_dir = remote_dir_override.map_or_else(
-		|| {
-			compute_remote_path(
-				&config.sync.remote_root,
-				&unique_project_name,
-				Path::new(""),
-			)
-		},
-		String::from,
-	);
+	let remote_dir = match remote_dir_override {
+		Some(remote_dir) => remote_dir.to_owned(),
+		None => compute_project_remote_dir(config, project_root)?,
+	};
 
 	let remote_state = fetch_remote_state(client, config, &remote_dir).await?;
 	debug!(
@@ -891,37 +735,6 @@ pub async fn sync_project(
 	}
 
 	Ok(stats)
-}
-
-/// Normalizes a remote relative path and rejects absolute or traversal paths.
-fn parse_remote_path(raw_path: &str, entry_kind: &str) -> Option<String> {
-	let path = raw_path.strip_prefix("./").unwrap_or(raw_path);
-	if path.is_empty() || path == "." {
-		return None;
-	}
-
-	if path.starts_with('/')
-		|| path == "~"
-		|| path.starts_with("~/")
-		|| path == "$HOME"
-		|| path.starts_with("$HOME/")
-	{
-		warn!(
-			"Skipping remote {entry_kind} with invalid absolute path: {}",
-			path
-		);
-		return None;
-	}
-
-	if path.split('/').any(|comp| comp == "..") {
-		warn!(
-			"Skipping remote {entry_kind} with invalid path traversal components: {}",
-			path
-		);
-		return None;
-	}
-
-	Some(path.to_owned())
 }
 
 /// Parses the output of the remote sync-state script into a directory set and file hash map.
@@ -1220,6 +1033,22 @@ mod tests {
 		assert_eq!(
 			leaves,
 			vec!["a/b/c".to_owned(), "a/d".to_owned(), "e".to_owned()]
+		);
+	}
+
+	#[test]
+	fn collect_leaf_directories_handles_string_prefix_siblings() {
+		let leaves = collect_leaf_directories(&[
+			"a".to_owned(),
+			"a-b".to_owned(),
+			"a/b".to_owned(),
+			"a/b-c".to_owned(),
+			"a/b/c".to_owned(),
+		]);
+
+		assert_eq!(
+			leaves,
+			vec!["a/b/c".to_owned(), "a/b-c".to_owned(), "a-b".to_owned()]
 		);
 	}
 

--- a/src/ssh/sync_paths.rs
+++ b/src/ssh/sync_paths.rs
@@ -1,0 +1,226 @@
+use crate::Result;
+use crate::config::types::Config;
+use color_eyre::eyre::{Context as _, ContextCompat as _};
+use core::cmp::Ordering;
+use core::mem::take;
+use gethostname::gethostname;
+use sha2::{Digest as _, Sha256};
+use std::path::Path;
+use tracing::warn;
+
+/// Conservative upper bound for a batched remote `mkdir -p` command.
+pub(super) const MAX_REMOTE_MKDIR_COMMAND_LEN: usize = 4096;
+
+/// Shell-quotes a remote path while preserving home directory expansion.
+///
+/// If the path starts with `~/`, the `~` is replaced with `$HOME` and placed
+/// outside the quotes so the shell can expand it. Otherwise, the entire path
+/// is quoted with `shell_words::quote`.
+pub(super) fn shell_quote_path(path: &str) -> String {
+	if path == "~" || path == "$HOME" {
+		return "\"$HOME\"".to_owned();
+	}
+	if let Some(rest) = path
+		.strip_prefix("~/")
+		.or_else(|| path.strip_prefix("$HOME/"))
+	{
+		return format!("\"$HOME\"/{}", shell_words::quote(rest));
+	}
+	shell_words::quote(path).into_owned()
+}
+
+/// Computes the absolute remote path for a given local file.
+pub(super) fn compute_remote_path(
+	remote_root: &Path,
+	project_name: &str,
+	relative: &Path,
+) -> String {
+	let mut path = remote_root.to_string_lossy().into_owned();
+	if !path.ends_with('/') {
+		path.push('/');
+	}
+	path.push_str(project_name);
+
+	let rel_str = relative.to_string_lossy();
+	if !rel_str.is_empty() {
+		if !path.ends_with('/') && !rel_str.starts_with('/') {
+			path.push('/');
+		}
+		path.push_str(&rel_str);
+	}
+	path
+}
+
+/// Computes a unique project name based on the hostname and project root's canonical path.
+fn compute_unique_project_name(project_root: &Path) -> Result<String> {
+	let project_name = project_root
+		.file_name()
+		.wrap_err("Invalid project root directory")?
+		.to_string_lossy()
+		.into_owned();
+
+	// Create a unique hash based on the hostname and absolute path to prevent
+	// collisions between projects with the same name across machines.
+	let mut hasher = Sha256::new();
+	hasher.update(gethostname().to_string_lossy().as_bytes());
+	hasher.update([0]);
+	hasher.update(
+		project_root
+			.canonicalize()
+			.wrap_err("Failed to canonicalize project root")?
+			.to_string_lossy()
+			.as_bytes(),
+	);
+	let hash_hex = hex::encode(hasher.finalize());
+	#[expect(
+		clippy::string_slice,
+		reason = "Hex encoded strings are strictly ASCII, slicing is safe"
+	)]
+	Ok(format!("{}-{}", project_name, &hash_hex[..8]))
+}
+
+/// Computes the remote directory path for a given project.
+///
+/// This is the directory where synced files are stored on the remote server.
+pub(super) fn compute_project_remote_dir(config: &Config, project_root: &Path) -> Result<String> {
+	let unique_project_name = compute_unique_project_name(project_root)?;
+	Ok(compute_remote_path(
+		&config.sync.remote_root,
+		&unique_project_name,
+		Path::new(""),
+	))
+}
+
+/// SFTP naturally resolves paths not starting with `/` relative to the user's home directory.
+/// It does NOT expand `~/` or `$HOME/` like a shell would. Therefore, we strip them so SFTP
+/// looks in the home directory instead of looking for literal `~` or `$HOME` folders.
+pub(super) fn resolve_sftp_path(remote_path: &str) -> &str {
+	remote_path
+		.strip_prefix("~/")
+		.or_else(|| remote_path.strip_prefix("$HOME/"))
+		.unwrap_or_else(|| {
+			if remote_path == "~" || remote_path == "$HOME" {
+				"."
+			} else {
+				remote_path
+			}
+		})
+}
+
+/// Compares remote paths by slash-separated components.
+fn compare_remote_paths(left: &str, right: &str) -> Ordering {
+	let mut left_components = left.split('/');
+	let mut right_components = right.split('/');
+
+	loop {
+		match (left_components.next(), right_components.next()) {
+			(Some(left_component), Some(right_component)) => {
+				let ordering = left_component.cmp(right_component);
+				if ordering != Ordering::Equal {
+					return ordering;
+				}
+			}
+			(None, Some(_)) => return Ordering::Less,
+			(Some(_), None) => return Ordering::Greater,
+			(None, None) => return Ordering::Equal,
+		}
+	}
+}
+
+/// Returns whether `candidate` is nested beneath `ancestor`.
+fn is_nested_directory(candidate: &str, ancestor: &str) -> bool {
+	candidate != ancestor && Path::new(candidate).starts_with(ancestor)
+}
+
+/// Reduces a directory set to its deepest leaf paths.
+pub(super) fn collect_leaf_directories(paths: &[String]) -> Vec<String> {
+	if paths.is_empty() {
+		return Vec::new();
+	}
+
+	let mut sorted = paths.to_vec();
+	sorted.sort_unstable_by(|left, right| compare_remote_paths(left, right));
+	sorted.dedup();
+
+	let mut leaves = Vec::new();
+	for (index, current) in sorted.iter().enumerate() {
+		let is_leaf = sorted
+			.get(index.saturating_add(1))
+			.is_none_or(|next| !is_nested_directory(next, current));
+		if is_leaf {
+			leaves.push(current.clone());
+		}
+	}
+
+	leaves
+}
+
+/// Splits directory creation into bounded `mkdir -p` batches.
+pub(super) fn build_mkdir_commands(
+	umask: &str,
+	remote_dir: &str,
+	relative_paths: &[String],
+) -> Vec<String> {
+	if relative_paths.is_empty() {
+		return Vec::new();
+	}
+
+	let prefix = format!("umask {umask} && mkdir -p --");
+	let mut commands = Vec::new();
+	let mut current = prefix.clone();
+
+	for quoted_path in relative_paths
+		.iter()
+		.map(|path| format!("{remote_dir}/{path}"))
+		.map(|path| shell_quote_path(&path))
+	{
+		let projected_len = current
+			.len()
+			.saturating_add(1)
+			.saturating_add(quoted_path.len());
+		if current.len() > prefix.len() && projected_len > MAX_REMOTE_MKDIR_COMMAND_LEN {
+			commands.push(take(&mut current));
+			current.clone_from(&prefix);
+		}
+
+		current.push(' ');
+		current.push_str(&quoted_path);
+	}
+
+	if current.len() > prefix.len() {
+		commands.push(current);
+	}
+
+	commands
+}
+
+/// Normalizes a remote relative path and rejects absolute or traversal paths.
+pub(super) fn parse_remote_path(raw_path: &str, entry_kind: &str) -> Option<String> {
+	let path = raw_path.strip_prefix("./").unwrap_or(raw_path);
+	if path.is_empty() || path == "." {
+		return None;
+	}
+
+	if path.starts_with('/')
+		|| path == "~"
+		|| path.starts_with("~/")
+		|| path == "$HOME"
+		|| path.starts_with("$HOME/")
+	{
+		warn!(
+			"Skipping remote {entry_kind} with invalid absolute path: {}",
+			path
+		);
+		return None;
+	}
+
+	if path.split('/').any(|comp| comp == "..") {
+		warn!(
+			"Skipping remote {entry_kind} with invalid path traversal components: {}",
+			path
+		);
+		return None;
+	}
+
+	Some(path.to_owned())
+}


### PR DESCRIPTION
## Summary
- Extract SSH sync path, quoting, remote-dir, and mkdir batching helpers into a dedicated module
- Share environment-flag truthiness parsing between CLI logging and top-level error reporting
- Split CLI sync pattern absolutization into small tested helpers
- Apply the AI review suggestion by making leaf-directory collection sort/dedup plus a linear scan
- Fix strict clippy nits in SSH client helpers and make config format tests avoid env-overridden assertions

## Verification
- cargo fmt --check
- cargo clippy --all-targets -- --deny warnings
- cargo test --bin biwa
