### PR TITLE
feat(ssh): forward Ctrl+C to remote command

### DIFF
--- a/src/ssh/client/execute.rs
+++ b/src/ssh/client/execute.rs
@@ -14,7 +14,7 @@ pub struct CommandExecutedResult {
 }
 
 /// Maps a remote [`Sig`] to a synthetic non-zero exit code (POSIX-style `128 + signal`).
-const fn exit_status_from_signal(sig: &Sig) -> u32 {
+pub(in crate::ssh) const fn exit_status_from_signal(sig: &Sig) -> u32 {
 	match sig {
 		Sig::HUP => 129,
 		Sig::INT => 130,

--- a/src/ssh/exec.rs
+++ b/src/ssh/exec.rs
@@ -8,18 +8,21 @@ use crate::env_vars::{
 };
 use crate::ssh::client::Client;
 use crate::ssh::client::auth::AuthenticationFailed;
-use crate::ssh::client::execute::await_channel_confirmation;
+use crate::ssh::client::execute::{await_channel_confirmation, exit_status_from_signal};
 use crate::ui::create_spinner;
 use bytes::Bytes;
 use color_eyre::eyre::{Context as _, Report, bail};
 use console::style;
 use core::time::Duration;
 use indicatif::ProgressBar;
-use russh::{Channel, ChannelMsg, Pty, client::Msg};
+use russh::{Channel, ChannelMsg, Pty, Sig, client::Msg};
 use std::env;
-use std::io::{Error as IoError, IsTerminal as _, Read as _, stdin as std_stdin};
+use std::io::{
+	Error as IoError, ErrorKind as IoErrorKind, IsTerminal as _, Read as _, stdin as std_stdin,
+};
 use std::thread;
 use tokio::io::{copy, sink, stderr, stdout};
+use tokio::signal::ctrl_c;
 use tokio::sync::mpsc;
 use tokio::time::sleep;
 use tokio_stream::StreamExt as _;
@@ -55,6 +58,9 @@ struct ResolvedEnvVar {
 
 /// Receiver carrying stdin chunks or an EOF marker for a remote command.
 type StdinReceiver = mpsc::Receiver<Option<Vec<u8>>>;
+
+/// Terminal interrupt character sent when forwarding Ctrl+C into a remote PTY.
+const PTY_INTERRUPT: &[u8] = b"\x03";
 
 /// Static execution settings reused across remote command helpers.
 struct RunCommandOptions<'a> {
@@ -213,6 +219,9 @@ fn spawn_stdin_forwarder() -> StdinReceiver {
 					if stdin_tx.blocking_send(Some(chunk)).is_err() {
 						break;
 					}
+				}
+				Err(error) if error.kind() == IoErrorKind::Interrupted => {
+					debug!("Retrying local stdin read interrupted by signal");
 				}
 				result => {
 					if let Err(error) = result {
@@ -490,7 +499,7 @@ async fn execute_with_forward_method(
 				.wrap_err("Failed to execute remote command")?;
 			await_channel_confirmation(&mut channel, "remote command exec request").await?;
 
-			stream_channel_output(channel, stdout_tx, stderr_tx, stdin_rx).await
+			stream_channel_output(channel, stdout_tx, stderr_tx, stdin_rx, stdin_is_terminal).await
 		}
 		EnvForwardMethod::Setenv => {
 			let mut channel = client
@@ -536,9 +545,47 @@ async fn execute_with_forward_method(
 				.wrap_err("Failed to execute remote command")?;
 			await_channel_confirmation(&mut channel, "remote command exec request").await?;
 
-			stream_channel_output(channel, stdout_tx, stderr_tx, stdin_rx).await
+			stream_channel_output(channel, stdout_tx, stderr_tx, stdin_rx, stdin_is_terminal).await
 		}
 	}
+}
+
+/// Stops forwarding stdin once the remote side has reported process termination.
+async fn stop_forwarding_stdin_after_remote_exit(
+	channel: &Channel<Msg>,
+	stdin_rx: &mut Option<StdinReceiver>,
+) {
+	if stdin_rx.is_some() {
+		if let Err(error) = channel.eof().await {
+			debug!(
+				%error,
+				"Ignoring stdin EOF send failure after remote command exit"
+			);
+		}
+		*stdin_rx = None;
+	}
+}
+
+/// Forwards a local Ctrl+C into the remote session.
+async fn forward_local_sigint(channel: &Channel<Msg>, stdin_is_terminal: bool) -> Result<()> {
+	if stdin_is_terminal {
+		channel
+			.data(PTY_INTERRUPT)
+			.await
+			.wrap_err("Failed to forward Ctrl+C to remote PTY")?;
+	} else {
+		channel
+			.signal(Sig::INT)
+			.await
+			.wrap_err("Failed to send SIGINT to remote command")?;
+	}
+
+	debug!(
+		remote_pty = stdin_is_terminal,
+		"Forwarded local Ctrl+C to remote command"
+	);
+
+	Ok(())
 }
 
 /// Streams SSH channel stdout/stderr into local output buffers until exit.
@@ -547,6 +594,7 @@ async fn stream_channel_output(
 	stdout_tx: mpsc::Sender<Vec<u8>>,
 	stderr_tx: mpsc::Sender<Vec<u8>>,
 	mut stdin_rx: Option<mpsc::Receiver<Option<Vec<u8>>>>,
+	stdin_is_terminal: bool,
 ) -> Result<u32> {
 	let mut exit_status = None;
 
@@ -578,7 +626,7 @@ async fn stream_channel_output(
 					}
 					None => stdin_rx = None,
 				}
-			}
+			},
 			msg = channel.wait() => match msg {
 				Some(ChannelMsg::Data { data }) => {
 					stdout_tx
@@ -596,18 +644,18 @@ async fn stream_channel_output(
 					exit_status: status,
 				}) => {
 					exit_status = Some(status);
-					if stdin_rx.is_some() {
-						if let Err(error) = channel.eof().await {
-							debug!(
-								%error,
-								"Ignoring stdin EOF send failure after remote command exit"
-							);
-						}
-						stdin_rx = None;
-					}
+					stop_forwarding_stdin_after_remote_exit(&channel, &mut stdin_rx).await;
+				}
+				Some(ChannelMsg::ExitSignal { signal_name, .. }) => {
+					exit_status = Some(exit_status_from_signal(&signal_name));
+					stop_forwarding_stdin_after_remote_exit(&channel, &mut stdin_rx).await;
 				}
 				Some(_) => {}
 				None => break,
+			},
+			result = ctrl_c(), if exit_status.is_none() => {
+				result.wrap_err("Failed to listen for local Ctrl+C")?;
+				forward_local_sigint(&channel, stdin_is_terminal).await?;
 			}
 		}
 	}

--- a/src/ssh/exec.rs
+++ b/src/ssh/exec.rs
@@ -18,12 +18,13 @@ use indicatif::ProgressBar;
 use russh::{Channel, ChannelMsg, Pty, Sig, client::Msg};
 use std::env;
 use std::io::{
-	Error as IoError, ErrorKind as IoErrorKind, IsTerminal as _, Read as _, stdin as std_stdin,
+	Error as IoError, ErrorKind as IoErrorKind, IsTerminal as _, Read as _, Result as IoResult,
+	stdin as std_stdin,
 };
 use std::thread;
 use tokio::io::{copy, sink, stderr, stdout};
 use tokio::signal::ctrl_c;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tokio::time::sleep;
 use tokio_stream::StreamExt as _;
 use tokio_stream::wrappers::ReceiverStream;
@@ -294,6 +295,59 @@ struct ExecuteCommandStreams {
 	stdin_is_terminal: bool,
 }
 
+/// Local Ctrl+C notifications for a single remote command.
+struct CtrlCForwarder {
+	/// Receiver notified whenever local Ctrl+C is observed.
+	interrupt_rx: mpsc::Receiver<IoResult<()>>,
+	/// Stops the background listener when command streaming ends.
+	shutdown_tx: Option<oneshot::Sender<()>>,
+}
+
+impl CtrlCForwarder {
+	/// Spawns a listener that converts local Ctrl+C signals into channel notifications.
+	fn spawn() -> Self {
+		let (interrupt_tx, interrupt_rx) = mpsc::channel(8);
+		let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+
+		tokio::spawn(async move {
+			#[expect(
+				clippy::integer_division_remainder_used,
+				reason = "tokio::select! macro expansion triggers this lint spuriously"
+			)]
+			loop {
+				tokio::select! {
+					result = ctrl_c() => {
+						if interrupt_tx.send(result).await.is_err() {
+							break;
+						}
+					}
+					_ = &mut shutdown_rx => break,
+				}
+			}
+		});
+
+		Self {
+			interrupt_rx,
+			shutdown_tx: Some(shutdown_tx),
+		}
+	}
+
+	/// Receives the next local Ctrl+C notification.
+	async fn recv(&mut self) -> Option<IoResult<()>> {
+		self.interrupt_rx.recv().await
+	}
+}
+
+impl Drop for CtrlCForwarder {
+	fn drop(&mut self) {
+		if let Some(shutdown_tx) = self.shutdown_tx.take()
+			&& shutdown_tx.send(()).is_err()
+		{
+			debug!("Ctrl+C listener already stopped");
+		}
+	}
+}
+
 /// Run a pre-built command string on an already-connected SSH client.
 ///
 /// Returns the remote exit code, printing stdout/stderr as they arrive
@@ -475,13 +529,6 @@ async fn execute_with_forward_method(
 	forward_method: &EnvForwardMethod,
 	streams: ExecuteCommandStreams,
 ) -> Result<u32> {
-	let ExecuteCommandStreams {
-		stdout_tx,
-		stderr_tx,
-		stdin_rx,
-		stdin_is_terminal,
-	} = streams;
-
 	match forward_method {
 		EnvForwardMethod::Export => {
 			let mut channel = client
@@ -489,7 +536,7 @@ async fn execute_with_forward_method(
 				.await
 				.wrap_err("Failed to open SSH session channel")?;
 
-			if stdin_is_terminal {
+			if streams.stdin_is_terminal {
 				request_terminal_pty(&mut channel).await?;
 			}
 
@@ -499,7 +546,7 @@ async fn execute_with_forward_method(
 				.wrap_err("Failed to execute remote command")?;
 			await_channel_confirmation(&mut channel, "remote command exec request").await?;
 
-			stream_channel_output(channel, stdout_tx, stderr_tx, stdin_rx, stdin_is_terminal).await
+			stream_channel_output(channel, streams).await
 		}
 		EnvForwardMethod::Setenv => {
 			let mut channel = client
@@ -507,7 +554,7 @@ async fn execute_with_forward_method(
 				.await
 				.wrap_err("Failed to open SSH session channel")?;
 
-			if stdin_is_terminal {
+			if streams.stdin_is_terminal {
 				request_terminal_pty(&mut channel).await?;
 			}
 
@@ -545,7 +592,7 @@ async fn execute_with_forward_method(
 				.wrap_err("Failed to execute remote command")?;
 			await_channel_confirmation(&mut channel, "remote command exec request").await?;
 
-			stream_channel_output(channel, stdout_tx, stderr_tx, stdin_rx, stdin_is_terminal).await
+			stream_channel_output(channel, streams).await
 		}
 	}
 }
@@ -591,12 +638,16 @@ async fn forward_local_sigint(channel: &Channel<Msg>, stdin_is_terminal: bool) -
 /// Streams SSH channel stdout/stderr into local output buffers until exit.
 async fn stream_channel_output(
 	mut channel: Channel<Msg>,
-	stdout_tx: mpsc::Sender<Vec<u8>>,
-	stderr_tx: mpsc::Sender<Vec<u8>>,
-	mut stdin_rx: Option<mpsc::Receiver<Option<Vec<u8>>>>,
-	stdin_is_terminal: bool,
+	streams: ExecuteCommandStreams,
 ) -> Result<u32> {
+	let ExecuteCommandStreams {
+		stdout_tx,
+		stderr_tx,
+		mut stdin_rx,
+		stdin_is_terminal,
+	} = streams;
 	let mut exit_status = None;
+	let mut ctrl_c_forwarder = CtrlCForwarder::spawn();
 
 	#[expect(
 		clippy::integer_division_remainder_used,
@@ -653,10 +704,13 @@ async fn stream_channel_output(
 				Some(_) => {}
 				None => break,
 			},
-			result = ctrl_c(), if exit_status.is_none() => {
-				result.wrap_err("Failed to listen for local Ctrl+C")?;
-				forward_local_sigint(&channel, stdin_is_terminal).await?;
-			}
+			interrupt = ctrl_c_forwarder.recv(), if exit_status.is_none() => match interrupt {
+				Some(result) => {
+					result.wrap_err("Failed to listen for local Ctrl+C")?;
+					forward_local_sigint(&channel, stdin_is_terminal).await?;
+				}
+				None => bail!("Local Ctrl+C listener stopped before remote command completed"),
+			},
 		}
 	}
 

--- a/tests/ssh_e2e_run.rs
+++ b/tests/ssh_e2e_run.rs
@@ -33,6 +33,107 @@ fn biwa_process(args: &[&str]) -> Command {
 	command
 }
 
+const SIGINT_REMOTE_SCRIPT: &str =
+	"trap 'printf interrupted; exit 130' INT; printf 'ready\\n'; while true; do sleep 1; done";
+
+fn run_sigint_forwarding_case(use_pty: bool) -> Result<()> {
+	let timeout_secs = e2e_timeout_secs();
+	let use_pty = if use_pty { "True" } else { "False" };
+	let python = format!(
+		r#"import os, pty, select, signal, subprocess, sys
+use_pty = {use_pty}
+master = None
+slave = None
+stdin = subprocess.DEVNULL
+
+if use_pty:
+    master, slave = pty.openpty()
+    stdin = slave
+
+try:
+    proc = subprocess.Popen(
+        [{biwa_path:?}, "--quiet", "run", "--skip-sync", "--", "bash", "-c", {remote_script:?}],
+        stdin=stdin,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=os.environ.copy(),
+    )
+finally:
+    if slave is not None:
+        os.close(slave)
+
+def close_master():
+    global master
+    if master is not None:
+        os.close(master)
+        master = None
+
+def kill_and_fail(message, code, prefix=b""):
+    proc.kill()
+    out, err = proc.communicate()
+    close_master()
+    sys.stderr.write(message + "\n")
+    sys.stderr.buffer.write(prefix)
+    sys.stderr.buffer.write(out)
+    sys.stderr.buffer.write(err)
+    sys.exit(code)
+
+ready, _, _ = select.select([proc.stdout], [], [], {timeout_secs})
+mode = "remote PTY" if use_pty else "remote"
+if not ready:
+    kill_and_fail(f"timed out while waiting for {{mode}} command readiness", 124)
+
+line = proc.stdout.readline()
+if b"ready" not in line:
+    kill_and_fail(f"unexpected readiness line: {{line!r}}", 1)
+
+os.kill(proc.pid, signal.SIGINT)
+try:
+    out, err = proc.communicate(timeout={timeout_secs})
+except subprocess.TimeoutExpired:
+    kill_and_fail(f"timed out waiting for biwa to forward SIGINT into the {{mode}} command", 124, line)
+
+close_master()
+combined = line + out
+sys.stdout.buffer.write(combined)
+sys.stderr.buffer.write(err)
+if b"interrupted" not in combined:
+    sys.stderr.write(f"{{mode}} command was not interrupted\n")
+    sys.exit(1)
+if proc.returncode == 0:
+    sys.stderr.write(f"biwa exited successfully after {{mode}} SIGINT\n")
+    sys.exit(1)
+sys.exit(0)
+"#,
+		biwa_path = env!("CARGO_BIN_EXE_biwa"),
+		remote_script = SIGINT_REMOTE_SCRIPT,
+		timeout_secs = timeout_secs,
+		use_pty = use_pty,
+	);
+
+	let output = Command::new("python3")
+		.arg("-c")
+		.arg(&python)
+		.env("BIWA_SSH_HOST", "127.0.0.1")
+		.env("BIWA_SSH_PORT", "2222")
+		.env("BIWA_SSH_USER", "testuser")
+		.env("BIWA_SSH_PASSWORD", "password123")
+		.output()?;
+
+	assert!(
+		output.status.success(),
+		"stdout: {}\nstderr: {}",
+		String::from_utf8_lossy(&output.stdout),
+		String::from_utf8_lossy(&output.stderr)
+	);
+	assert!(
+		String::from_utf8_lossy(&output.stdout).contains("interrupted"),
+		"stdout: {}",
+		String::from_utf8_lossy(&output.stdout)
+	);
+	Ok(())
+}
+
 #[test]
 fn e2e_run_command() -> Result<()> {
 	let output = biwa_cmd(&["run", "--skip-sync", "echo", "hello e2e from biwa"])
@@ -47,6 +148,16 @@ fn e2e_run_command() -> Result<()> {
 	assert!(output.status.success());
 	assert!(stdout.contains("hello e2e from biwa"));
 	Ok(())
+}
+
+#[test]
+fn e2e_run_forwards_sigint_without_pty() -> Result<()> {
+	run_sigint_forwarding_case(false)
+}
+
+#[test]
+fn e2e_run_forwards_sigint_with_pty() -> Result<()> {
+	run_sigint_forwarding_case(true)
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This fixes `biwa run` so a local Ctrl+C is forwarded to the remote command instead of only terminating the local `biwa` process.

The change covers both remote execution modes used by `src/ssh/exec.rs`:

- **PTY-backed sessions**: forward Ctrl+C as the terminal interrupt byte (`0x03`) through the SSH channel data stream. This mirrors what an interactive terminal does locally: the remote PTY driver receives the interrupt character and turns it into `SIGINT` for the foreground remote process group.
- **Non-PTY sessions**: forward Ctrl+C as an SSH channel signal request with `SIGINT`, because there is no remote terminal driver to interpret `0x03`.

Fixes #411

## How It Works

Before this PR, `biwa` did not install a local SIGINT handler while streaming a remote command. Pressing Ctrl+C therefore used the OS default behavior: the local client exited immediately, the SSH connection dropped, and the remote command was not explicitly interrupted.

With this PR, command streaming creates one `CtrlCForwarder` for the lifetime of the remote command. That helper listens for `tokio::signal::ctrl_c()` in a background task and sends interrupt notifications back to the SSH channel streaming loop.

When the streaming loop receives a local interrupt:

1. If the session requested a remote PTY, it writes `0x03` to the channel with `channel.data(...)`.
2. If the session is not using a PTY, it sends `channel.signal(Sig::INT)`.
3. The streaming loop keeps running so it can still collect the remote process output and exit status after the interrupt.

The stdin forwarding thread also now retries `stdin.read(...)` when the read is interrupted by a signal. That prevents the local Ctrl+C from being mistaken for stdin EOF while the signal forwarding path is handling the interrupt.

## Exit Status Handling

`src/ssh/client/execute.rs` already mapped remote `ExitSignal` messages to POSIX-style synthetic exit statuses such as `130` for `SIGINT`. This PR reuses that mapping in the streaming `biwa run` path too, so a remote signal message is interpreted consistently whether output is collected or streamed live.

`biwa run` still reports a non-zero remote exit as an error through the existing CLI behavior; this PR does not try to redesign how the top-level process exit code is surfaced.

## Tests

The new E2E coverage exercises the real local-signal path by spawning `biwa` as a subprocess, waiting until the remote command prints `ready`, sending SIGINT to the local `biwa` process, and then asserting that the remote command prints `interrupted`.

Two cases are covered:

- `e2e_run_forwards_sigint_without_pty`: local stdin is not a terminal, so `biwa` should send an SSH `SIGINT` channel request.
- `e2e_run_forwards_sigint_with_pty`: local stdin is a PTY, so `biwa` should request a remote PTY and send the terminal interrupt byte.

## Verification

- `LINT=true mise run check:rustfmt`
- `cargo clippy --all-targets -- --deny warnings`
- `cargo test --test ssh_e2e_run e2e_run_forwards_sigint -- --nocapture`
- `cargo test`

## CI Note

All GitHub Actions checks passed on the current head commit. The remaining failing status is `codecov/patch`; I left a PR comment explaining that this behavior is covered by E2E subprocess tests, but tarpaulin/Codecov does not attribute that subprocess coverage back to `src/ssh/exec.rs`. Codecov also reports that its base report is 228 commits behind `main`.