### PR TITLE
ci: test mise rust cache

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -33,14 +33,11 @@ jobs:
           persist-credentials: false
 
       - name: Install mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # risu/cache-rust-toolchains
         with:
           version: 2026.5.5
           install_args: --locked
-
-      - name: Re-install Rust
-        # cache doesn't work well with rust
-        run: mise install --locked rust --force
+          cache_rust: true
 
       - name: Update mise lockfile
         if: github.event.pull_request.user.login == 'renovate[bot]'

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -33,7 +33,7 @@ jobs:
           persist-credentials: false
 
       - name: Install mise
-        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # risu/cache-rust-toolchains
+        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # zizmor: ignore[stale-action-refs,ref-version-mismatch] temporary SHA for jdx/mise-action PR 467
         with:
           version: 2026.5.5
           install_args: --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,14 +92,11 @@ jobs:
           persist-credentials: false
 
       - name: Install mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # risu/cache-rust-toolchains
         with:
           version: 2026.5.5
           install_args: --locked
-
-      - name: Re-install Rust
-        # cache doesn't work well with rust
-        run: mise install --locked rust --force
+          cache_rust: true
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -128,14 +125,11 @@ jobs:
           persist-credentials: false
 
       - name: Install mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # risu/cache-rust-toolchains
         with:
           version: 2026.5.5
           install_args: --locked
-
-      - name: Re-install Rust
-        # cache doesn't work well with rust
-        run: mise install --locked rust --force
+          cache_rust: true
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -166,10 +160,11 @@ jobs:
           persist-credentials: false
 
       - name: Install mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # risu/cache-rust-toolchains
         with:
           version: 2026.5.5
           install_args: --locked
+          cache_rust: true
 
       - name: Validate schema
         run: mise run schema

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           persist-credentials: false
 
       - name: Install mise
-        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # risu/cache-rust-toolchains
+        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # zizmor: ignore[stale-action-refs,ref-version-mismatch] temporary SHA for jdx/mise-action PR 467
         with:
           version: 2026.5.5
           install_args: --locked
@@ -125,7 +125,7 @@ jobs:
           persist-credentials: false
 
       - name: Install mise
-        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # risu/cache-rust-toolchains
+        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # zizmor: ignore[stale-action-refs,ref-version-mismatch] temporary SHA for jdx/mise-action PR 467
         with:
           version: 2026.5.5
           install_args: --locked
@@ -160,7 +160,7 @@ jobs:
           persist-credentials: false
 
       - name: Install mise
-        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # risu/cache-rust-toolchains
+        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # zizmor: ignore[stale-action-refs,ref-version-mismatch] temporary SHA for jdx/mise-action PR 467
         with:
           version: 2026.5.5
           install_args: --locked

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -33,14 +33,11 @@ jobs:
           persist-credentials: false
 
       - name: Install mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # risu/cache-rust-toolchains
         with:
           version: 2026.5.5
           install_args: --locked
-
-      - name: Re-install Rust
-        # cache doesn't work well with rust
-        run: mise install --locked rust --force
+          cache_rust: true
 
       - name: Create biwa-bot GitHub App token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
@@ -74,14 +71,11 @@ jobs:
           persist-credentials: false
 
       - name: Install mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # risu/cache-rust-toolchains
         with:
           version: 2026.5.5
           install_args: --locked
-
-      - name: Re-install Rust
-        # cache doesn't work well with rust
-        run: mise install --locked rust --force
+          cache_rust: true
 
       - name: Create biwa-bot GitHub App token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -33,7 +33,7 @@ jobs:
           persist-credentials: false
 
       - name: Install mise
-        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # risu/cache-rust-toolchains
+        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # zizmor: ignore[stale-action-refs,ref-version-mismatch] temporary SHA for jdx/mise-action PR 467
         with:
           version: 2026.5.5
           install_args: --locked
@@ -71,7 +71,7 @@ jobs:
           persist-credentials: false
 
       - name: Install mise
-        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # risu/cache-rust-toolchains
+        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # zizmor: ignore[stale-action-refs,ref-version-mismatch] temporary SHA for jdx/mise-action PR 467
         with:
           version: 2026.5.5
           install_args: --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,19 +58,15 @@ jobs:
 
       - name: Install mise
         id: install-mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # risu/cache-rust-toolchains
         with:
           version: 2026.5.5
           install_args: --locked
           cache: ${{ steps.mode.outputs.publishing == 'false' }}
           cache_key: "{{default}}-release"
+          cache_rust: true
         env:
           MISE_ENABLE_TOOLS: rust,cargo-dist
-
-      - name: Re-install Rust
-        if: steps.install-mise.outputs.cache-hit == 'true'
-        # cache doesn't work well with rust
-        run: mise install --locked rust --force
 
       - name: Plan Release
         id: plan
@@ -112,19 +108,15 @@ jobs:
 
       - name: Install mise
         id: install-mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # risu/cache-rust-toolchains
         with:
           version: 2026.5.5
           install_args: --locked
           cache: ${{ needs.plan.outputs.publishing == 'false' }}
           cache_key: "{{default}}-release"
+          cache_rust: true
         env:
           MISE_ENABLE_TOOLS: rust,cargo-dist
-
-      - name: Re-install Rust
-        if: steps.install-mise.outputs.cache-hit == 'true'
-        # cache doesn't work well with rust
-        run: mise install --locked rust --force
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -209,19 +201,15 @@ jobs:
 
       - name: Install mise
         id: install-mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # risu/cache-rust-toolchains
         with:
           version: 2026.5.5
           install_args: --locked
           cache: ${{ needs.plan.outputs.publishing == 'false' }}
           cache_key: "{{default}}-release"
+          cache_rust: true
         env:
           MISE_ENABLE_TOOLS: rust,cargo-dist
-
-      - name: Re-install Rust
-        if: steps.install-mise.outputs.cache-hit == 'true'
-        # cache doesn't work well with rust
-        run: mise install --locked rust --force
 
       - name: Download local artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -280,7 +268,7 @@ jobs:
           persist-credentials: false
 
       - name: Install mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # risu/cache-rust-toolchains
         with:
           version: 2026.5.5
           install_args: --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Install mise
         id: install-mise
-        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # risu/cache-rust-toolchains
+        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # zizmor: ignore[stale-action-refs,ref-version-mismatch] temporary SHA for jdx/mise-action PR 467
         with:
           version: 2026.5.5
           install_args: --locked
@@ -108,7 +108,7 @@ jobs:
 
       - name: Install mise
         id: install-mise
-        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # risu/cache-rust-toolchains
+        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # zizmor: ignore[stale-action-refs,ref-version-mismatch] temporary SHA for jdx/mise-action PR 467
         with:
           version: 2026.5.5
           install_args: --locked
@@ -201,7 +201,7 @@ jobs:
 
       - name: Install mise
         id: install-mise
-        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # risu/cache-rust-toolchains
+        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # zizmor: ignore[stale-action-refs,ref-version-mismatch] temporary SHA for jdx/mise-action PR 467
         with:
           version: 2026.5.5
           install_args: --locked
@@ -268,7 +268,7 @@ jobs:
           persist-credentials: false
 
       - name: Install mise
-        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # risu/cache-rust-toolchains
+        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # zizmor: ignore[stale-action-refs,ref-version-mismatch] temporary SHA for jdx/mise-action PR 467
         with:
           version: 2026.5.5
           install_args: --locked


### PR DESCRIPTION
## Summary

- point mise-action uses at risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 from jdx/mise-action#467
- enable `cache_rust: true` where mise installs cached Rust toolchains
- remove the `mise install --locked rust --force` workaround steps

## Verification

- `actionlint .github/workflows/ci.yml .github/workflows/autofix.yml .github/workflows/release.yml .github/workflows/release-plz.yml`
- `pinact run --verify --check .github/workflows/ci.yml .github/workflows/autofix.yml .github/workflows/release.yml .github/workflows/release-plz.yml`
- `git diff --check`

This PR is intended to verify that the mise-action Rust cache opt-in restores rustfmt/clippy correctly from cache.