### PR TITLE
test(ssh): cover capable setenv and setstat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
             test:
               - *ci
               - *build
+              - 'docker-compose.yml'
               - 'tests/**'
               - 'tarpaulin.toml'
               - 'tasks.toml'
@@ -75,21 +76,14 @@ jobs:
       contents: read # for checkout
       id-token: write # for codecov
 
-    services:
-      ssh-server:
-        image: lscr.io/linuxserver/openssh-server@sha256:29d4e3f887596c4c2fc609f4e07040b08890a238178da400ffa2a602b55245bc
-        ports:
-          - 2222:2222
-        env:
-          USER_NAME: testuser
-          USER_PASSWORD: password123
-          PASSWORD_ACCESS: "true"
-
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Start SSH test services
+        run: docker compose up --build --detach --wait --wait-timeout 60
 
       - name: Install mise
         uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # zizmor: ignore[stale-action-refs,ref-version-mismatch] temporary SHA for jdx/mise-action PR 467
@@ -103,6 +97,10 @@ jobs:
 
       - name: Test (coverage)
         run: mise run test:coverage
+
+      - name: Show SSH service logs
+        if: failure()
+        run: docker compose logs --no-color
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ It captures the commands, conventions, and guardrails that are actually used her
 - `mise x --` is usually unnecessary, but if a binary is not found or the environment looks wrong, retry with it.
 - `target/debug/` is added to PATH via `mise.toml`, so local `biwa` builds can be invoked directly in a mise environment.
 - `pitchfork.toml` enables automatic background daemons when you enter the directory.
-- The required SSH test server normally starts automatically via `pitchfork`; if it is not running, use `pitchfork start --all`.
+- The required SSH test servers normally start automatically via `pitchfork`; if they are not running, use `pitchfork start --all`.
 - Do not run `docker compose up` manually for the test server; prefer `pitchfork`.
 
 ## High-Value Commands
@@ -94,8 +94,9 @@ It captures the commands, conventions, and guardrails that are actually used her
 
 ## Test Environment Notes
 
-- E2E tests use the local SSH container described in `docker-compose.yml`.
-- CI starts an SSH service container with username `testuser`, password `password123`, port `2222`.
+- E2E tests use the local SSH containers described in `docker-compose.yml`.
+- The default/restrictive SSH server listens on port `2222`; the capable SSH server for `setenv` and SFTP permission-update tests listens on port `2223`.
+- CI starts the same SSH test services through `docker compose up --build --detach --wait`.
 - Shared integration helpers are in `tests/common/mod.rs`.
 - Tests install `color_eyre` globally at startup for improved diagnostics.
 - Tests that mutate environment variables use `#[serial]` and cleanup guards; preserve that pattern.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,25 @@ services:
       - USER_NAME=testuser
       - USER_PASSWORD=password123
       - PASSWORD_ACCESS=true
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "2222"]
+      interval: 1s
+      timeout: 1s
+      retries: 30
+
+  ssh-server-capable:
+    build:
+      context: .
+      dockerfile: tests/fixtures/ssh-capable/Dockerfile
+    container_name: ssh_test_server_capable
+    ports:
+      - "2223:2222"
+    environment:
+      - USER_NAME=testuser
+      - USER_PASSWORD=password123
+      - PASSWORD_ACCESS=true
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "2222"]
+      interval: 1s
+      timeout: 1s
+      retries: 30

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -34,6 +34,13 @@ That's it! The environment is automatically managed by mise and `mise.toml`.
    ```
 5. Submit a Pull Request.
 
+End-to-end SSH tests use the Docker Compose services in `docker-compose.yml`. `pitchfork`
+normally starts them automatically; if they are not running, use:
+
+```bash
+pitchfork start --all
+```
+
 ## Documentation
 
 To work on documentation:

--- a/pitchfork.toml
+++ b/pitchfork.toml
@@ -7,7 +7,7 @@ general.mise = true
 run = "docker compose up --build"
 watch = ["docker-compose.yml", "tests/fixtures/ssh-capable/Dockerfile"]
 auto = ["start", "stop"]
-ready_cmd = "bash -c '</dev/tcp/127.0.0.1/2222 && </dev/tcp/127.0.0.1/2223'"
+ready_cmd = "nc -z 127.0.0.1 2222 && nc -z 127.0.0.1 2223"
 
 [daemons.docs]
 run = "mise run docs:dev --strictPort"

--- a/pitchfork.toml
+++ b/pitchfork.toml
@@ -4,10 +4,10 @@
 general.mise = true
 
 [daemons.ssh-server]
-run = "docker compose up"
-watch = ["docker-compose.yml"]
+run = "docker compose up --build"
+watch = ["docker-compose.yml", "tests/fixtures/ssh-capable/Dockerfile"]
 auto = ["start", "stop"]
-ready_port = 2222
+ready_cmd = "bash -c '</dev/tcp/127.0.0.1/2222 && </dev/tcp/127.0.0.1/2223'"
 
 [daemons.docs]
 run = "mise run docs:dev --strictPort"

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -40,13 +40,29 @@ fn init_test_env() {
 /// cleanup so `biwa clean --auto` does not remove other tests’ remote project directories.
 /// The state directory is isolated from the developer's real XDG state.
 pub fn biwa_cmd(args: &[&str]) -> duct::Expression {
+	biwa_cmd_with_port(args, "2222")
+}
+
+fn biwa_cmd_with_port(args: &[&str], port: &str) -> duct::Expression {
 	duct::cmd(env!("CARGO_BIN_EXE_biwa"), args)
 		.env("BIWA_SSH_HOST", "127.0.0.1")
-		.env("BIWA_SSH_PORT", "2222")
+		.env("BIWA_SSH_PORT", port)
 		.env("BIWA_SSH_USER", "testuser")
 		.env("BIWA_SSH_PASSWORD", "password123")
 		.env("BIWA_CLEAN_AUTO", "false")
 		.env("BIWA_STATE_DIR", TEST_STATE_DIR.path())
+}
+
+/// Creates a `duct::Expression` to run the `biwa` CLI against the capable SSH server.
+///
+/// The capable server allows `BIWA_TEST_*` variables through SSH `setenv` and uses an
+/// SFTP subsystem that supports permission updates for files owned by the test user.
+#[allow(
+	dead_code,
+	reason = "Only some integration test binaries use the capable server."
+)]
+pub fn biwa_cmd_capable(args: &[&str]) -> duct::Expression {
+	biwa_cmd_with_port(args, "2223")
 }
 
 /// Computes the absolute path to the remote project directory.

--- a/tests/fixtures/ssh-capable/Dockerfile
+++ b/tests/fixtures/ssh-capable/Dockerfile
@@ -1,0 +1,4 @@
+FROM lscr.io/linuxserver/openssh-server@sha256:29d4e3f887596c4c2fc609f4e07040b08890a238178da400ffa2a602b55245bc
+
+RUN printf '\nAcceptEnv BIWA_TEST_*\n' >> /etc/ssh/sshd_config \
+	&& sed -i 's|^Subsystem[[:space:]]\+sftp[[:space:]].*$|Subsystem sftp /usr/lib/ssh/sftp-server -u 022|' /etc/ssh/sshd_config

--- a/tests/ssh_e2e_run.rs
+++ b/tests/ssh_e2e_run.rs
@@ -8,7 +8,7 @@ use std::io::{BufRead as _, BufReader, Read as _};
 use core::time::Duration;
 mod common;
 use color_eyre::eyre::{WrapErr as _, eyre};
-use common::{Result, biwa_cmd};
+use common::{Result, biwa_cmd, biwa_cmd_capable};
 use rstest::rstest;
 use std::{
 	env, ffi::OsStr, fs, path::PathBuf, process::Command, process::Stdio, thread, time::Instant,
@@ -654,6 +654,56 @@ fn e2e_run_env_wildcard_and_negation_from_flag() -> Result<()> {
 		String::from_utf8_lossy(&output.stdout).trim(),
 		"development|missing"
 	);
+	Ok(())
+}
+
+#[test]
+fn e2e_run_rejects_setenv_on_default_server() -> Result<()> {
+	let output = biwa_cmd(&[
+		"--quiet",
+		"run",
+		"--skip-sync",
+		"--env",
+		"BIWA_TEST_FLAG=ok",
+		"printenv",
+		"BIWA_TEST_FLAG",
+	])
+	.env("BIWA_ENV_FORWARD_METHOD", "setenv")
+	.stdout_capture()
+	.stderr_capture()
+	.unchecked()
+	.run()?;
+
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	assert!(!output.status.success(), "stderr: {stderr}");
+	assert!(
+		stderr.contains("rejected environment variable forwarding via setenv"),
+		"stderr: {stderr}"
+	);
+	Ok(())
+}
+
+#[test]
+fn e2e_run_forwards_setenv_on_capable_server() -> Result<()> {
+	let output = biwa_cmd_capable(&[
+		"--quiet",
+		"run",
+		"--skip-sync",
+		"--env",
+		"BIWA_TEST_FLAG=ok",
+		"printenv",
+		"BIWA_TEST_FLAG",
+	])
+	.env("BIWA_ENV_FORWARD_METHOD", "setenv")
+	.stdout_capture()
+	.stderr_capture()
+	.unchecked()
+	.run()?;
+
+	let stdout = String::from_utf8_lossy(&output.stdout);
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	assert!(output.status.success(), "stderr: {stderr}");
+	pretty_assertions::assert_eq!(stdout.trim(), "ok");
 	Ok(())
 }
 

--- a/tests/ssh_e2e_sync.rs
+++ b/tests/ssh_e2e_sync.rs
@@ -527,11 +527,8 @@ fn e2e_sync_setstat_permissions_on_capable_server() -> Result<()> {
 		fs::set_permissions(&file_path, perms)?;
 	}
 
-	let run_cmd = |args: &[&str]| {
-		biwa_cmd_capable_tilde(args, dir.path()).env("BIWA_SYNC_SFTP_PERMISSIONS", "setstat")
-	};
-
-	let output = run_cmd(&["sync"])
+	let output = biwa_cmd_capable_tilde(&["sync"], dir.path())
+		.env("BIWA_SYNC_SFTP_PERMISSIONS", "setstat")
 		.stdout_capture()
 		.stderr_capture()
 		.unchecked()
@@ -546,11 +543,14 @@ fn e2e_sync_setstat_permissions_on_capable_server() -> Result<()> {
 
 	let remote_proj_dir = common::get_remote_project_dir(dir.path())?;
 	let remote_file = format!("{remote_proj_dir}/secret.txt");
-	let ls_output = run_cmd(&["run", "--skip-sync", "ls", "-l", &remote_file])
-		.stdout_capture()
-		.stderr_capture()
-		.unchecked()
-		.run()?;
+	let ls_output = biwa_cmd_capable_tilde(
+		&["run", "--skip-sync", "ls", "-l", &remote_file],
+		dir.path(),
+	)
+	.stdout_capture()
+	.stderr_capture()
+	.unchecked()
+	.run()?;
 
 	let ls_stdout = String::from_utf8_lossy(&ls_output.stdout);
 	assert!(

--- a/tests/ssh_e2e_sync.rs
+++ b/tests/ssh_e2e_sync.rs
@@ -19,8 +19,16 @@ fn biwa_cmd(args: &[&str], current_dir: &Path) -> duct::Expression {
 	common::biwa_cmd(args).dir(current_dir)
 }
 
+fn biwa_cmd_capable(args: &[&str], current_dir: &Path) -> duct::Expression {
+	common::biwa_cmd_capable(args).dir(current_dir)
+}
+
 fn biwa_cmd_tilde(args: &[&str], current_dir: &Path) -> duct::Expression {
 	biwa_cmd(args, current_dir).env("BIWA_SYNC_REMOTE_ROOT", "~/.cache/biwa/projects")
+}
+
+fn biwa_cmd_capable_tilde(args: &[&str], current_dir: &Path) -> duct::Expression {
+	biwa_cmd_capable(args, current_dir).env("BIWA_SYNC_REMOTE_ROOT", "~/.cache/biwa/projects")
 }
 
 #[test]
@@ -500,6 +508,59 @@ fn e2e_sync_permissions(
 	assert!(
 		ls_group_stdout.contains(expected_group),
 		"group stdout: {ls_group_stdout}"
+	);
+	Ok(())
+}
+
+#[test]
+fn e2e_sync_setstat_permissions_on_capable_server() -> Result<()> {
+	let dir = tempfile::tempdir()?;
+	let file_path = dir.path().join("secret.txt");
+	fs::write(&file_path, "secret")?;
+
+	#[cfg(unix)]
+	{
+		use std::os::unix::fs::PermissionsExt as _;
+
+		let mut perms = fs::metadata(&file_path)?.permissions();
+		perms.set_mode(0o644);
+		fs::set_permissions(&file_path, perms)?;
+	}
+
+	let run_cmd = |args: &[&str]| {
+		biwa_cmd_capable_tilde(args, dir.path()).env("BIWA_SYNC_SFTP_PERMISSIONS", "setstat")
+	};
+
+	let output = run_cmd(&["sync"])
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
+
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	assert!(output.status.success(), "stderr: {stderr}");
+	assert!(
+		!stderr.contains("Failed to enforce file permissions via fsetstat"),
+		"stderr: {stderr}"
+	);
+
+	let remote_proj_dir = common::get_remote_project_dir(dir.path())?;
+	let remote_file = format!("{remote_proj_dir}/secret.txt");
+	let ls_output = run_cmd(&["run", "--skip-sync", "ls", "-l", &remote_file])
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
+
+	let ls_stdout = String::from_utf8_lossy(&ls_output.stdout);
+	assert!(
+		ls_output.status.success(),
+		"ls failed for {remote_file}: {ls_stdout}\nstderr: {}",
+		String::from_utf8_lossy(&ls_output.stderr)
+	);
+	assert!(
+		ls_stdout.contains("-rw-------"),
+		"File {remote_file} does not have 0600 permissions. ls output: {ls_stdout}"
 	);
 	Ok(())
 }


### PR DESCRIPTION
## Summary
- add a capable SSH test image and compose/pitchfork wiring on port 2223
- add explicit e2e coverage for default-server setenv rejection and capable-server setenv success
- add capable-server SFTP setstat permission coverage

Closes #368

## Local verification
- cargo test --test ssh_e2e_run
- cargo test --test ssh_e2e_sync
- cargo clippy --all-targets -- --deny warnings
- LINT=true mise run check:actionlint
- LINT=true mise run check:pinact
- LINT=true mise run check:ghalint
- LINT=true mise run check:zizmor
- LINT=true mise run check:yamllint
- LINT=true mise run check:oxfmt

Note: I started full `LINT=true mise run check`; all non-Rust subtasks completed successfully, then I stopped its clippy subtask because the local cargo wrapper was queued behind unrelated jobs and reran the same clippy command directly with pinned Cargo.
