### PR TITLE
docs: align Cloudflare Workers config

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -39,3 +39,4 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 # Wrangler auto-generated files
 .wrangler
+.dev.vars*

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -66,7 +66,9 @@ export default withMermaid(
 			plugins: [
 				// Cloudflare plugin doesn't work on dev for some reason
 				// oxlint-disable-next-line no-undef
-				...(process.env.NODE_ENV === "production" ? [cloudflare()] : []),
+				...(process.env.NODE_ENV === "production"
+					? [cloudflare({ configPath: "../wrangler.jsonc" })]
+					: []),
 			],
 		},
 	}),

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,8 +3,8 @@
 	"type": "module",
 	"scripts": {
 		"build": "vitepress build",
-		"deploy": "wrangler deploy",
-		"deploy-preview": "wrangler versions upload"
+		"deploy": "wrangler deploy --config .vitepress/dist/wrangler.json",
+		"deploy-preview": "wrangler versions upload --config .vitepress/dist/wrangler.json"
 	},
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "1.37.0",

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -10,6 +10,7 @@
 	],
 	"exclude": ["node_modules", "dist"],
 	"compilerOptions": {
-		"types": ["bun"]
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"types": ["bun", "vite/client"]
 	}
 }

--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -2,6 +2,7 @@
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "biwa-docs",
 	"compatibility_date": "2026-05-15",
+	"workers_dev": false,
 	"preview_urls": true,
 	"routes": [
 		{
@@ -10,7 +11,6 @@
 		},
 	],
 	"assets": {
-		"directory": "./.vitepress/dist",
 		"not_found_handling": "single-page-application",
 	},
 }


### PR DESCRIPTION
## Summary
- point the Cloudflare Vite plugin at `docs/wrangler.jsonc` so the generated Worker config keeps the intended `biwa-docs` service name
- deploy from the generated `.vitepress/dist/wrangler.json` config
- keep production `workers.dev` disabled with `workers_dev: false`, while leaving preview URLs enabled
- align docs TypeScript and local Cloudflare ignores with the current Workers Vite plugin tutorial

## Split
- First PR in the split.
- Follow-up: #633 contains the mise-managed Wrangler tooling and GitHub Actions deploy workflow.

## Verification
- `mise run docs:build`
- `mise run check:tsc`
- `LINT=true mise run check:oxfmt`
- `cd docs && bun run deploy --dry-run`