### PR TITLE
chore(mise): manage Wrangler for docs deploys

### DIFF
--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -12,7 +12,6 @@
         "vitepress": "2.0.0-alpha.17",
         "vitepress-plugin-mermaid": "2.0.17",
         "vue-tsc": "3.2.9",
-        "wrangler": "4.91.0",
       },
     },
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,8 +3,8 @@
 	"type": "module",
 	"scripts": {
 		"build": "vitepress build",
-		"deploy": "wrangler deploy --config .vitepress/dist/wrangler.json",
-		"deploy-preview": "wrangler versions upload --config .vitepress/dist/wrangler.json"
+		"deploy": "mise x --no-deps -- wrangler deploy --config .vitepress/dist/wrangler.json",
+		"deploy-preview": "mise x --no-deps -- wrangler versions upload --config .vitepress/dist/wrangler.json"
 	},
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "1.37.0",
@@ -14,8 +14,7 @@
 		"typescript": "6.0.3",
 		"vitepress": "2.0.0-alpha.17",
 		"vitepress-plugin-mermaid": "2.0.17",
-		"vue-tsc": "3.2.9",
-		"wrangler": "4.91.0"
+		"vue-tsc": "3.2.9"
 	},
 	"overrides": {
 		"vite": "8.0.13"

--- a/mise.lock
+++ b/mise.lock
@@ -216,9 +216,41 @@ checksum = "sha256:a48eb40fc541a440ac0e62a22bfb7984819a1409591b4ce7e20d3d1a01625
 url = "https://github.com/xd009642/tarpaulin/releases/download/0.35.4/cargo-tarpaulin-x86_64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/xd009642/tarpaulin/releases/assets/405218940"
 
+[[tools.node]]
+version = "24.15.0"
+backend = "core:node"
+
+[tools.node."platforms.linux-arm64"]
+checksum = "sha256:73afc234d558c24919875f51c2d1ea002a2ada4ea6f83601a383869fefa64eed"
+url = "https://nodejs.org/dist/v24.15.0/node-v24.15.0-linux-arm64.tar.gz"
+
+[tools.node."platforms.linux-arm64-musl"]
+checksum = "sha256:31e98aa960a067da91edffd5d93bc46657b5d2a8029612c359f5f2ac0060152a"
+url = "https://unofficial-builds.nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-arm64-musl.tar.gz"
+
+[tools.node."platforms.linux-x64"]
+checksum = "sha256:44836872d9aec49f1e6b52a9a922872db9a2b02d235a616a5681b6a85fec8d89"
+url = "https://nodejs.org/dist/v24.15.0/node-v24.15.0-linux-x64.tar.gz"
+
+[tools.node."platforms.linux-x64-musl"]
+checksum = "sha256:f55af5bd489c5347b113ca6594cae00a54b30ba57ac5875324311bfc6f4762e3"
+url = "https://unofficial-builds.nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-x64-musl.tar.gz"
+
+[tools.node."platforms.macos-arm64"]
+checksum = "sha256:372331b969779ab5d15b949884fc6eaf88d5afe87bde8ba881d6400b9100ffc4"
+url = "https://nodejs.org/dist/v24.15.0/node-v24.15.0-darwin-arm64.tar.gz"
+
+[tools.node."platforms.macos-x64"]
+checksum = "sha256:ffd5ee293467927f3ee731a553eb88fd1f48cf74eebc2d74a6babe4af228673b"
+url = "https://nodejs.org/dist/v24.15.0/node-v24.15.0-darwin-x64.tar.gz"
+
 [[tools."npm:ajv-cli"]]
 version = "5.0.0"
 backend = "npm:ajv-cli"
+
+[[tools."npm:wrangler"]]
+version = "4.92.0"
+backend = "npm:wrangler"
 
 [[tools.oxfmt]]
 version = "0.48.0"

--- a/mise.toml
+++ b/mise.toml
@@ -16,11 +16,13 @@ typos = "1.46.2"
 release-plz = "0.3.158"
 cargo-dist = "0.31.0"
 bun = "1.3.14"
+node = "24.15.0"
 oxlint = "1.63.0"
 oxfmt = "0.48.0"
 pitchfork = "2.11.0"
 tombi = "0.11.5"
 "npm:ajv-cli" = "5.0.0"
+"npm:wrangler" = "4.92.0"
 yq = "4.53.2"
 
 [settings]


### PR DESCRIPTION
## Summary
- add mise-managed Node 24.15.0 and `npm:wrangler` 4.92.0
- remove the direct docs `wrangler` dev dependency
- run docs deploy scripts through `mise x --no-deps -- wrangler`, while leaving the Vite plugin's transitive Wrangler dependency in `bun.lock`

## Split
- Depends on #647.
- Follow-up: #633 adds the GitHub Actions deploy workflow.

## Notes
- The Cloudflare dashboard-side `Workers Builds: biwa-docs` integration may still run on this PR. That is external to these repo changes and is being replaced by #633.

## Verification
- `mise run docs:build`
- `mise run check:tsc`
- `LINT=true mise run check:oxfmt`
- `mise x --no-deps -- wrangler --version` -> `4.92.0`
- `cd docs && bun run deploy --dry-run`