### PR TITLE
fix: use git root as default sync root

### DIFF
--- a/biwa.usage.kdl
+++ b/biwa.usage.kdl
@@ -13,9 +13,10 @@ cmd run help="Run commands on remote host" {
     alias r
     flag --skip-sync help="Skip automatic synchronization before running the command (automatically set if --remote-dir is used)"
     flag --sync help="Force automatic synchronization before running the command"
-    flag --sync-root help="Base directory to start the synchronization from. Overrides the current working directory" {
+    flag --sync-root help="Base directory to start the synchronization from. Overrides the default sync root" {
         arg <SYNC_ROOT>
     }
+    flag --sync-cwd help="Use the current working directory as the default sync root instead of the nearest Git root"
     flag "-d --remote-dir" help="Override the remote project directory path. Bypasses the default `remote_root` + project name" {
         arg <REMOTE_DIR>
     }
@@ -34,9 +35,10 @@ cmd run help="Run commands on remote host" {
 }
 cmd sync help="Synchronize files to remote host" {
     alias s
-    flag --sync-root help="Base directory to start the synchronization from. Overrides the current working directory" {
+    flag --sync-root help="Base directory to start the synchronization from. Overrides the default sync root" {
         arg <SYNC_ROOT>
     }
+    flag --sync-cwd help="Use the current working directory as the default sync root instead of the nearest Git root"
     flag "-d --remote-dir" help="Override the remote project directory path. Bypasses the default `remote_root` + project name" {
         arg <REMOTE_DIR>
     }

--- a/docs/src/cli/run.md
+++ b/docs/src/cli/run.md
@@ -28,7 +28,11 @@ Force automatic synchronization before running the command
 
 ### `--sync-root <SYNC_ROOT>`
 
-Base directory to start the synchronization from. Overrides the current working directory
+Base directory to start the synchronization from. Overrides the default sync root
+
+### `--sync-cwd`
+
+Use the current working directory as the default sync root instead of the nearest Git root
 
 ### `-d --remote-dir <REMOTE_DIR>`
 

--- a/docs/src/cli/sync.md
+++ b/docs/src/cli/sync.md
@@ -10,7 +10,11 @@ Synchronize files to remote host
 
 ### `--sync-root <SYNC_ROOT>`
 
-Base directory to start the synchronization from. Overrides the current working directory
+Base directory to start the synchronization from. Overrides the default sync root
+
+### `--sync-cwd`
+
+Use the current working directory as the default sync root instead of the nearest Git root
 
 ### `-d --remote-dir <REMOTE_DIR>`
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -77,13 +77,14 @@ Storing your password in a configuration file is **not recommended** for securit
 
 ### `[sync]` — Synchronization Settings
 
-| Key           | Type    | Default                                                | Description                                                                                 |
-| ------------- | ------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
-| `auto`        | boolean | `true`                                                 | Automatically synchronize the project before running remote commands                        |
-| `sync_root`   | string? | `null`                                                 | Base directory to start the synchronization from. If not specified, uses current directory. |
-| `engine`      | string  | `"sftp"`                                               | The synchronization engine to use (`"sftp"` or `"mutagen"`)                                 |
-| `remote_root` | string  | `"~/.cache/biwa/projects"`                             | Remote directory to sync the project to                                                     |
-| `exclude`     | array   | `["**/.git/**", "**/target/**", "**/node_modules/**"]` | List of target strings (using globset) to exclude during synchronization                    |
+| Key                   | Type    | Default                                                | Description                                                                   |
+| --------------------- | ------- | ------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| `auto`                | boolean | `true`                                                 | Automatically synchronize the project before running remote commands          |
+| `sync_root`           | string? | `null`                                                 | Base directory to start the synchronization from                              |
+| `default_to_git_root` | boolean | `true`                                                 | Use the nearest Git root as the default sync root when `sync_root` is not set |
+| `engine`              | string  | `"sftp"`                                               | The synchronization engine to use (`"sftp"` or `"mutagen"`)                   |
+| `remote_root`         | string  | `"~/.cache/biwa/projects"`                             | Remote directory to sync the project to                                       |
+| `exclude`             | array   | `["**/.git/**", "**/target/**", "**/node_modules/**"]` | List of target strings (using globset) to exclude during synchronization      |
 
 #### `[sync.sftp]` — SFTP Engine Settings
 

--- a/docs/src/sync-behavior.md
+++ b/docs/src/sync-behavior.md
@@ -14,6 +14,12 @@ By default, `biwa run` automatically runs `biwa sync` before executing your comm
 
 If a directory still exists locally after its last file is removed, `biwa sync` will keep it on the remote side as an empty directory instead of deleting it.
 
+## Sync Root
+
+When `sync.sync_root` and `--sync-root` are not set, biwa uses the nearest Git root as the default sync root. This keeps `biwa run` and `biwa sync` aligned to the same remote project directory when you invoke them from subdirectories of the same repository.
+
+Set `sync.default_to_git_root = false` or pass `--sync-cwd` to use the current working directory as the default sync root instead.
+
 ## Target Filtering & Path Resolution
 
 Biwa utilizes `globset` for specifying target exclusions and inclusions, supporting standard Unix-style glob matching syntax. The `exclude` array configuration is additive to the CLI `--exclude` flag.

--- a/schema/config.json
+++ b/schema/config.json
@@ -37,6 +37,7 @@
       "$ref": "#/$defs/SyncConfig",
       "default": {
         "auto": true,
+        "default_to_git_root": true,
         "engine": "sftp",
         "exclude": [
           "**/.git/**",
@@ -229,6 +230,11 @@
           "type": "boolean",
           "default": true
         },
+        "default_to_git_root": {
+          "description": "Use the nearest Git root as the default sync root when `sync_root` is not set.",
+          "type": "boolean",
+          "default": true
+        },
         "engine": {
           "description": "The synchronization engine to use.",
           "$ref": "#/$defs/SyncEngine",
@@ -260,7 +266,7 @@
           }
         },
         "sync_root": {
-          "description": "Base directory to start the synchronization from. If not specified, uses the current working directory.",
+          "description": "Base directory to start the synchronization from. If not specified, uses the nearest Git root by default, falling back to the current directory.",
           "type": [
             "string",
             "null"

--- a/src/cli/snapshots/biwa__cli__init__tests__init_json.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_json.snap
@@ -22,6 +22,7 @@ expression: content
   },
   "sync": {
     "auto": true,
+    "default_to_git_root": true,
     "engine": "sftp",
     "exclude": [
       "**/.git/**",

--- a/src/cli/snapshots/biwa__cli__init__tests__init_json5.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_json5.snap
@@ -61,10 +61,17 @@ expression: content
     // Default value: true
     //auto: true,
 
-    // Base directory to start the synchronization from. If not specified, uses the current working directory.
+    // Base directory to start the synchronization from. If not specified, uses the nearest Git root by default, falling back to the current directory.
     //
     // Can also be specified via environment variable `BIWA_SYNC_ROOT`.
     //sync_root: ,
+
+    // Use the nearest Git root as the default sync root when `sync_root` is not set.
+    //
+    // Can also be specified via environment variable `BIWA_SYNC_DEFAULT_TO_GIT_ROOT`.
+    //
+    // Default value: true
+    //default_to_git_root: true,
 
     // Remote directory to sync the project to.
     //

--- a/src/cli/snapshots/biwa__cli__init__tests__init_jsonc.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_jsonc.snap
@@ -61,10 +61,17 @@ expression: content
     // Default value: true
     //"auto": true,
 
-    // Base directory to start the synchronization from. If not specified, uses the current working directory.
+    // Base directory to start the synchronization from. If not specified, uses the nearest Git root by default, falling back to the current directory.
     //
     // Can also be specified via environment variable `BIWA_SYNC_ROOT`.
     //"sync_root": ,
+
+    // Use the nearest Git root as the default sync root when `sync_root` is not set.
+    //
+    // Can also be specified via environment variable `BIWA_SYNC_DEFAULT_TO_GIT_ROOT`.
+    //
+    // Default value: true
+    //"default_to_git_root": true,
 
     // Remote directory to sync the project to.
     //

--- a/src/cli/snapshots/biwa__cli__init__tests__init_toml.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_toml.snap
@@ -61,10 +61,17 @@ expression: content
 # Default value: true
 #auto = true
 
-# Base directory to start the synchronization from. If not specified, uses the current working directory.
+# Base directory to start the synchronization from. If not specified, uses the nearest Git root by default, falling back to the current directory.
 #
 # Can also be specified via environment variable `BIWA_SYNC_ROOT`.
 #sync_root =
+
+# Use the nearest Git root as the default sync root when `sync_root` is not set.
+#
+# Can also be specified via environment variable `BIWA_SYNC_DEFAULT_TO_GIT_ROOT`.
+#
+# Default value: true
+#default_to_git_root = true
 
 # Remote directory to sync the project to.
 #

--- a/src/cli/snapshots/biwa__cli__init__tests__init_yaml.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_yaml.snap
@@ -60,10 +60,17 @@ sync:
   # Default value: true
   #auto: true
 
-  # Base directory to start the synchronization from. If not specified, uses the current working directory.
+  # Base directory to start the synchronization from. If not specified, uses the nearest Git root by default, falling back to the current directory.
   #
   # Can also be specified via environment variable `BIWA_SYNC_ROOT`.
   #sync_root:
+
+  # Use the nearest Git root as the default sync root when `sync_root` is not set.
+  #
+  # Can also be specified via environment variable `BIWA_SYNC_DEFAULT_TO_GIT_ROOT`.
+  #
+  # Default value: true
+  #default_to_git_root: true
 
   # Remote directory to sync the project to.
   #

--- a/src/cli/snapshots/biwa__cli__init__tests__init_yml.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_yml.snap
@@ -60,10 +60,17 @@ sync:
   # Default value: true
   #auto: true
 
-  # Base directory to start the synchronization from. If not specified, uses the current working directory.
+  # Base directory to start the synchronization from. If not specified, uses the nearest Git root by default, falling back to the current directory.
   #
   # Can also be specified via environment variable `BIWA_SYNC_ROOT`.
   #sync_root:
+
+  # Use the nearest Git root as the default sync root when `sync_root` is not set.
+  #
+  # Can also be specified via environment variable `BIWA_SYNC_DEFAULT_TO_GIT_ROOT`.
+  #
+  # Default value: true
+  #default_to_git_root: true
 
   # Remote directory to sync the project to.
   #

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -5,6 +5,7 @@ use crate::ssh::sync::{Options, sync_project};
 use clap::Args;
 use std::env;
 use std::fs::canonicalize;
+use std::io;
 use std::path::{Path, PathBuf};
 
 /// Arguments for synchronization.
@@ -34,13 +35,22 @@ pub struct SyncArgs {
 impl SyncArgs {
 	/// Resolve the sync root directory.
 	///
-	/// Priority: CLI flag > config file > current working directory.
+	/// Priority: CLI flag > config file > nearest VCS root > current working directory.
 	pub fn resolve_sync_root(&self, config: &Config) -> Result<PathBuf> {
+		self.resolve_sync_root_with(config, default_sync_root)
+	}
+
+	/// Resolve the sync root directory using a supplied implicit default.
+	fn resolve_sync_root_with(
+		&self,
+		config: &Config,
+		default_root: impl FnOnce() -> io::Result<PathBuf>,
+	) -> Result<PathBuf> {
 		let root = self
 			.sync_root
 			.clone()
 			.or_else(|| config.sync.sync_root.clone())
-			.map_or_else(env::current_dir, Ok)?;
+			.map_or_else(default_root, Ok)?;
 		Ok(canonicalize(&root).unwrap_or(root))
 	}
 
@@ -54,6 +64,25 @@ impl SyncArgs {
 			include: absolutize_patterns(&self.include, &cwd),
 		}
 	}
+}
+
+/// Returns the default sync root for the current directory.
+fn default_sync_root() -> io::Result<PathBuf> {
+	let cwd = env::current_dir()?;
+	Ok(default_sync_root_from(&cwd))
+}
+
+/// Returns the default sync root for `cwd`.
+fn default_sync_root_from(cwd: &Path) -> PathBuf {
+	find_git_root(cwd).unwrap_or_else(|| cwd.to_path_buf())
+}
+
+/// Finds the nearest Git worktree root at or above `start`.
+fn find_git_root(start: &Path) -> Option<PathBuf> {
+	start
+		.ancestors()
+		.find(|path| path.join(".git").exists())
+		.map(Path::to_path_buf)
 }
 
 /// Returns the canonical current directory, falling back to `.` if needed.
@@ -118,6 +147,101 @@ impl Sync {
 mod tests {
 	use super::*;
 	use pretty_assertions::assert_eq;
+	use std::fs;
+	use tempfile::tempdir;
+
+	#[test]
+	fn resolve_sync_root_uses_git_root_from_subdirectory() -> Result<()> {
+		let dir = tempdir()?;
+		let root = dir.path().join("project");
+		let nested = root.join("src/bin");
+		fs::create_dir_all(&nested)?;
+		fs::create_dir_all(root.join(".git"))?;
+
+		let root = canonicalize(&root).unwrap_or(root);
+		let args = SyncArgs::default();
+
+		assert_eq!(
+			args.resolve_sync_root_with(&Config::default(), || {
+				Ok(default_sync_root_from(&nested))
+			})?,
+			root
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn resolve_sync_root_uses_current_directory_without_git_root() -> Result<()> {
+		let dir = tempdir()?;
+		let nested = dir.path().join("standalone/nested");
+		fs::create_dir_all(&nested)?;
+
+		let nested = canonicalize(&nested).unwrap_or(nested);
+		let args = SyncArgs::default();
+
+		assert_eq!(
+			args.resolve_sync_root_with(&Config::default(), || {
+				Ok(default_sync_root_from(&nested))
+			})?,
+			nested
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn resolve_sync_root_preserves_explicit_config_root() -> Result<()> {
+		let dir = tempdir()?;
+		let configured_root = dir.path().join("configured");
+		fs::create_dir_all(&configured_root)?;
+
+		let mut config = Config::default();
+		config.sync.sync_root = Some(configured_root.clone());
+		let args = SyncArgs::default();
+
+		assert_eq!(
+			args.resolve_sync_root_with(&config, default_root_should_not_be_used)?,
+			canonicalize(&configured_root).unwrap_or(configured_root)
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn resolve_sync_root_preserves_explicit_cli_root() -> Result<()> {
+		let dir = tempdir()?;
+		let configured_root = dir.path().join("configured");
+		let cli_root = dir.path().join("cli");
+		fs::create_dir_all(&configured_root)?;
+		fs::create_dir_all(&cli_root)?;
+
+		let mut config = Config::default();
+		config.sync.sync_root = Some(configured_root);
+		let args = SyncArgs {
+			sync_root: Some(cli_root.clone()),
+			..Default::default()
+		};
+
+		assert_eq!(
+			args.resolve_sync_root_with(&config, default_root_should_not_be_used)?,
+			canonicalize(&cli_root).unwrap_or(cli_root)
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn find_git_root_accepts_worktree_git_file() -> Result<()> {
+		let dir = tempdir()?;
+		let root = dir.path().join("project");
+		let nested = root.join("src");
+		fs::create_dir_all(&nested)?;
+		fs::write(root.join(".git"), "gitdir: ../.git/worktrees/project\n")?;
+
+		assert_eq!(find_git_root(&nested), Some(root));
+		Ok(())
+	}
+
+	fn default_root_should_not_be_used() -> io::Result<PathBuf> {
+		Err(io::Error::other("explicit sync root should skip default"))
+	}
 
 	#[test]
 	fn resolve_options_absolute_paths() {

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -11,9 +11,13 @@ use std::path::{Path, PathBuf};
 /// Arguments for synchronization.
 #[derive(Args, Debug, Default, Clone)]
 pub struct SyncArgs {
-	/// Base directory to start the synchronization from. Overrides the current working directory.
+	/// Base directory to start the synchronization from. Overrides the default sync root.
 	#[arg(long)]
 	pub sync_root: Option<PathBuf>,
+
+	/// Use the current working directory as the default sync root instead of the nearest Git root.
+	#[arg(long)]
+	pub sync_cwd: bool,
 
 	/// Override the remote project directory path. Bypasses the default `remote_root` + project name.
 	#[arg(long, short = 'd')]
@@ -35,9 +39,10 @@ pub struct SyncArgs {
 impl SyncArgs {
 	/// Resolve the sync root directory.
 	///
-	/// Priority: CLI flag > config file > nearest Git root > current working directory.
+	/// Priority: CLI `--sync-root` > config `sync_root` > nearest Git root unless disabled > current working directory.
 	pub fn resolve_sync_root(&self, config: &Config) -> Result<PathBuf> {
-		self.resolve_sync_root_with(config, default_sync_root)
+		let default_to_git_root = self.default_to_git_root(config);
+		self.resolve_sync_root_with(config, || default_sync_root(default_to_git_root))
 	}
 
 	/// Resolve the sync root directory using a supplied implicit default.
@@ -54,6 +59,11 @@ impl SyncArgs {
 		Ok(canonicalize(&root).unwrap_or(root))
 	}
 
+	/// Returns whether the implicit sync root should prefer the nearest Git root.
+	const fn default_to_git_root(&self, config: &Config) -> bool {
+		config.sync.default_to_git_root && !self.sync_cwd
+	}
+
 	/// Resolve the sync options.
 	pub fn resolve_options(&self) -> Options {
 		let cwd = canonical_current_dir();
@@ -67,14 +77,18 @@ impl SyncArgs {
 }
 
 /// Returns the default sync root for the current directory.
-fn default_sync_root() -> io::Result<PathBuf> {
+fn default_sync_root(default_to_git_root: bool) -> io::Result<PathBuf> {
 	let cwd = env::current_dir()?;
-	Ok(default_sync_root_from(&cwd))
+	Ok(default_sync_root_from(&cwd, default_to_git_root))
 }
 
 /// Returns the default sync root for `cwd`.
-fn default_sync_root_from(cwd: &Path) -> PathBuf {
-	find_git_root(cwd).unwrap_or_else(|| cwd.to_path_buf())
+fn default_sync_root_from(cwd: &Path, default_to_git_root: bool) -> PathBuf {
+	if default_to_git_root {
+		find_git_root(cwd).unwrap_or_else(|| cwd.to_path_buf())
+	} else {
+		cwd.to_path_buf()
+	}
 }
 
 /// Finds the nearest Git worktree root at or above `start`.
@@ -163,7 +177,10 @@ mod tests {
 
 		assert_eq!(
 			args.resolve_sync_root_with(&Config::default(), || {
-				Ok(default_sync_root_from(&nested))
+				Ok(default_sync_root_from(
+					&nested,
+					args.default_to_git_root(&Config::default()),
+				))
 			})?,
 			root
 		);
@@ -181,8 +198,59 @@ mod tests {
 
 		assert_eq!(
 			args.resolve_sync_root_with(&Config::default(), || {
-				Ok(default_sync_root_from(&nested))
+				Ok(default_sync_root_from(
+					&nested,
+					args.default_to_git_root(&Config::default()),
+				))
 			})?,
+			nested
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn resolve_sync_root_uses_current_directory_when_config_disables_git_root() -> Result<()> {
+		let dir = tempdir()?;
+		let root = dir.path().join("project");
+		let nested = root.join("src");
+		fs::create_dir_all(&nested)?;
+		fs::create_dir_all(root.join(".git"))?;
+
+		let nested = canonicalize(&nested).unwrap_or(nested);
+		let mut config = Config::default();
+		config.sync.default_to_git_root = false;
+		let args = SyncArgs::default();
+
+		assert_eq!(
+			args.resolve_sync_root_with(&config, || Ok(default_sync_root_from(
+				&nested,
+				args.default_to_git_root(&config),
+			)))?,
+			nested
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn resolve_sync_root_uses_current_directory_when_cli_disables_git_root() -> Result<()> {
+		let dir = tempdir()?;
+		let root = dir.path().join("project");
+		let nested = root.join("src");
+		fs::create_dir_all(&nested)?;
+		fs::create_dir_all(root.join(".git"))?;
+
+		let nested = canonicalize(&nested).unwrap_or(nested);
+		let config = Config::default();
+		let args = SyncArgs {
+			sync_cwd: true,
+			..Default::default()
+		};
+
+		assert_eq!(
+			args.resolve_sync_root_with(&config, || Ok(default_sync_root_from(
+				&nested,
+				args.default_to_git_root(&config),
+			)))?,
 			nested
 		);
 		Ok(())

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -35,7 +35,7 @@ pub struct SyncArgs {
 impl SyncArgs {
 	/// Resolve the sync root directory.
 	///
-	/// Priority: CLI flag > config file > nearest VCS root > current working directory.
+	/// Priority: CLI flag > config file > nearest Git root > current working directory.
 	pub fn resolve_sync_root(&self, config: &Config) -> Result<PathBuf> {
 		self.resolve_sync_root_with(config, default_sync_root)
 	}

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -377,6 +377,7 @@ mod tests {
 		  "sync": {
 		    "auto": true,
 		    "sync_root": null,
+		    "default_to_git_root": true,
 		    "remote_root": "~/.cache/biwa/projects",
 		    "exclude": [
 		      "**/.git/**",

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -114,6 +114,12 @@ mod schema_defaults {
 		true
 	}
 
+	/// Default for `SyncConfig::default_to_git_root` in schema.
+	#[must_use]
+	pub const fn sync_default_to_git_root() -> bool {
+		true
+	}
+
 	/// Default for `SyncSftpConfig::max_files_to_sync` in schema.
 	#[must_use]
 	pub const fn max_files_to_sync() -> usize {
@@ -258,9 +264,13 @@ pub struct SyncConfig {
 	#[config(default = true, env = "BIWA_SYNC_AUTO")]
 	#[schemars(default = "crate::config::types::schema_defaults::sync_auto")]
 	pub auto: bool,
-	/// Base directory to start the synchronization from. If not specified, uses the current working directory.
+	/// Base directory to start the synchronization from. If not specified, uses the nearest Git root by default, falling back to the current directory.
 	#[config(env = "BIWA_SYNC_ROOT")]
 	pub sync_root: Option<PathBuf>,
+	/// Use the nearest Git root as the default sync root when `sync_root` is not set.
+	#[config(default = true, env = "BIWA_SYNC_DEFAULT_TO_GIT_ROOT")]
+	#[schemars(default = "crate::config::types::schema_defaults::sync_default_to_git_root")]
+	pub default_to_git_root: bool,
 	/// Remote directory to sync the project to.
 	#[config(default = "~/.cache/biwa/projects", env = "BIWA_SYNC_REMOTE_ROOT")]
 	#[schemars(default = "crate::config::types::schema_defaults::sync_remote_root")]


### PR DESCRIPTION
## Summary
- default implicit sync root to the nearest Git worktree root when no CLI or config sync root is set
- keep explicit `--sync-root` and `sync.sync_root` precedence unchanged
- add tests for nested Git directories, worktree `.git` files, fallback behavior, and explicit overrides

Fixes #414

## Testing
- `cargo test cli::sync`
- `cargo clippy --all-targets -- -D warnings`
- `mise run check:rustfmt`