### PR TITLE
fix: clean stale SSH test containers

### DIFF
--- a/pitchfork.toml
+++ b/pitchfork.toml
@@ -4,8 +4,12 @@
 general.mise = true
 
 [daemons.ssh-server]
-run = "docker compose up --build"
-watch = ["docker-compose.yml", "tests/fixtures/ssh-capable/Dockerfile"]
+run = "./tasks/start-ssh-server"
+watch = [
+	"docker-compose.yml",
+	"tasks/start-ssh-server",
+	"tests/fixtures/ssh-capable/Dockerfile"
+]
 auto = ["start", "stop"]
 ready_cmd = "nc -z 127.0.0.1 2222 && nc -z 127.0.0.1 2223"
 

--- a/tasks/start-ssh-server
+++ b/tasks/start-ssh-server
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+containers=(
+	ssh_test_server
+	ssh_test_server_capable
+)
+
+for container in "${containers[@]}"; do
+	status=$(docker inspect --format '{{.State.Status}}' "${container}" 2>/dev/null || true)
+	if [[ -n "${status}" && "${status}" != "running" ]]; then
+		echo "Removing stale SSH test container ${container} (${status})." >&2
+		docker rm --force "${container}" >/dev/null
+	fi
+done
+
+exec docker compose up --build

--- a/tasks/start-ssh-server
+++ b/tasks/start-ssh-server
@@ -2,17 +2,20 @@
 
 set -euo pipefail
 
-containers=(
-	ssh_test_server
-	ssh_test_server_capable
+# Use configured container names because stale containers can belong to an older
+# Compose project and therefore not appear in `docker compose ps`.
+container_names=$(
+	docker compose config --format json \
+		| yq --input-format json --output-format tsv '.services[].container_name | select(. != null)'
 )
 
-for container in "${containers[@]}"; do
+while IFS= read -r container; do
+	[[ -n "${container}" ]] || continue
 	status=$(docker inspect --format '{{.State.Status}}' "${container}" 2>/dev/null || true)
 	if [[ -n "${status}" && "${status}" != "running" ]]; then
 		echo "Removing stale SSH test container ${container} (${status})." >&2
 		docker rm --force "${container}" >/dev/null
 	fi
-done
+done <<<"${container_names}"
 
 exec docker compose up --build


### PR DESCRIPTION
## Summary
- route the pitchfork SSH daemon through a startup helper
- remove existing SSH test containers when Docker reports they are not running
- keep normal `docker compose up --build` lifecycle behavior after cleanup

## Why

`docker-compose.yml` uses explicit `container_name` values for the SSH test servers. Those names are global in Docker, not scoped to a Compose project or temporary checkout. If an earlier `pitchfork`/Compose run leaves `ssh_test_server` or `ssh_test_server_capable` behind in an exited state, a later `pitchfork start ssh-server` fails before it can recreate the service:

```text
Conflict. The container name "/ssh_test_server" is already in use
```

`docker compose up --build` does not automatically remove that stopped container, and pitchfork only sees the Compose startup failure. The wrapper fixes that narrow startup case by reading the configured `container_name` values from `docker compose config`, removing only containers that already exist and are not `running`, then handing off to the same `docker compose up --build` command. Running containers are left alone so an active SSH test server is not interrupted.

## Verification
- `bash -n tasks/start-ssh-server`
- `pitchfork start ssh-server`
- `cargo test --test ssh_e2e_run e2e_run_command`
- `LINT=true mise run check:tombi`
- `LINT=true mise run check:typos`