### PR TITLE
chore(tombi): validate mise task schema

### DIFF
--- a/tasks.toml
+++ b/tasks.toml
@@ -1,3 +1,4 @@
+#:schema https://mise.jdx.dev/schema/mise-task.json
 # ref: https://mise.jdx.dev/tasks/
 
 [build]


### PR DESCRIPTION
## Summary
- restore the mise task schema directive in `tasks.toml`
- leave `tombi.toml` without `schema.strict`, because strict schema checking is already the default

## Verification
- `LINT=true mise run check:tombi`