### PR TITLE
ci(mise): install tools from lockfile

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -36,10 +36,16 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.3
+          install_args: --locked
 
       - name: Re-install Rust
         # cache doesn't work well with rust
-        run: mise install rust --force
+        run: mise install --locked rust --force
+
+      - name: Update mise lockfile
+        if: github.event.pull_request.user.login == 'renovate[bot]'
+        run: mise lock
+        continue-on-error: true
 
       - name: Run autofix
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           filters: |
             ci: &ci
               - 'mise.toml'
+              - 'mise.lock'
               - '.github/workflows/ci.yml'
             build: &build
               - *ci
@@ -94,10 +95,11 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.3
+          install_args: --locked
 
       - name: Re-install Rust
         # cache doesn't work well with rust
-        run: mise install rust --force
+        run: mise install --locked rust --force
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -129,10 +131,11 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.3
+          install_args: --locked
 
       - name: Re-install Rust
         # cache doesn't work well with rust
-        run: mise install rust --force
+        run: mise install --locked rust --force
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -166,6 +169,7 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.3
+          install_args: --locked
 
       - name: Validate schema
         run: mise run schema

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -36,10 +36,11 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.3
+          install_args: --locked
 
       - name: Re-install Rust
         # cache doesn't work well with rust
-        run: mise install rust --force
+        run: mise install --locked rust --force
 
       - name: Create biwa-bot GitHub App token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
@@ -76,10 +77,11 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.3
+          install_args: --locked
 
       - name: Re-install Rust
         # cache doesn't work well with rust
-        run: mise install rust --force
+        run: mise install --locked rust --force
 
       - name: Create biwa-bot GitHub App token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
       - v*
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: release-${{ github.ref }}
   cancel-in-progress: false
 
 permissions: {}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.3
+          install_args: --locked
           cache: ${{ steps.mode.outputs.publishing == 'false' }}
           cache_key: "{{default}}-release"
         env:
@@ -69,7 +70,7 @@ jobs:
       - name: Re-install Rust
         if: steps.install-mise.outputs.cache-hit == 'true'
         # cache doesn't work well with rust
-        run: mise install rust --force
+        run: mise install --locked rust --force
 
       - name: Plan Release
         id: plan
@@ -114,6 +115,7 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.3
+          install_args: --locked
           cache: ${{ needs.plan.outputs.publishing == 'false' }}
           cache_key: "{{default}}-release"
         env:
@@ -122,7 +124,7 @@ jobs:
       - name: Re-install Rust
         if: steps.install-mise.outputs.cache-hit == 'true'
         # cache doesn't work well with rust
-        run: mise install rust --force
+        run: mise install --locked rust --force
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -210,6 +212,7 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.3
+          install_args: --locked
           cache: ${{ needs.plan.outputs.publishing == 'false' }}
           cache_key: "{{default}}-release"
         env:
@@ -218,7 +221,7 @@ jobs:
       - name: Re-install Rust
         if: steps.install-mise.outputs.cache-hit == 'true'
         # cache doesn't work well with rust
-        run: mise install rust --force
+        run: mise install --locked rust --force
 
       - name: Download local artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -280,6 +283,7 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.3
+          install_args: --locked
           cache: false
         env:
           MISE_ENABLE_TOOLS: rust,cargo-dist

--- a/mise.lock
+++ b/mise.lock
@@ -19,17 +19,7 @@ checksum = "sha256:8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a
 url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz"
 provenance = "github-attestations"
 
-[tools.actionlint."platforms.linux-x64-baseline"]
-checksum = "sha256:8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
-url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz"
-provenance = "github-attestations"
-
 [tools.actionlint."platforms.linux-x64-musl"]
-checksum = "sha256:8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
-url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz"
-provenance = "github-attestations"
-
-[tools.actionlint."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
 url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz"
 provenance = "github-attestations"
@@ -42,21 +32,6 @@ provenance = "github-attestations"
 [tools.actionlint."platforms.macos-x64"]
 checksum = "sha256:5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644"
 url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_darwin_amd64.tar.gz"
-provenance = "github-attestations"
-
-[tools.actionlint."platforms.macos-x64-baseline"]
-checksum = "sha256:5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644"
-url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_darwin_amd64.tar.gz"
-provenance = "github-attestations"
-
-[tools.actionlint."platforms.windows-x64"]
-checksum = "sha256:6e7241b51e6817ea6a047693d8e6fed13b31819c9a0dd6c5a726e1592d22f6e9"
-url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_windows_amd64.zip"
-provenance = "github-attestations"
-
-[tools.actionlint."platforms.windows-x64-baseline"]
-checksum = "sha256:6e7241b51e6817ea6a047693d8e6fed13b31819c9a0dd6c5a726e1592d22f6e9"
-url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_windows_amd64.zip"
 provenance = "github-attestations"
 
 [[tools."aqua:EmbarkStudios/cargo-deny"]]
@@ -75,15 +50,7 @@ url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.19.5/carg
 checksum = "sha256:5ea64ae09959b5fe1072d898f95caaa89b374678ba6728d5e9ed1366745479b0"
 url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.19.5/cargo-deny-0.19.5-x86_64-unknown-linux-musl.tar.gz"
 
-[tools."aqua:EmbarkStudios/cargo-deny"."platforms.linux-x64-baseline"]
-checksum = "sha256:5ea64ae09959b5fe1072d898f95caaa89b374678ba6728d5e9ed1366745479b0"
-url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.19.5/cargo-deny-0.19.5-x86_64-unknown-linux-musl.tar.gz"
-
 [tools."aqua:EmbarkStudios/cargo-deny"."platforms.linux-x64-musl"]
-checksum = "sha256:5ea64ae09959b5fe1072d898f95caaa89b374678ba6728d5e9ed1366745479b0"
-url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.19.5/cargo-deny-0.19.5-x86_64-unknown-linux-musl.tar.gz"
-
-[tools."aqua:EmbarkStudios/cargo-deny"."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:5ea64ae09959b5fe1072d898f95caaa89b374678ba6728d5e9ed1366745479b0"
 url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.19.5/cargo-deny-0.19.5-x86_64-unknown-linux-musl.tar.gz"
 
@@ -94,18 +61,6 @@ url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.19.5/carg
 [tools."aqua:EmbarkStudios/cargo-deny"."platforms.macos-x64"]
 checksum = "sha256:36102b6ab83a546036ada57526227317a7827e1788ce39ac6df1c9102b86fa10"
 url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.19.5/cargo-deny-0.19.5-x86_64-apple-darwin.tar.gz"
-
-[tools."aqua:EmbarkStudios/cargo-deny"."platforms.macos-x64-baseline"]
-checksum = "sha256:36102b6ab83a546036ada57526227317a7827e1788ce39ac6df1c9102b86fa10"
-url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.19.5/cargo-deny-0.19.5-x86_64-apple-darwin.tar.gz"
-
-[tools."aqua:EmbarkStudios/cargo-deny"."platforms.windows-x64"]
-checksum = "sha256:390159ef49444b9b0b98ce36b35bc068180103d078b73f0d3d67872eff375e3e"
-url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.19.5/cargo-deny-0.19.5-x86_64-pc-windows-msvc.tar.gz"
-
-[tools."aqua:EmbarkStudios/cargo-deny"."platforms.windows-x64-baseline"]
-checksum = "sha256:390159ef49444b9b0b98ce36b35bc068180103d078b73f0d3d67872eff375e3e"
-url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.19.5/cargo-deny-0.19.5-x86_64-pc-windows-msvc.tar.gz"
 
 [[tools.bun]]
 version = "1.3.13"
@@ -147,14 +102,6 @@ url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.13/bun-darwin-x
 checksum = "sha256:a98ba6a480f22fda9b343626b906a4e26aa53618bf85d2bc5928ecf2ba45f0ed"
 url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.13/bun-darwin-x64-baseline.zip"
 
-[tools.bun."platforms.windows-x64"]
-checksum = "sha256:85b14f3e0584218e9b63407b3aa6b90c4835ec5c32435c1f12cb6fc13667c7c9"
-url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.13/bun-windows-x64.zip"
-
-[tools.bun."platforms.windows-x64-baseline"]
-checksum = "sha256:c68c7903c1190101590cc1b2129835f47211b3b37ae87759f2b97d6534aa3ad1"
-url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.13/bun-windows-x64-baseline.zip"
-
 [[tools.cargo-dist]]
 version = "0.31.0"
 backend = "aqua:axodotdev/cargo-dist"
@@ -174,17 +121,7 @@ checksum = "sha256:1d46b93a785e8b666c0e7add581d747d53c3f29589cc3ef9aee60341ad899
 url = "https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-x86_64-unknown-linux-musl.tar.xz"
 provenance = "github-attestations"
 
-[tools.cargo-dist."platforms.linux-x64-baseline"]
-checksum = "sha256:1d46b93a785e8b666c0e7add581d747d53c3f29589cc3ef9aee60341ad899023"
-url = "https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-x86_64-unknown-linux-musl.tar.xz"
-provenance = "github-attestations"
-
 [tools.cargo-dist."platforms.linux-x64-musl"]
-checksum = "sha256:1d46b93a785e8b666c0e7add581d747d53c3f29589cc3ef9aee60341ad899023"
-url = "https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-x86_64-unknown-linux-musl.tar.xz"
-provenance = "github-attestations"
-
-[tools.cargo-dist."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:1d46b93a785e8b666c0e7add581d747d53c3f29589cc3ef9aee60341ad899023"
 url = "https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-x86_64-unknown-linux-musl.tar.xz"
 provenance = "github-attestations"
@@ -197,21 +134,6 @@ provenance = "github-attestations"
 [tools.cargo-dist."platforms.macos-x64"]
 checksum = "sha256:fd4d8f9f07802359cbcdc52bac3abd7d5201c4b73a7cbcdd6faca2232a389f0c"
 url = "https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-x86_64-apple-darwin.tar.xz"
-provenance = "github-attestations"
-
-[tools.cargo-dist."platforms.macos-x64-baseline"]
-checksum = "sha256:fd4d8f9f07802359cbcdc52bac3abd7d5201c4b73a7cbcdd6faca2232a389f0c"
-url = "https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-x86_64-apple-darwin.tar.xz"
-provenance = "github-attestations"
-
-[tools.cargo-dist."platforms.windows-x64"]
-checksum = "sha256:a14e17557b269b101405e0cc6b647581d56313c954a51c7fddd423bba21e17b2"
-url = "https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-x86_64-pc-windows-msvc.zip"
-provenance = "github-attestations"
-
-[tools.cargo-dist."platforms.windows-x64-baseline"]
-checksum = "sha256:a14e17557b269b101405e0cc6b647581d56313c954a51c7fddd423bba21e17b2"
-url = "https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-x86_64-pc-windows-msvc.zip"
 provenance = "github-attestations"
 
 [[tools.ghalint]]
@@ -239,25 +161,11 @@ url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/ghali
 [tools.ghalint."platforms.linux-x64".provenance.slsa]
 url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/multiple.intoto.jsonl"
 
-[tools.ghalint."platforms.linux-x64-baseline"]
-checksum = "sha256:98ee0e3330de7286f470d1e89c03ff7ce70d7a5998ba0f15969c400447be579c"
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/ghalint_1.5.6_linux_amd64.tar.gz"
-
-[tools.ghalint."platforms.linux-x64-baseline".provenance.slsa]
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/multiple.intoto.jsonl"
-
 [tools.ghalint."platforms.linux-x64-musl"]
 checksum = "sha256:98ee0e3330de7286f470d1e89c03ff7ce70d7a5998ba0f15969c400447be579c"
 url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/ghalint_1.5.6_linux_amd64.tar.gz"
 
 [tools.ghalint."platforms.linux-x64-musl".provenance.slsa]
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/multiple.intoto.jsonl"
-
-[tools.ghalint."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:98ee0e3330de7286f470d1e89c03ff7ce70d7a5998ba0f15969c400447be579c"
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/ghalint_1.5.6_linux_amd64.tar.gz"
-
-[tools.ghalint."platforms.linux-x64-musl-baseline".provenance.slsa]
 url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/multiple.intoto.jsonl"
 
 [tools.ghalint."platforms.macos-arm64"]
@@ -272,27 +180,6 @@ checksum = "sha256:d2a0e8605333068065dcf4c9b7b7a24891eda1750ac01fb755dfba426a390
 url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/ghalint_1.5.6_darwin_amd64.tar.gz"
 
 [tools.ghalint."platforms.macos-x64".provenance.slsa]
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/multiple.intoto.jsonl"
-
-[tools.ghalint."platforms.macos-x64-baseline"]
-checksum = "sha256:d2a0e8605333068065dcf4c9b7b7a24891eda1750ac01fb755dfba426a390883"
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/ghalint_1.5.6_darwin_amd64.tar.gz"
-
-[tools.ghalint."platforms.macos-x64-baseline".provenance.slsa]
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/multiple.intoto.jsonl"
-
-[tools.ghalint."platforms.windows-x64"]
-checksum = "sha256:109ea9b39c8e263cef924bd3b4fe5505964204f934ca60d986f4090d01a99ba5"
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/ghalint_1.5.6_windows_amd64.zip"
-
-[tools.ghalint."platforms.windows-x64".provenance.slsa]
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/multiple.intoto.jsonl"
-
-[tools.ghalint."platforms.windows-x64-baseline"]
-checksum = "sha256:109ea9b39c8e263cef924bd3b4fe5505964204f934ca60d986f4090d01a99ba5"
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/ghalint_1.5.6_windows_amd64.zip"
-
-[tools.ghalint."platforms.windows-x64-baseline".provenance.slsa]
 url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/multiple.intoto.jsonl"
 
 [[tools."github:xd009642/tarpaulin"]]
@@ -314,17 +201,7 @@ checksum = "sha256:e8a6bb8b8588ff8169b2881d12fc57d021bccb538803bc5237e6785aafad0
 url = "https://github.com/xd009642/tarpaulin/releases/download/0.35.4/cargo-tarpaulin-x86_64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/xd009642/tarpaulin/releases/assets/405218689"
 
-[tools."github:xd009642/tarpaulin"."platforms.linux-x64-baseline"]
-checksum = "sha256:e8a6bb8b8588ff8169b2881d12fc57d021bccb538803bc5237e6785aafad052a"
-url = "https://github.com/xd009642/tarpaulin/releases/download/0.35.4/cargo-tarpaulin-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/xd009642/tarpaulin/releases/assets/405218689"
-
 [tools."github:xd009642/tarpaulin"."platforms.linux-x64-musl"]
-checksum = "sha256:bc60f0668389edd48b112c4ecc7374d3180f522cf933b7fcb3486a447f24aef8"
-url = "https://github.com/xd009642/tarpaulin/releases/download/0.35.4/cargo-tarpaulin-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/xd009642/tarpaulin/releases/assets/405219784"
-
-[tools."github:xd009642/tarpaulin"."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:bc60f0668389edd48b112c4ecc7374d3180f522cf933b7fcb3486a447f24aef8"
 url = "https://github.com/xd009642/tarpaulin/releases/download/0.35.4/cargo-tarpaulin-x86_64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/xd009642/tarpaulin/releases/assets/405219784"
@@ -338,21 +215,6 @@ url_api = "https://api.github.com/repos/xd009642/tarpaulin/releases/assets/40521
 checksum = "sha256:a48eb40fc541a440ac0e62a22bfb7984819a1409591b4ce7e20d3d1a01625e96"
 url = "https://github.com/xd009642/tarpaulin/releases/download/0.35.4/cargo-tarpaulin-x86_64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/xd009642/tarpaulin/releases/assets/405218940"
-
-[tools."github:xd009642/tarpaulin"."platforms.macos-x64-baseline"]
-checksum = "sha256:a48eb40fc541a440ac0e62a22bfb7984819a1409591b4ce7e20d3d1a01625e96"
-url = "https://github.com/xd009642/tarpaulin/releases/download/0.35.4/cargo-tarpaulin-x86_64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/xd009642/tarpaulin/releases/assets/405218940"
-
-[tools."github:xd009642/tarpaulin"."platforms.windows-x64"]
-checksum = "sha256:6d51cfca33da65079392c55b2506705f8dcf518337a9a68f619d4de14c5aa5e6"
-url = "https://github.com/xd009642/tarpaulin/releases/download/0.35.4/cargo-tarpaulin-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/xd009642/tarpaulin/releases/assets/405218912"
-
-[tools."github:xd009642/tarpaulin"."platforms.windows-x64-baseline"]
-checksum = "sha256:6d51cfca33da65079392c55b2506705f8dcf518337a9a68f619d4de14c5aa5e6"
-url = "https://github.com/xd009642/tarpaulin/releases/download/0.35.4/cargo-tarpaulin-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/xd009642/tarpaulin/releases/assets/405218912"
 
 [[tools."npm:ajv-cli"]]
 version = "5.0.0"
@@ -385,17 +247,7 @@ checksum = "sha256:6adcc8a2217e4114e0841f8bca0cddf9958a9c52e3e89760c35b791cdba1a
 url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.2/pinact_linux_amd64.tar.gz"
 provenance = "github-attestations"
 
-[tools.pinact."platforms.linux-x64-baseline"]
-checksum = "sha256:6adcc8a2217e4114e0841f8bca0cddf9958a9c52e3e89760c35b791cdba1a916"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.2/pinact_linux_amd64.tar.gz"
-provenance = "github-attestations"
-
 [tools.pinact."platforms.linux-x64-musl"]
-checksum = "sha256:6adcc8a2217e4114e0841f8bca0cddf9958a9c52e3e89760c35b791cdba1a916"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.2/pinact_linux_amd64.tar.gz"
-provenance = "github-attestations"
-
-[tools.pinact."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:6adcc8a2217e4114e0841f8bca0cddf9958a9c52e3e89760c35b791cdba1a916"
 url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.2/pinact_linux_amd64.tar.gz"
 provenance = "github-attestations"
@@ -410,21 +262,6 @@ checksum = "sha256:5facbcd8cd4e20fb88c4ef3ace9c54b7d295735563634ef4373694cd286be
 url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.2/pinact_darwin_amd64.tar.gz"
 provenance = "github-attestations"
 
-[tools.pinact."platforms.macos-x64-baseline"]
-checksum = "sha256:5facbcd8cd4e20fb88c4ef3ace9c54b7d295735563634ef4373694cd286be67a"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.2/pinact_darwin_amd64.tar.gz"
-provenance = "github-attestations"
-
-[tools.pinact."platforms.windows-x64"]
-checksum = "sha256:a7f82e352eb4f706addfb864a7c4853f34bdcfc604ebef8733adecbbbacaaeef"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.2/pinact_windows_amd64.zip"
-provenance = "github-attestations"
-
-[tools.pinact."platforms.windows-x64-baseline"]
-checksum = "sha256:a7f82e352eb4f706addfb864a7c4853f34bdcfc604ebef8733adecbbbacaaeef"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.2/pinact_windows_amd64.zip"
-provenance = "github-attestations"
-
 [[tools.pitchfork]]
 version = "2.10.0"
 backend = "aqua:jdx/pitchfork"
@@ -437,21 +274,9 @@ url = "https://github.com/endevco/pitchfork/releases/download/v2.10.0/pitchfork-
 checksum = "sha256:a6a09cce0b08135cdb884b6c70c7413bd3991f03c084bdc11bf778bb274116c4"
 url = "https://github.com/endevco/pitchfork/releases/download/v2.10.0/pitchfork-x86_64-unknown-linux-gnu.tar.gz"
 
-[tools.pitchfork."platforms.linux-x64-baseline"]
-checksum = "sha256:a6a09cce0b08135cdb884b6c70c7413bd3991f03c084bdc11bf778bb274116c4"
-url = "https://github.com/endevco/pitchfork/releases/download/v2.10.0/pitchfork-x86_64-unknown-linux-gnu.tar.gz"
-
 [tools.pitchfork."platforms.macos-arm64"]
 checksum = "sha256:94427b1ce42709003f9db48d14b073bde807f41bfa034b54ccca7067b5234a4f"
 url = "https://github.com/endevco/pitchfork/releases/download/v2.10.0/pitchfork-aarch64-apple-darwin.tar.gz"
-
-[tools.pitchfork."platforms.windows-x64"]
-checksum = "sha256:659b3c483ee0518de1f54bfb735aebbc696ff96a1c60549131cf49fb0521ba80"
-url = "https://github.com/endevco/pitchfork/releases/download/v2.10.0/pitchfork-x86_64-pc-windows-msvc.zip"
-
-[tools.pitchfork."platforms.windows-x64-baseline"]
-checksum = "sha256:659b3c483ee0518de1f54bfb735aebbc696ff96a1c60549131cf49fb0521ba80"
-url = "https://github.com/endevco/pitchfork/releases/download/v2.10.0/pitchfork-x86_64-pc-windows-msvc.zip"
 
 [[tools.release-plz]]
 version = "0.3.157"
@@ -469,29 +294,13 @@ url = "https://github.com/release-plz/release-plz/releases/download/release-plz-
 checksum = "sha256:2fc44a3c68e6bf4eaf761926c6c3b2971d6eaef8ffd2420640ac2f2f22e12c51"
 url = "https://github.com/release-plz/release-plz/releases/download/release-plz-v0.3.157/release-plz-x86_64-unknown-linux-musl.tar.gz"
 
-[tools.release-plz."platforms.linux-x64-baseline"]
-checksum = "sha256:2fc44a3c68e6bf4eaf761926c6c3b2971d6eaef8ffd2420640ac2f2f22e12c51"
-url = "https://github.com/release-plz/release-plz/releases/download/release-plz-v0.3.157/release-plz-x86_64-unknown-linux-musl.tar.gz"
-
 [tools.release-plz."platforms.linux-x64-musl"]
-checksum = "sha256:2fc44a3c68e6bf4eaf761926c6c3b2971d6eaef8ffd2420640ac2f2f22e12c51"
-url = "https://github.com/release-plz/release-plz/releases/download/release-plz-v0.3.157/release-plz-x86_64-unknown-linux-musl.tar.gz"
-
-[tools.release-plz."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:2fc44a3c68e6bf4eaf761926c6c3b2971d6eaef8ffd2420640ac2f2f22e12c51"
 url = "https://github.com/release-plz/release-plz/releases/download/release-plz-v0.3.157/release-plz-x86_64-unknown-linux-musl.tar.gz"
 
 [tools.release-plz."platforms.macos-arm64"]
 checksum = "sha256:0006b843fd25e11b4aec073a6feb5e9b1be27702863504bef1432c39b795b52c"
 url = "https://github.com/release-plz/release-plz/releases/download/release-plz-v0.3.157/release-plz-aarch64-apple-darwin.tar.gz"
-
-[tools.release-plz."platforms.windows-x64"]
-checksum = "sha256:02594d6e5a62849c89547209e6a47e9565e0b53764e0875d0c5399259570bb11"
-url = "https://github.com/release-plz/release-plz/releases/download/release-plz-v0.3.157/release-plz-x86_64-pc-windows-msvc.tar.gz"
-
-[tools.release-plz."platforms.windows-x64-baseline"]
-checksum = "sha256:02594d6e5a62849c89547209e6a47e9565e0b53764e0875d0c5399259570bb11"
-url = "https://github.com/release-plz/release-plz/releases/download/release-plz-v0.3.157/release-plz-x86_64-pc-windows-msvc.tar.gz"
 
 [[tools.rust]]
 version = "1.95.0"
@@ -513,15 +322,7 @@ url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellche
 checksum = "sha256:8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198"
 url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz"
 
-[tools.shellcheck."platforms.linux-x64-baseline"]
-checksum = "sha256:8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198"
-url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz"
-
 [tools.shellcheck."platforms.linux-x64-musl"]
-checksum = "sha256:8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198"
-url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz"
-
-[tools.shellcheck."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198"
 url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz"
 
@@ -532,18 +333,6 @@ url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellche
 [tools.shellcheck."platforms.macos-x64"]
 checksum = "sha256:3c89db4edcab7cf1c27bff178882e0f6f27f7afdf54e859fa041fca10febe4c6"
 url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.x86_64.tar.xz"
-
-[tools.shellcheck."platforms.macos-x64-baseline"]
-checksum = "sha256:3c89db4edcab7cf1c27bff178882e0f6f27f7afdf54e859fa041fca10febe4c6"
-url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.x86_64.tar.xz"
-
-[tools.shellcheck."platforms.windows-x64"]
-checksum = "sha256:8a4e35ab0b331c85d73567b12f2a444df187f483e5079ceffa6bda1faa2e740e"
-url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.zip"
-
-[tools.shellcheck."platforms.windows-x64-baseline"]
-checksum = "sha256:8a4e35ab0b331c85d73567b12f2a444df187f483e5079ceffa6bda1faa2e740e"
-url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.zip"
 
 [[tools.tombi]]
 version = "0.11.1"
@@ -561,15 +350,7 @@ url = "https://github.com/tombi-toml/tombi/releases/download/v0.11.1/tombi-cli-0
 checksum = "sha256:827a8de6959b37b28e9a4d2dc3bfdb28e647d6de690d81a9a6751afabaa73763"
 url = "https://github.com/tombi-toml/tombi/releases/download/v0.11.1/tombi-cli-0.11.1-x86_64-unknown-linux-musl.tar.gz"
 
-[tools.tombi."platforms.linux-x64-baseline"]
-checksum = "sha256:827a8de6959b37b28e9a4d2dc3bfdb28e647d6de690d81a9a6751afabaa73763"
-url = "https://github.com/tombi-toml/tombi/releases/download/v0.11.1/tombi-cli-0.11.1-x86_64-unknown-linux-musl.tar.gz"
-
 [tools.tombi."platforms.linux-x64-musl"]
-checksum = "sha256:827a8de6959b37b28e9a4d2dc3bfdb28e647d6de690d81a9a6751afabaa73763"
-url = "https://github.com/tombi-toml/tombi/releases/download/v0.11.1/tombi-cli-0.11.1-x86_64-unknown-linux-musl.tar.gz"
-
-[tools.tombi."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:827a8de6959b37b28e9a4d2dc3bfdb28e647d6de690d81a9a6751afabaa73763"
 url = "https://github.com/tombi-toml/tombi/releases/download/v0.11.1/tombi-cli-0.11.1-x86_64-unknown-linux-musl.tar.gz"
 
@@ -580,18 +361,6 @@ url = "https://github.com/tombi-toml/tombi/releases/download/v0.11.1/tombi-cli-0
 [tools.tombi."platforms.macos-x64"]
 checksum = "sha256:c9245de0d601154d01e0cd6d57f0b92465b1fa03f95221faca13a929b1e4648e"
 url = "https://github.com/tombi-toml/tombi/releases/download/v0.11.1/tombi-cli-0.11.1-x86_64-apple-darwin.tar.gz"
-
-[tools.tombi."platforms.macos-x64-baseline"]
-checksum = "sha256:c9245de0d601154d01e0cd6d57f0b92465b1fa03f95221faca13a929b1e4648e"
-url = "https://github.com/tombi-toml/tombi/releases/download/v0.11.1/tombi-cli-0.11.1-x86_64-apple-darwin.tar.gz"
-
-[tools.tombi."platforms.windows-x64"]
-checksum = "sha256:ad90d99ed4a525b820afeb414946e9bfe20770913d1975da04f57a350729e7d4"
-url = "https://github.com/tombi-toml/tombi/releases/download/v0.11.1/tombi-cli-0.11.1-x86_64-pc-windows-msvc.zip"
-
-[tools.tombi."platforms.windows-x64-baseline"]
-checksum = "sha256:ad90d99ed4a525b820afeb414946e9bfe20770913d1975da04f57a350729e7d4"
-url = "https://github.com/tombi-toml/tombi/releases/download/v0.11.1/tombi-cli-0.11.1-x86_64-pc-windows-msvc.zip"
 
 [[tools.typos]]
 version = "1.46.1"
@@ -609,15 +378,7 @@ url = "https://github.com/crate-ci/typos/releases/download/v1.46.1/typos-v1.46.1
 checksum = "sha256:c574fa505596922ba2e7b1027a0a5b2df528f399b86b6915d85748186a65ca44"
 url = "https://github.com/crate-ci/typos/releases/download/v1.46.1/typos-v1.46.1-x86_64-unknown-linux-musl.tar.gz"
 
-[tools.typos."platforms.linux-x64-baseline"]
-checksum = "sha256:c574fa505596922ba2e7b1027a0a5b2df528f399b86b6915d85748186a65ca44"
-url = "https://github.com/crate-ci/typos/releases/download/v1.46.1/typos-v1.46.1-x86_64-unknown-linux-musl.tar.gz"
-
 [tools.typos."platforms.linux-x64-musl"]
-checksum = "sha256:c574fa505596922ba2e7b1027a0a5b2df528f399b86b6915d85748186a65ca44"
-url = "https://github.com/crate-ci/typos/releases/download/v1.46.1/typos-v1.46.1-x86_64-unknown-linux-musl.tar.gz"
-
-[tools.typos."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:c574fa505596922ba2e7b1027a0a5b2df528f399b86b6915d85748186a65ca44"
 url = "https://github.com/crate-ci/typos/releases/download/v1.46.1/typos-v1.46.1-x86_64-unknown-linux-musl.tar.gz"
 
@@ -628,18 +389,6 @@ url = "https://github.com/crate-ci/typos/releases/download/v1.46.1/typos-v1.46.1
 [tools.typos."platforms.macos-x64"]
 checksum = "sha256:bc585c22f2c4f5963ad782df1d4764a91476d3079477a08833ff87dfa416bb72"
 url = "https://github.com/crate-ci/typos/releases/download/v1.46.1/typos-v1.46.1-x86_64-apple-darwin.tar.gz"
-
-[tools.typos."platforms.macos-x64-baseline"]
-checksum = "sha256:bc585c22f2c4f5963ad782df1d4764a91476d3079477a08833ff87dfa416bb72"
-url = "https://github.com/crate-ci/typos/releases/download/v1.46.1/typos-v1.46.1-x86_64-apple-darwin.tar.gz"
-
-[tools.typos."platforms.windows-x64"]
-checksum = "sha256:a7b042fc79bf7b73b00ece054ec3109858e001136c2642f28004544b571d37a2"
-url = "https://github.com/crate-ci/typos/releases/download/v1.46.1/typos-v1.46.1-x86_64-pc-windows-msvc.zip"
-
-[tools.typos."platforms.windows-x64-baseline"]
-checksum = "sha256:a7b042fc79bf7b73b00ece054ec3109858e001136c2642f28004544b571d37a2"
-url = "https://github.com/crate-ci/typos/releases/download/v1.46.1/typos-v1.46.1-x86_64-pc-windows-msvc.zip"
 
 [[tools.usage]]
 version = "3.3.0"
@@ -657,15 +406,7 @@ url = "https://github.com/jdx/usage/releases/download/v3.3.0/usage-aarch64-unkno
 checksum = "sha256:9a4316d633243aa54308ff3bf6970923b18c105dea34fbc3009d51889e1dd03f"
 url = "https://github.com/jdx/usage/releases/download/v3.3.0/usage-x86_64-unknown-linux-musl.tar.gz"
 
-[tools.usage."platforms.linux-x64-baseline"]
-checksum = "sha256:9a4316d633243aa54308ff3bf6970923b18c105dea34fbc3009d51889e1dd03f"
-url = "https://github.com/jdx/usage/releases/download/v3.3.0/usage-x86_64-unknown-linux-musl.tar.gz"
-
 [tools.usage."platforms.linux-x64-musl"]
-checksum = "sha256:9a4316d633243aa54308ff3bf6970923b18c105dea34fbc3009d51889e1dd03f"
-url = "https://github.com/jdx/usage/releases/download/v3.3.0/usage-x86_64-unknown-linux-musl.tar.gz"
-
-[tools.usage."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:9a4316d633243aa54308ff3bf6970923b18c105dea34fbc3009d51889e1dd03f"
 url = "https://github.com/jdx/usage/releases/download/v3.3.0/usage-x86_64-unknown-linux-musl.tar.gz"
 
@@ -676,18 +417,6 @@ url = "https://github.com/jdx/usage/releases/download/v3.3.0/usage-universal-app
 [tools.usage."platforms.macos-x64"]
 checksum = "sha256:ab6c69a6541e18ffca7bd950dd4cc867ea9267d0f91115c13aa650cde6634d62"
 url = "https://github.com/jdx/usage/releases/download/v3.3.0/usage-universal-apple-darwin.tar.gz"
-
-[tools.usage."platforms.macos-x64-baseline"]
-checksum = "sha256:ab6c69a6541e18ffca7bd950dd4cc867ea9267d0f91115c13aa650cde6634d62"
-url = "https://github.com/jdx/usage/releases/download/v3.3.0/usage-universal-apple-darwin.tar.gz"
-
-[tools.usage."platforms.windows-x64"]
-checksum = "sha256:628b8743d552f2cff2dee2b783a4827ef555409def3fb9ec536117d96cda2018"
-url = "https://github.com/jdx/usage/releases/download/v3.3.0/usage-x86_64-pc-windows-msvc.zip"
-
-[tools.usage."platforms.windows-x64-baseline"]
-checksum = "sha256:628b8743d552f2cff2dee2b783a4827ef555409def3fb9ec536117d96cda2018"
-url = "https://github.com/jdx/usage/releases/download/v3.3.0/usage-x86_64-pc-windows-msvc.zip"
 
 [[tools.uv]]
 version = "0.11.12"
@@ -708,17 +437,7 @@ checksum = "sha256:591a7557f5ba7e51565f338dd4c50cebc12820ec2ebb8403a4304685f8d53
 url = "https://github.com/astral-sh/uv/releases/download/0.11.12/uv-x86_64-unknown-linux-musl.tar.gz"
 provenance = "github-attestations"
 
-[tools.uv."platforms.linux-x64-baseline"]
-checksum = "sha256:591a7557f5ba7e51565f338dd4c50cebc12820ec2ebb8403a4304685f8d53ab9"
-url = "https://github.com/astral-sh/uv/releases/download/0.11.12/uv-x86_64-unknown-linux-musl.tar.gz"
-provenance = "github-attestations"
-
 [tools.uv."platforms.linux-x64-musl"]
-checksum = "sha256:591a7557f5ba7e51565f338dd4c50cebc12820ec2ebb8403a4304685f8d53ab9"
-url = "https://github.com/astral-sh/uv/releases/download/0.11.12/uv-x86_64-unknown-linux-musl.tar.gz"
-provenance = "github-attestations"
-
-[tools.uv."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:591a7557f5ba7e51565f338dd4c50cebc12820ec2ebb8403a4304685f8d53ab9"
 url = "https://github.com/astral-sh/uv/releases/download/0.11.12/uv-x86_64-unknown-linux-musl.tar.gz"
 provenance = "github-attestations"
@@ -731,21 +450,6 @@ provenance = "github-attestations"
 [tools.uv."platforms.macos-x64"]
 checksum = "sha256:32fb217e6181384bf6534b31adcc66cd552eff98643c4bb35832be8552486912"
 url = "https://github.com/astral-sh/uv/releases/download/0.11.12/uv-x86_64-apple-darwin.tar.gz"
-provenance = "github-attestations"
-
-[tools.uv."platforms.macos-x64-baseline"]
-checksum = "sha256:32fb217e6181384bf6534b31adcc66cd552eff98643c4bb35832be8552486912"
-url = "https://github.com/astral-sh/uv/releases/download/0.11.12/uv-x86_64-apple-darwin.tar.gz"
-provenance = "github-attestations"
-
-[tools.uv."platforms.windows-x64"]
-checksum = "sha256:e46956a6b088a0382101c797eef945c1b03826e629e968d434cf838d42d85b6b"
-url = "https://github.com/astral-sh/uv/releases/download/0.11.12/uv-x86_64-pc-windows-msvc.zip"
-provenance = "github-attestations"
-
-[tools.uv."platforms.windows-x64-baseline"]
-checksum = "sha256:e46956a6b088a0382101c797eef945c1b03826e629e968d434cf838d42d85b6b"
-url = "https://github.com/astral-sh/uv/releases/download/0.11.12/uv-x86_64-pc-windows-msvc.zip"
 provenance = "github-attestations"
 
 [[tools.yamllint]]
@@ -768,15 +472,7 @@ url = "https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_arm64"
 checksum = "sha256:d56bf5c6819e8e696340c312bd70f849dc1678a7cda9c2ad63eebd906371d56b"
 url = "https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64"
 
-[tools.yq."platforms.linux-x64-baseline"]
-checksum = "sha256:d56bf5c6819e8e696340c312bd70f849dc1678a7cda9c2ad63eebd906371d56b"
-url = "https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64"
-
 [tools.yq."platforms.linux-x64-musl"]
-checksum = "sha256:d56bf5c6819e8e696340c312bd70f849dc1678a7cda9c2ad63eebd906371d56b"
-url = "https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64"
-
-[tools.yq."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:d56bf5c6819e8e696340c312bd70f849dc1678a7cda9c2ad63eebd906371d56b"
 url = "https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64"
 
@@ -787,18 +483,6 @@ url = "https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_darwin_arm64
 [tools.yq."platforms.macos-x64"]
 checksum = "sha256:616b0a0f6a5b79d746f05a169c2b9bb40dee00c605ef165b9a1c1681bba738ac"
 url = "https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_darwin_amd64"
-
-[tools.yq."platforms.macos-x64-baseline"]
-checksum = "sha256:616b0a0f6a5b79d746f05a169c2b9bb40dee00c605ef165b9a1c1681bba738ac"
-url = "https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_darwin_amd64"
-
-[tools.yq."platforms.windows-x64"]
-checksum = "sha256:2aee32f1de46a20672f48c25df3018839798bd509143f2ce05fdab1550ff5592"
-url = "https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_windows_amd64.exe"
-
-[tools.yq."platforms.windows-x64-baseline"]
-checksum = "sha256:2aee32f1de46a20672f48c25df3018839798bd509143f2ce05fdab1550ff5592"
-url = "https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_windows_amd64.exe"
 
 [[tools.zizmor]]
 version = "1.24.1"
@@ -817,15 +501,7 @@ checksum = "sha256:a8000f3c683319a523d3b20df0e75457ba591f049cfcbfa98966631b56733
 url = "https://github.com/zizmorcore/zizmor/releases/download/v1.24.1/zizmor-x86_64-unknown-linux-gnu.tar.gz"
 provenance = "github-attestations"
 
-[tools.zizmor."platforms.linux-x64-baseline"]
-checksum = "sha256:a8000f3c683319a523d3b20df0e75457ba591f049cfcbfa98966631b56733c03"
-url = "https://github.com/zizmorcore/zizmor/releases/download/v1.24.1/zizmor-x86_64-unknown-linux-gnu.tar.gz"
-provenance = "github-attestations"
-
 [tools.zizmor."platforms.linux-x64-musl"]
-provenance = "github-attestations"
-
-[tools.zizmor."platforms.linux-x64-musl-baseline"]
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.macos-arm64"]
@@ -836,19 +512,4 @@ provenance = "github-attestations"
 [tools.zizmor."platforms.macos-x64"]
 checksum = "sha256:721ba70d7fca753aeef1a4ee959a9bc20c55784d4faa6c56e66129a2611fd52f"
 url = "https://github.com/zizmorcore/zizmor/releases/download/v1.24.1/zizmor-x86_64-apple-darwin.tar.gz"
-provenance = "github-attestations"
-
-[tools.zizmor."platforms.macos-x64-baseline"]
-checksum = "sha256:721ba70d7fca753aeef1a4ee959a9bc20c55784d4faa6c56e66129a2611fd52f"
-url = "https://github.com/zizmorcore/zizmor/releases/download/v1.24.1/zizmor-x86_64-apple-darwin.tar.gz"
-provenance = "github-attestations"
-
-[tools.zizmor."platforms.windows-x64"]
-checksum = "sha256:b777ec2cb1098139ba74b32e30d11ed149c69ab692d23788c466d4a31704bd4b"
-url = "https://github.com/zizmorcore/zizmor/releases/download/v1.24.1/zizmor-x86_64-pc-windows-msvc.zip"
-provenance = "github-attestations"
-
-[tools.zizmor."platforms.windows-x64-baseline"]
-checksum = "sha256:b777ec2cb1098139ba74b32e30d11ed149c69ab692d23788c466d4a31704bd4b"
-url = "https://github.com/zizmorcore/zizmor/releases/download/v1.24.1/zizmor-x86_64-pc-windows-msvc.zip"
 provenance = "github-attestations"

--- a/mise.toml
+++ b/mise.toml
@@ -25,6 +25,14 @@ yq = "4.53.2"
 
 [settings]
 experimental = true
+lockfile_platforms = [
+	"linux-arm64",
+	"linux-arm64-musl",
+	"linux-x64",
+	"linux-x64-musl",
+	"macos-arm64",
+	"macos-x64",
+]
 
 [env]
 '_'.path = ["target/debug/"]


### PR DESCRIPTION
## Summary
- install mise-managed tools with `--locked` in CI, autofix, release-plz, and release workflows
- re-run `mise lock` in autofix only for Renovate PRs, with errors tolerated so autofix can still commit other fixes
- scope mise lockfile platforms to Linux and macOS and regenerate `mise.lock` without Windows entries
- include `mise.lock` in CI path filtering
- isolate Release workflow concurrency so PR CI can run the reusable release build visibly

## Notes
- Renovate detection uses `github.event.pull_request.user.login == "renovate[bot]"`; `github.actor` was rejected by zizmor as spoofable for this bot check.
- `mise lock` is required for Renovate because Renovate does not yet update mise lockfiles.

## Verification
- `mise install --locked --dry-run`
- `mise install --locked rust --force --dry-run`
- `mise lock --dry-run`
- `LINT=true mise run check:actionlint`
- `LINT=true mise run check:pinact`
- `GITHUB_TOKEN="$(gh auth token)" LINT=true mise run check:zizmor`
- `LINT=true mise run check:ghalint`
- `LINT=true mise run check:yamllint`
- `LINT=true mise run check:tombi`
- `LINT=true mise run check:oxfmt`