### PR TITLE
ci: unlock autofix mise install

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -36,7 +36,6 @@ jobs:
         uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # zizmor: ignore[stale-action-refs,ref-version-mismatch] temporary SHA for jdx/mise-action PR 467
         with:
           version: 2026.5.5
-          install_args: --locked
           cache_rust: true
 
       - name: Update mise lockfile


### PR DESCRIPTION
## Summary
- remove `install_args: --locked` from the autofix mise install step
- keep the Renovate-only `mise lock` step so lockfile updates can be generated before autofix commits

## Verification
- `mise run check:actionlint`
- `mise run check:yamllint`
- `LINT=true mise run check:oxfmt`
- `LINT=true mise run check:pinact`
- `LINT=true mise run check:zizmor`
- `LINT=true mise run check:ghalint`