### PR TITLE
ci: deploy docs from GitHub Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,90 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/docs.yml
+      - docs/**
+      - mise.toml
+      - mise.lock
+      - tasks/docs/**
+      - tasks.toml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/docs.yml
+      - docs/**
+      - mise.toml
+      - mise.lock
+      - tasks/docs/**
+      - tasks.toml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  docs:
+    name: Build docs
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read # for checkout
+
+    env:
+      MISE_RUSTUP_HOME: /home/runner/.local/share/mise/rustup
+      MISE_CARGO_HOME: /home/runner/.local/share/mise/cargo
+      CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          version: 2026.5.11
+          install_args: --locked
+        env:
+          MISE_ENABLE_TOOLS: bun,node,wrangler
+
+      - name: Build docs
+        run: mise run docs:build
+
+      - name: Check Cloudflare token
+        id: cloudflare-token
+        if: github.repository == 'risu729/biwa' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          if [[ -n "${CLOUDFLARE_API_TOKEN}" ]]; then
+            echo "available=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "available=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Upload docs preview
+        if: github.repository == 'risu729/biwa' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.cloudflare-token.outputs.available == 'true'
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          WORKER_NAME: biwa-docs
+        run: mise run docs:deploy -- preview
+
+      - name: Deploy docs
+        if: github.repository == 'risu729/biwa' && github.event_name != 'pull_request' && steps.cloudflare-token.outputs.available == 'true'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: mise run docs:deploy

--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -12,7 +12,6 @@
         "vitepress": "2.0.0-alpha.17",
         "vitepress-plugin-mermaid": "2.0.17",
         "vue-tsc": "3.2.9",
-        "wrangler": "4.92.0",
       },
     },
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,11 +1,6 @@
 {
 	"$schema": "https://www.schemastore.org/package",
 	"type": "module",
-	"scripts": {
-		"build": "vitepress build",
-		"deploy": "wrangler deploy --config .vitepress/dist/wrangler.json",
-		"deploy-preview": "wrangler versions upload --config .vitepress/dist/wrangler.json"
-	},
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "1.37.1",
 		"@risu729/tsconfigs": "3.0.0",
@@ -14,8 +9,7 @@
 		"typescript": "6.0.3",
 		"vitepress": "2.0.0-alpha.17",
 		"vitepress-plugin-mermaid": "2.0.17",
-		"vue-tsc": "3.2.9",
-		"wrangler": "4.92.0"
+		"vue-tsc": "3.2.9"
 	},
 	"overrides": {
 		"vite": "8.0.13"

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -6,7 +6,8 @@
 		"src/**/*.vue",
 		".vitepress/**/*.ts",
 		".vitepress/**/*.vue",
-		"vite-env.d.ts"
+		"vite-env.d.ts",
+		"../tasks/docs/**/*.ts"
 	],
 	"exclude": ["node_modules", "dist"],
 	"compilerOptions": {

--- a/mise.lock
+++ b/mise.lock
@@ -216,9 +216,41 @@ checksum = "sha256:a48eb40fc541a440ac0e62a22bfb7984819a1409591b4ce7e20d3d1a01625
 url = "https://github.com/xd009642/tarpaulin/releases/download/0.35.4/cargo-tarpaulin-x86_64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/xd009642/tarpaulin/releases/assets/405218940"
 
+[[tools.node]]
+version = "25.9.0"
+backend = "core:node"
+
+[tools.node."platforms.linux-arm64"]
+checksum = "sha256:8fb4283301b8c720fc9f18bffff0f659e72cc14d0cf207a3bb411808aaa73a57"
+url = "https://nodejs.org/dist/v25.9.0/node-v25.9.0-linux-arm64.tar.gz"
+
+[tools.node."platforms.linux-arm64-musl"]
+checksum = "sha256:97f6fe125faa51f84a7bb600d0cd7aefcfaaa0e75a5f49a7c61c3df91d12d535"
+url = "https://unofficial-builds.nodejs.org/download/release/v25.9.0/node-v25.9.0-linux-arm64-musl.tar.gz"
+
+[tools.node."platforms.linux-x64"]
+checksum = "sha256:134e55b2408448a219760fe04dc44d6851f9de8a79549021ffd870e9082d9e7b"
+url = "https://nodejs.org/dist/v25.9.0/node-v25.9.0-linux-x64.tar.gz"
+
+[tools.node."platforms.linux-x64-musl"]
+checksum = "sha256:1ac44af012be6bc17f1e3723edbf12897c0baeae5d1dc75b9f97d71413e4c8f5"
+url = "https://unofficial-builds.nodejs.org/download/release/v25.9.0/node-v25.9.0-linux-x64-musl.tar.gz"
+
+[tools.node."platforms.macos-arm64"]
+checksum = "sha256:e479f3c469d3d9303a44f00a8ea37a3788395d171bb8059c48a4bbbd2e371b59"
+url = "https://nodejs.org/dist/v25.9.0/node-v25.9.0-darwin-arm64.tar.gz"
+
+[tools.node."platforms.macos-x64"]
+checksum = "sha256:7d737b53ce191142bfa1c17cfa5b070d96e84eebf76b8dd06d84981cbdc3f7e3"
+url = "https://nodejs.org/dist/v25.9.0/node-v25.9.0-darwin-x64.tar.gz"
+
 [[tools."npm:ajv-cli"]]
 version = "5.0.0"
 backend = "npm:ajv-cli"
+
+[[tools."npm:wrangler"]]
+version = "4.92.0"
+backend = "npm:wrangler"
 
 [[tools.oxfmt]]
 version = "0.48.0"
@@ -451,6 +483,10 @@ provenance = "github-attestations"
 checksum = "sha256:42bca7cc879d117ed7139a0e26de8cab0b6f033ad439a32144f324d1f8580d8c"
 url = "https://github.com/astral-sh/uv/releases/download/0.11.15/uv-x86_64-apple-darwin.tar.gz"
 provenance = "github-attestations"
+
+[[tools.wrangler]]
+version = "4.92.0"
+backend = "npm:wrangler"
 
 [[tools.yamllint]]
 version = "1.38.0"

--- a/mise.toml
+++ b/mise.toml
@@ -16,11 +16,13 @@ typos = "1.46.2"
 release-plz = "0.3.158"
 cargo-dist = "0.31.0"
 bun = "1.3.14"
+node = "25.9.0"
 oxlint = "1.63.0"
 oxfmt = "0.48.0"
 pitchfork = "2.11.0"
 tombi = "0.11.5"
 "npm:ajv-cli" = "5.0.0"
+wrangler = "4.92.0"
 yq = "4.53.2"
 
 [settings]

--- a/tasks.toml
+++ b/tasks.toml
@@ -94,7 +94,7 @@ dir = "docs"
 description = "Start VitePress development server."
 
 ["docs:build"]
-run = "bun run --bun build"
+run = "bun run --bun vitepress build"
 dir = "docs"
 description = "Build VitePress documentation for production."
 

--- a/tasks/docs/deploy.ts
+++ b/tasks/docs/deploy.ts
@@ -1,0 +1,248 @@
+#!/usr/bin/env bun
+//MISE description="Deploy the VitePress docs with Cloudflare Wrangler."
+
+import { createHash } from "node:crypto";
+import { appendFile, mkdir, readdir, rm } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+import { $ } from "bun";
+
+type Mode = "preview" | "production";
+
+type WranglerOutputEntry =
+	| {
+			type: "deploy";
+			targets?: string[];
+	  }
+	| {
+			type: "version-upload";
+			preview_url?: string;
+			preview_alias_url?: string;
+	  }
+	| {
+			type: string;
+	  };
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+const docsDir = join(repoRoot, "docs");
+const configPath = ".vitepress/dist/wrangler.json";
+const workerName = process.env["WORKER_NAME"] ?? "biwa-docs";
+
+await main();
+
+async function main() {
+	const { mode, wranglerArgs } = parseArgs(process.argv.slice(2));
+	const dryRun = wranglerArgs.includes("--dry-run");
+	const outputDir = join(
+		process.env["RUNNER_TEMP"] ?? "/tmp",
+		`wrangler-output-${mode}-${process.pid}`,
+	);
+
+	process.chdir(docsDir);
+	process.env["WRANGLER_OUTPUT_FILE_DIRECTORY"] = outputDir;
+
+	await rm(outputDir, { force: true, recursive: true });
+	await mkdir(outputDir, { recursive: true });
+
+	if (mode === "preview") {
+		await uploadPreview({ dryRun, outputDir, wranglerArgs });
+		return;
+	}
+
+	await deployProduction({ outputDir, wranglerArgs });
+}
+
+function parseArgs(args: string[]): { mode: Mode; wranglerArgs: string[] } {
+	if (args[0] === "preview" || args[0] === "production") {
+		return { mode: args[0], wranglerArgs: args.slice(1) };
+	}
+	if (args[0] && !args[0].startsWith("-")) {
+		throw new Error("Usage: mise run docs:deploy -- [preview|production] [wrangler args...]");
+	}
+	return { mode: "production", wranglerArgs: args };
+}
+
+async function uploadPreview({
+	dryRun,
+	outputDir,
+	wranglerArgs,
+}: {
+	dryRun: boolean;
+	outputDir: string;
+	wranglerArgs: string[];
+}) {
+	const branchName = await resolveBranchName();
+	const previewAlias =
+		process.env["PREVIEW_ALIAS"] ?? resolvePreviewAlias({ branchName, workerName });
+
+	await $`wrangler versions upload --config ${configPath} --preview-alias ${previewAlias} ${wranglerArgs}`;
+
+	const upload = await findWranglerOutput({ outputDir, type: "version-upload" });
+	if (!upload) {
+		if (dryRun) {
+			return;
+		}
+		throw new Error("Unable to find Wrangler version upload output");
+	}
+
+	const previewUrl = upload.preview_url ?? "";
+	const previewAliasUrl = upload.preview_alias_url ?? "";
+	await appendOutput([`preview-url=${previewUrl}`, `preview-alias-url=${previewAliasUrl}`, ""]);
+	await appendSummary([
+		"### Cloudflare Workers Preview",
+		"",
+		`Branch alias: \`${previewAlias}\``,
+		"",
+		"| Name | URL |",
+		"| - | - |",
+		`| Version preview | ${link(previewUrl)} |`,
+		`| Branch alias preview | ${link(previewAliasUrl)} |`,
+		"",
+	]);
+}
+
+async function deployProduction({
+	outputDir,
+	wranglerArgs,
+}: {
+	outputDir: string;
+	wranglerArgs: string[];
+}) {
+	await $`wrangler deploy --config ${configPath} ${wranglerArgs}`;
+
+	const deploy = await findWranglerOutput({ outputDir, type: "deploy" });
+	const targets = deploy?.targets ?? [];
+	await appendSummary([
+		"### Cloudflare Workers Production Deploy",
+		"",
+		"| Target |",
+		"| - |",
+		...(targets.length > 0 ? targets.map((target) => `| <${target}> |`) : ["| _Unavailable_ |"]),
+		"",
+	]);
+}
+
+async function resolveBranchName(): Promise<string> {
+	const branchName = process.env["BRANCH_NAME"];
+	if (branchName) {
+		return branchName;
+	}
+	const headRef = process.env["GITHUB_HEAD_REF"];
+	if (headRef) {
+		return headRef;
+	}
+	const refName = process.env["GITHUB_REF_NAME"];
+	if (refName) {
+		return refName;
+	}
+	try {
+		return (await $`git rev-parse --abbrev-ref HEAD`.quiet().text()).trim();
+	} catch {
+		return "";
+	}
+}
+
+function resolvePreviewAlias({
+	branchName,
+	workerName,
+}: {
+	branchName: string;
+	workerName: string;
+}): string {
+	const fallbackSha = process.env["GITHUB_SHA"]?.slice(0, 8) ?? "local";
+	let alias = branchName
+		.toLowerCase()
+		.replaceAll(/[^a-z0-9-]+/g, "-")
+		.replaceAll(/-+/g, "-")
+		.replaceAll(/^-+|-+$/g, "");
+
+	if (!alias) {
+		alias = `branch-${fallbackSha}`;
+	}
+	if (!/^[a-z]/.test(alias)) {
+		alias = `branch-${alias}`;
+	}
+
+	const maxLength = 63 - workerName.length - 1;
+	if (maxLength < 1) {
+		throw new Error("Worker name is too long for a preview alias");
+	}
+	if (alias.length <= maxLength) {
+		return alias;
+	}
+
+	const hash = createHash("sha256").update(branchName).digest("hex").slice(0, 4);
+	const prefixLength = maxLength - hash.length - 1;
+	if (prefixLength < 1) {
+		throw new Error("Worker name leaves no room for a preview alias hash");
+	}
+	return `${alias.slice(0, prefixLength)}-${hash}`;
+}
+
+async function findWranglerOutput<Type extends WranglerOutputEntry["type"]>({
+	outputDir,
+	type,
+}: {
+	outputDir: string;
+	type: Type;
+}): Promise<Extract<WranglerOutputEntry, { type: Type }> | undefined> {
+	for (const path of await readdir(outputDir)) {
+		if (!path.startsWith("wrangler-output-") || !path.endsWith(".json")) {
+			continue;
+		}
+		for await (const line of readLines(join(outputDir, path))) {
+			const entry = JSON.parse(line) as WranglerOutputEntry;
+			if (entry.type === type) {
+				return entry as Extract<WranglerOutputEntry, { type: Type }>;
+			}
+		}
+	}
+	return undefined;
+}
+
+async function* readLines(path: string): AsyncGenerator<string> {
+	const reader = Bun.file(path).stream().pipeThrough(new TextDecoderStream()).getReader();
+	let buffered = "";
+
+	while (true) {
+		const { value, done } = await reader.read();
+		if (done) {
+			break;
+		}
+
+		buffered += value;
+		const lines = buffered.split("\n");
+		buffered = lines.pop() ?? "";
+		for (const line of lines) {
+			const trimmed = line.trim();
+			if (trimmed) {
+				yield trimmed;
+			}
+		}
+	}
+
+	const trimmed = buffered.trim();
+	if (trimmed) {
+		yield trimmed;
+	}
+}
+
+async function appendOutput(lines: string[]) {
+	await appendGitHubFile("GITHUB_OUTPUT", lines);
+}
+
+async function appendSummary(lines: string[]) {
+	await appendGitHubFile("GITHUB_STEP_SUMMARY", lines);
+}
+
+async function appendGitHubFile(name: string, lines: string[]) {
+	const path = process.env[name];
+	if (!path) {
+		return;
+	}
+	await appendFile(path, lines.join("\n"), "utf8");
+}
+
+function link(url: string) {
+	return url ? `<${url}>` : "_Unavailable_";
+}


### PR DESCRIPTION
## Summary
- add mise-managed Node 25.9.0 and `wrangler` 4.92.0 for docs deploys
- remove the direct docs `wrangler` dev dependency so deploys use the mise registry Wrangler, not package.json
- remove docs npm scripts entirely; docs commands now run through mise tasks
- add an executable Bun/TypeScript mise task at `tasks/docs/deploy.ts` for production deploys and PR preview uploads
- include the deploy task in the docs TypeScript check
- add the `Docs / Build docs` GitHub Actions workflow and keep deploy logic out of workflow YAML
- use the official `jdx/mise-action` with the same mise-managed Rust home workaround used by the other workflows
- read `CLOUDFLARE_ACCOUNT_ID` from repository variables and `CLOUDFLARE_API_TOKEN` from secrets
- gate deploy/upload steps when the Cloudflare token secret is absent; the Bun task assumes credentials exist when invoked
- deploy production docs with `wrangler deploy --config .vitepress/dist/wrangler.json`
- upload same-repository PR previews with `wrangler versions upload --preview-alias <branch-alias>`
- write production and preview URLs to `$GITHUB_STEP_SUMMARY`, not PR comments

## Split
- #647 has been merged, so this PR is rebased onto current `main`.
- #648 was folded back into this PR because the mise-managed Wrangler deploy task and the GitHub Actions deploy workflow need to land together while the old Cloudflare dashboard-side deploy integration is still active.
- Remaining split in this PR:
  - `chore(mise): manage docs deploy tooling`
  - `ci: deploy docs from GitHub Actions`

## Cloudflare token scopes
For `CLOUDFLARE_API_TOKEN`, start from Cloudflare's `Edit Cloudflare Workers` custom token policy, then scope it down to this account and the `takuk.me` zone.

Required for this workflow:
- Account resource: target account only.
- Account permission: `Workers Scripts: Edit` in the dashboard, documented by the API as `Workers Scripts Write`. This covers Worker script/version/deployment writes, static asset upload sessions, `wrangler versions upload`, `wrangler deploy`, and Workers custom-domain attachment.
- Zone resource: `takuk.me` only.
- Zone permission: `Zone: Read`. Wrangler resolves `biwa.takuk.me` to a zone with `GET /zones?name=...&account.id=...`, and that endpoint requires zone read.
- Zone permission: `Workers Routes: Read` is enough for route-conflict/list checks; `Workers Routes: Edit` is required if this config ever deploys normal Workers routes instead of only a Workers Custom Domain. The Cloudflare Workers token template uses route edit.

DNS note:
- The current `docs/wrangler.jsonc` uses a Workers Custom Domain (`routes[].custom_domain: true`) for `biwa.takuk.me`. Cloudflare's custom-domain docs say Cloudflare creates the DNS record on your behalf, and the Workers `Attach Domain` API currently lists `Workers Scripts Write` as its accepted permission.
- Do not add `DNS: Edit` unless deploy proves it is needed to overwrite or remove an existing conflicting DNS record outside the Workers Custom Domain API flow. If it is needed, restrict it to the `takuk.me` zone only and treat it as elevated access because it can edit DNS records.

References checked:
- https://developers.cloudflare.com/workers/ci-cd/external-cicd/github-actions/
- https://developers.cloudflare.com/api/resources/workers/subresources/scripts/subresources/deployments/methods/create/
- https://developers.cloudflare.com/api/resources/workers/subresources/routes/methods/create/
- https://developers.cloudflare.com/api/resources/workers/subresources/domains/methods/update
- https://developers.cloudflare.com/api/resources/zones/methods/list/
- https://developers.cloudflare.com/fundamentals/api/reference/permissions/

## Why not `cloudflare/wrangler-action`
I checked the current `cloudflare/wrangler-action` source. It now reads Wrangler output artifacts for Workers `deploy` and `versions upload`, but it still does not fit this workflow:
- It installs/runs Wrangler through the action package-manager path, while this repo wants the mise registry tool to be the single pinned Wrangler source.
- Its job-summary support is tied to Pages deploy artifacts. Workers `versions upload` only sets `deployment-url` from `preview_url`; it does not summarize both the version preview URL and the branch alias preview URL.
- This workflow needs a branch alias table in `$GITHUB_STEP_SUMMARY` and no PR comment path.

Wrangler 4.92.0 does not expose `--json` for the two commands this workflow runs (`wrangler deploy` and `wrangler versions upload`), so the task reads `WRANGLER_OUTPUT_FILE_DIRECTORY` JSONL artifacts instead. Commands that support `--json` are not part of this deploy path.

## Notes / what to do
- Repository variable `CLOUDFLARE_ACCOUNT_ID` is set to `59ea63cc00914b30ca410b062ae2bb7f`.
- Configure repository Actions secret `CLOUDFLARE_API_TOKEN`.
- Until `CLOUDFLARE_API_TOKEN` exists, the GitHub Actions deploy/upload steps are skipped so docs build checks can still settle. Once the secret is configured, the task assumes credentials are present and lets Wrangler handle auth failures.
- Disable the Cloudflare dashboard-side Workers Builds integration when this lands. Otherwise Cloudflare's built-in Git integration can continue deploying and posting PR comments/checks in parallel with this workflow.
- PR preview deployment remains skipped for fork PRs because the preview step only runs for same-repository PRs.
- `workflow_dispatch` is enabled for manual production deploys.
- `docs/wrangler.jsonc` intentionally keeps production `workers_dev` disabled while enabling preview URLs with `preview_urls: true`. Cloudflare now defaults `preview_urls` from `workers_dev` when omitted, so the explicit `preview_urls: true` is needed for preview aliases while `workers_dev: false` remains in effect for production.
- Current Cloudflare preview URL docs checked:
  - https://developers.cloudflare.com/workers/configuration/previews/
  - https://developers.cloudflare.com/workers/configuration/routing/workers-dev/
  - https://developers.cloudflare.com/changelog/2025-10-23-preview-url-default-behavior/
- `node` 25.9.0 and `wrangler` 4.92.0 were resolved through mise. `wrangler` on PATH also resolves to the mise-managed 4.92.0 install.

## Verification
- `mise lock`
- `mise run docs:build`
- `mise run docs:deploy -- --dry-run`
- `BRANCH_NAME='ci/cloudflare-docs-deploy' mise run docs:deploy -- preview --dry-run`
- `mise run check:tombi`
- `mise run check:tsc`
- `mise run check:actionlint`
- `LINT=true mise run check:pinact`
- `LINT=true mise run check:ghalint`
- `mise run check:yamllint`
- `LINT=true mise run check:zizmor`
- `mise run check:oxfmt`
- `LINT=true mise run check:oxlint`
- `LINT=true mise run check:typos`
- `mise x -- node --version` -> `v25.9.0`
- `mise x -- wrangler --version` -> `4.92.0`
- `command -v wrangler && wrangler --version` -> mise-managed Wrangler 4.92.0
