### PR TITLE
fix(clippy): enable rust 1.95 lints

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
       - v*
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: release-${{ github.ref }}
   cancel-in-progress: false
 
 permissions: {}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "biwa"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.93.1"
+rust-version = "1.95.0"
 description = "CLI to execute commands on UNSW CSE servers from local"
 repository = "https://github.com/risu729/biwa"
 license = "MIT"
@@ -60,8 +60,6 @@ tempfile = "=3.27.0"
 # We prefer disabling rules than enabling them
 blanket_clippy_restriction_lints = "allow"
 cargo = { level = "warn", priority = -1 }
-# Rust 1.95 added new style suggestions; keep source churn out of tool bumps
-collapsible_match = "allow"
 default_numeric_fallback = "allow"
 default_union_representation = "allow"
 # We don't need to care about breaking changes in non-public APIs
@@ -75,8 +73,6 @@ float_arithmetic = "allow"
 get_unwrap = "allow"
 # We prefer idiomatic Rust code
 implicit_return = "allow"
-# Rust 1.95 added new style suggestions; keep source churn out of tool bumps
-map_unwrap_or = "allow"
 # We allow single char identifiers for brevity
 min_ident_chars = "allow"
 # We shouldn't enable globally
@@ -110,8 +106,6 @@ shadow_reuse = "allow"
 single_call_fn = "allow"
 # Single char lifetime names are more idiomatic
 single_char_lifetime_names = "allow"
-# Rust 1.95 added new style suggestions; keep source churn out of tool bumps
-str_to_string = "allow"
 # mut String is worse than String + "..."
 string_add = "allow"
 # We have some unimplemented features

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -159,14 +159,12 @@ impl OutputMode {
 
 /// Returns true when an environment variable is set to a truthy value.
 fn env_flag_is_truthy(name: &str) -> bool {
-	env::var(name)
-		.map(|value| {
-			matches!(
-				value.trim().to_ascii_lowercase().as_str(),
-				"1" | "true" | "yes" | "on"
-			)
-		})
-		.unwrap_or(false)
+	env::var(name).is_ok_and(|value| {
+		matches!(
+			value.trim().to_ascii_lowercase().as_str(),
+			"1" | "true" | "yes" | "on"
+		)
+	})
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,14 +98,12 @@ fn print_error(error: &Report, debug_error_report: bool) {
 
 /// Returns true when an environment variable is set to a truthy value.
 fn env_flag_is_truthy(name: &str) -> bool {
-	env::var(name)
-		.map(|value| {
-			matches!(
-				value.trim().to_ascii_lowercase().as_str(),
-				"1" | "true" | "yes" | "on"
-			)
-		})
-		.unwrap_or(false)
+	env::var(name).is_ok_and(|value| {
+		matches!(
+			value.trim().to_ascii_lowercase().as_str(),
+			"1" | "true" | "yes" | "on"
+		)
+	})
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,3 +115,24 @@ fn init_test_env() {
 	)]
 	color_eyre::install().ok();
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::testing::EnvCleanup;
+	use serial_test::serial;
+
+	#[test]
+	#[serial]
+	fn env_flag_is_truthy_reads_truthy_values() {
+		let _cleanup = EnvCleanup::set("BIWA_DEBUG_ERROR_REPORT", " yes ");
+		assert!(env_flag_is_truthy("BIWA_DEBUG_ERROR_REPORT"));
+	}
+
+	#[test]
+	#[serial]
+	fn env_flag_is_truthy_defaults_to_false_when_missing() {
+		let _cleanup = EnvCleanup::remove("BIWA_DEBUG_ERROR_REPORT");
+		assert!(!env_flag_is_truthy("BIWA_DEBUG_ERROR_REPORT"));
+	}
+}

--- a/src/ssh/client/auth.rs
+++ b/src/ssh/client/auth.rs
@@ -50,7 +50,7 @@ impl Method {
 	pub fn with_key_file<T: AsRef<Path>>(key_file_path: T, passphrase: Option<&str>) -> Self {
 		Self::PrivateKeyFile {
 			key_file_path: key_file_path.as_ref().to_path_buf(),
-			key_pass: passphrase.map(str::to_string),
+			key_pass: passphrase.map(str::to_owned),
 		}
 	}
 

--- a/src/ssh/client/auth.rs
+++ b/src/ssh/client/auth.rs
@@ -159,3 +159,31 @@ pub(super) async fn authenticate<H: Handler>(
 	}
 	Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use pretty_assertions::assert_eq;
+
+	#[test]
+	fn key_file_method_preserves_passphrase() {
+		assert_eq!(
+			Method::with_key_file("id_ed25519", Some("secret")),
+			Method::PrivateKeyFile {
+				key_file_path: PathBuf::from("id_ed25519"),
+				key_pass: Some(String::from("secret")),
+			}
+		);
+	}
+
+	#[test]
+	fn key_file_method_allows_missing_passphrase() {
+		assert_eq!(
+			Method::with_key_file("id_ed25519", None),
+			Method::PrivateKeyFile {
+				key_file_path: PathBuf::from("id_ed25519"),
+				key_pass: None,
+			}
+		);
+	}
+}

--- a/src/ssh/client/execute.rs
+++ b/src/ssh/client/execute.rs
@@ -75,27 +75,10 @@ pub(super) async fn execute(
 	let mut exit_status = None;
 
 	while let Some(msg) = channel.wait().await {
-		#[expect(
-			clippy::wildcard_enum_match_arm,
-			reason = "We only care about stdout, stderr, exit status, and exit signal"
-		)]
-		match msg {
-			ChannelMsg::Data { data } => {
-				stdout_buffer.extend_from_slice(&data);
-			}
-			ChannelMsg::ExtendedData { data, ext: 1 } => {
-				stderr_buffer.extend_from_slice(&data);
-			}
-			ChannelMsg::ExitStatus {
-				exit_status: status,
-			} => {
-				exit_status = Some(status);
-			}
-			ChannelMsg::ExitSignal { signal_name, .. } => {
-				exit_status = Some(exit_status_from_signal(&signal_name));
-			}
-			_ => {}
-		}
+		collect_message(
+			msg,
+			(&mut stdout_buffer, &mut stderr_buffer, &mut exit_status),
+		);
 	}
 
 	if let Some(status) = exit_status {
@@ -106,5 +89,87 @@ pub(super) async fn execute(
 		})
 	} else {
 		bail!("Command did not return exit status")
+	}
+}
+
+/// Collects output and exit status from a channel message.
+fn collect_message(msg: ChannelMsg, output: (&mut Vec<u8>, &mut Vec<u8>, &mut Option<u32>)) {
+	let (stdout_buffer, stderr_buffer, exit_status) = output;
+
+	#[expect(
+		clippy::wildcard_enum_match_arm,
+		reason = "We only care about stdout, stderr, exit status, and exit signal"
+	)]
+	match msg {
+		ChannelMsg::Data { data } => {
+			stdout_buffer.extend_from_slice(&data);
+		}
+		ChannelMsg::ExtendedData { data, ext: 1 } => {
+			stderr_buffer.extend_from_slice(&data);
+		}
+		ChannelMsg::ExitStatus {
+			exit_status: status,
+		} => {
+			*exit_status = Some(status);
+		}
+		ChannelMsg::ExitSignal { signal_name, .. } => {
+			*exit_status = Some(exit_status_from_signal(&signal_name));
+		}
+		_ => {}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use bytes::Bytes;
+	use pretty_assertions::assert_eq;
+
+	#[test]
+	fn collect_message_routes_output_and_exit_status() {
+		let mut stdout_buffer = Vec::new();
+		let mut stderr_buffer = Vec::new();
+		let mut exit_status = None;
+
+		collect_message(
+			ChannelMsg::Data {
+				data: Bytes::from_static(b"out"),
+			},
+			(&mut stdout_buffer, &mut stderr_buffer, &mut exit_status),
+		);
+		collect_message(
+			ChannelMsg::ExtendedData {
+				data: Bytes::from_static(b"err"),
+				ext: 1,
+			},
+			(&mut stdout_buffer, &mut stderr_buffer, &mut exit_status),
+		);
+		collect_message(
+			ChannelMsg::ExtendedData {
+				data: Bytes::from_static(b"ignored"),
+				ext: 2,
+			},
+			(&mut stdout_buffer, &mut stderr_buffer, &mut exit_status),
+		);
+		collect_message(
+			ChannelMsg::ExitStatus { exit_status: 7 },
+			(&mut stdout_buffer, &mut stderr_buffer, &mut exit_status),
+		);
+
+		assert_eq!(stdout_buffer, b"out");
+		assert_eq!(stderr_buffer, b"err");
+		assert_eq!(exit_status, Some(7));
+
+		collect_message(
+			ChannelMsg::ExitSignal {
+				signal_name: Sig::TERM,
+				core_dumped: false,
+				error_message: String::new(),
+				lang_tag: String::new(),
+			},
+			(&mut stdout_buffer, &mut stderr_buffer, &mut exit_status),
+		);
+
+		assert_eq!(exit_status, Some(143));
 	}
 }

--- a/src/ssh/client/execute.rs
+++ b/src/ssh/client/execute.rs
@@ -83,10 +83,8 @@ pub(super) async fn execute(
 			ChannelMsg::Data { data } => {
 				stdout_buffer.extend_from_slice(&data);
 			}
-			ChannelMsg::ExtendedData { data, ext } => {
-				if ext == 1 {
-					stderr_buffer.extend_from_slice(&data);
-				}
+			ChannelMsg::ExtendedData { data, ext: 1 } => {
+				stderr_buffer.extend_from_slice(&data);
 			}
 			ChannelMsg::ExitStatus {
 				exit_status: status,

--- a/src/ssh/sync.rs
+++ b/src/ssh/sync.rs
@@ -638,15 +638,11 @@ async fn upload_file(
 	}
 
 	if matches!(permissions, SftpPermissions::Recreate) {
-		let should_remove = sftp
-			.metadata(sftp_path)
-			.await
-			.map(|attrs| {
-				attrs
-					.permissions
-					.map_or_else(|| true, |p| (p & 0o777) != secure_mode)
-			})
-			.unwrap_or(true); // Default to true if metadata fails
+		let should_remove = sftp.metadata(sftp_path).await.map_or(true, |attrs| {
+			attrs
+				.permissions
+				.map_or_else(|| true, |p| (p & 0o777) != secure_mode)
+		}); // Default to true if metadata fails
 		if should_remove && let Err(e) = sftp.remove_file(sftp_path).await {
 			debug!(error = %e, path = sftp_path, "Failed to remove pre-existing file or file did not exist");
 		}

--- a/src/ssh/sync.rs
+++ b/src/ssh/sync.rs
@@ -5,6 +5,7 @@ use crate::ui::create_spinner;
 use color_eyre::eyre::{Context as _, ContextCompat as _, bail};
 use console::style;
 use core::mem::take;
+use core::result::Result as CoreResult;
 use gethostname::gethostname;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use ignore::WalkBuilder;
@@ -638,11 +639,7 @@ async fn upload_file(
 	}
 
 	if matches!(permissions, SftpPermissions::Recreate) {
-		let should_remove = sftp.metadata(sftp_path).await.map_or(true, |attrs| {
-			attrs
-				.permissions
-				.map_or_else(|| true, |p| (p & 0o777) != secure_mode)
-		}); // Default to true if metadata fails
+		let should_remove = should_remove_for_recreate(sftp.metadata(sftp_path).await, secure_mode);
 		if should_remove && let Err(e) = sftp.remove_file(sftp_path).await {
 			debug!(error = %e, path = sftp_path, "Failed to remove pre-existing file or file did not exist");
 		}
@@ -670,6 +667,18 @@ async fn upload_file(
 		.wrap_err("Failed to write to remote file")?;
 
 	Ok(())
+}
+
+/// Returns true when an existing remote file must be removed before upload.
+fn should_remove_for_recreate<E>(
+	metadata: CoreResult<FileAttributes, E>,
+	secure_mode: u32,
+) -> bool {
+	metadata.map_or(true, |attrs| {
+		attrs
+			.permissions
+			.map_or_else(|| true, |p| (p & 0o777) != secure_mode)
+	})
 }
 
 /// Target and actions for a synchronization operation.
@@ -949,6 +958,32 @@ mod tests {
 	use pretty_assertions::assert_eq;
 	use std::fs;
 	use tempfile::tempdir;
+
+	#[test]
+	fn should_recreate_file_when_permissions_are_missing_or_different() {
+		assert!(should_remove_for_recreate(Err(()), 0o600));
+		assert!(should_remove_for_recreate(
+			Ok::<FileAttributes, ()>(FileAttributes {
+				permissions: None,
+				..Default::default()
+			}),
+			0o600
+		));
+		assert!(should_remove_for_recreate(
+			Ok::<FileAttributes, ()>(FileAttributes {
+				permissions: Some(0o100_644),
+				..Default::default()
+			}),
+			0o600
+		));
+		assert!(!should_remove_for_recreate(
+			Ok::<FileAttributes, ()>(FileAttributes {
+				permissions: Some(0o100_600),
+				..Default::default()
+			}),
+			0o600
+		));
+	}
 
 	#[test]
 	fn collect_local_files_basic() {


### PR DESCRIPTION
## Summary
- bump Cargo MSRV to Rust 1.95.0
- re-enable the Rust 1.95 Clippy lints that had temporary Cargo.toml allows
- fix the affected env parsing, SSH channel message handling, passphrase ownership, and sync recreate checks
- add focused tests for the rewritten helpers
- isolate Release workflow concurrency so PR CI can run the reusable release build visibly

## Verification
- `LINT=true mise run check:clippy`
- `LINT=true mise run check:rustfmt`
- `mise run test`
- `cargo tarpaulin --skip-clean`
- `cargo test env_flag_is_truthy`
- `cargo test ssh::client::`
- `cargo test should_recreate_file_when_permissions_are_missing_or_different`
- `LINT=true mise run check:actionlint`
- `LINT=true mise run check:ghalint`
- `GITHUB_TOKEN="$(gh auth token)" LINT=true mise run check:zizmor`