### PR TITLE
ci: use official mise-action for rust caches

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -43,7 +43,7 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.5
-          cache_key: "{{default}}-rustup-cargo-home-v1"
+          cache_key: "{{default}}-rustup-cargo-home-v2"
 
       - name: Update mise lockfile
         if: github.event.pull_request.user.login == 'renovate[bot]'

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -32,11 +32,18 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure mise Rust homes
+        run: |
+          {
+            echo "MISE_RUSTUP_HOME=${HOME}/.local/share/mise/rustup"
+            echo "MISE_CARGO_HOME=${HOME}/.local/share/mise/cargo"
+          } >> "${GITHUB_ENV}"
+
       - name: Install mise
-        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # zizmor: ignore[stale-action-refs,ref-version-mismatch] temporary SHA for jdx/mise-action PR 467
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.5
-          cache_rust: true
+          cache_key: "{{default}}-rustup-cargo-home-v1"
 
       - name: Update mise lockfile
         if: github.event.pull_request.user.login == 'renovate[bot]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         with:
           version: 2026.5.5
           install_args: --locked
-          cache_key: "{{default}}-rustup-cargo-home-v1"
+          cache_key: "{{default}}-rustup-cargo-home-v2"
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -143,7 +143,7 @@ jobs:
         with:
           version: 2026.5.5
           install_args: --locked
-          cache_key: "{{default}}-rustup-cargo-home-v1"
+          cache_key: "{{default}}-rustup-cargo-home-v2"
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -187,7 +187,7 @@ jobs:
         with:
           version: 2026.5.5
           install_args: --locked
-          cache_key: "{{default}}-rustup-cargo-home-v1"
+          cache_key: "{{default}}-rustup-cargo-home-v2"
 
       - name: Validate schema
         run: mise run schema

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,15 +85,24 @@ jobs:
       - name: Start SSH test services
         run: docker compose up --build --detach --wait --wait-timeout 60
 
+      - name: Configure mise Rust homes
+        run: |
+          {
+            echo "MISE_RUSTUP_HOME=${HOME}/.local/share/mise/rustup"
+            echo "MISE_CARGO_HOME=${HOME}/.local/share/mise/cargo"
+          } >> "${GITHUB_ENV}"
+
       - name: Install mise
-        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # zizmor: ignore[stale-action-refs,ref-version-mismatch] temporary SHA for jdx/mise-action PR 467
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.5
           install_args: --locked
-          cache_rust: true
+          cache_key: "{{default}}-rustup-cargo-home-v1"
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-bin: "false"
 
       - name: Test (coverage)
         run: mise run test:coverage
@@ -122,15 +131,24 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure mise Rust homes
+        run: |
+          {
+            echo "MISE_RUSTUP_HOME=${HOME}/.local/share/mise/rustup"
+            echo "MISE_CARGO_HOME=${HOME}/.local/share/mise/cargo"
+          } >> "${GITHUB_ENV}"
+
       - name: Install mise
-        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # zizmor: ignore[stale-action-refs,ref-version-mismatch] temporary SHA for jdx/mise-action PR 467
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.5
           install_args: --locked
-          cache_rust: true
+          cache_key: "{{default}}-rustup-cargo-home-v1"
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-bin: "false"
 
       - name: Render
         run: mise run --jobs 1 --continue-on-error render
@@ -157,12 +175,19 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure mise Rust homes
+        run: |
+          {
+            echo "MISE_RUSTUP_HOME=${HOME}/.local/share/mise/rustup"
+            echo "MISE_CARGO_HOME=${HOME}/.local/share/mise/cargo"
+          } >> "${GITHUB_ENV}"
+
       - name: Install mise
-        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # zizmor: ignore[stale-action-refs,ref-version-mismatch] temporary SHA for jdx/mise-action PR 467
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.5
           install_args: --locked
-          cache_rust: true
+          cache_key: "{{default}}-rustup-cargo-home-v1"
 
       - name: Validate schema
         run: mise run schema

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           version: 2026.5.5
           install_args: --locked
-          cache_key: "{{default}}-rustup-cargo-home-v1"
+          cache_key: "{{default}}-rustup-cargo-home-v2"
 
       - name: Create biwa-bot GitHub App token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -89,7 +89,7 @@ jobs:
         with:
           version: 2026.5.5
           install_args: --locked
-          cache_key: "{{default}}-rustup-cargo-home-v1"
+          cache_key: "{{default}}-rustup-cargo-home-v2"
 
       - name: Create biwa-bot GitHub App token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -32,12 +32,19 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Configure mise Rust homes
+        run: |
+          {
+            echo "MISE_RUSTUP_HOME=${HOME}/.local/share/mise/rustup"
+            echo "MISE_CARGO_HOME=${HOME}/.local/share/mise/cargo"
+          } >> "${GITHUB_ENV}"
+
       - name: Install mise
-        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # zizmor: ignore[stale-action-refs,ref-version-mismatch] temporary SHA for jdx/mise-action PR 467
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.5
           install_args: --locked
-          cache_rust: true
+          cache_key: "{{default}}-rustup-cargo-home-v1"
 
       - name: Create biwa-bot GitHub App token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -70,12 +77,19 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Configure mise Rust homes
+        run: |
+          {
+            echo "MISE_RUSTUP_HOME=${HOME}/.local/share/mise/rustup"
+            echo "MISE_CARGO_HOME=${HOME}/.local/share/mise/cargo"
+          } >> "${GITHUB_ENV}"
+
       - name: Install mise
-        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # zizmor: ignore[stale-action-refs,ref-version-mismatch] temporary SHA for jdx/mise-action PR 467
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.5
           install_args: --locked
-          cache_rust: true
+          cache_key: "{{default}}-rustup-cargo-home-v1"
 
       - name: Create biwa-bot GitHub App token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,15 +56,21 @@ jobs:
             } >> "${GITHUB_OUTPUT}"
           fi
 
+      - name: Configure mise Rust homes
+        run: |
+          {
+            echo "MISE_RUSTUP_HOME=${HOME}/.local/share/mise/rustup"
+            echo "MISE_CARGO_HOME=${HOME}/.local/share/mise/cargo"
+          } >> "${GITHUB_ENV}"
+
       - name: Install mise
         id: install-mise
-        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # zizmor: ignore[stale-action-refs,ref-version-mismatch] temporary SHA for jdx/mise-action PR 467
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.5
           install_args: --locked
           cache: ${{ steps.mode.outputs.publishing == 'false' }}
-          cache_key: "{{default}}-release"
-          cache_rust: true
+          cache_key: "{{default}}-release-rustup-cargo-home-v1"
         env:
           MISE_ENABLE_TOOLS: rust,cargo-dist
 
@@ -106,15 +112,21 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure mise Rust homes
+        run: |
+          {
+            echo "MISE_RUSTUP_HOME=${HOME}/.local/share/mise/rustup"
+            echo "MISE_CARGO_HOME=${HOME}/.local/share/mise/cargo"
+          } >> "${GITHUB_ENV}"
+
       - name: Install mise
         id: install-mise
-        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # zizmor: ignore[stale-action-refs,ref-version-mismatch] temporary SHA for jdx/mise-action PR 467
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.5
           install_args: --locked
           cache: ${{ needs.plan.outputs.publishing == 'false' }}
-          cache_key: "{{default}}-release"
-          cache_rust: true
+          cache_key: "{{default}}-release-rustup-cargo-home-v1"
         env:
           MISE_ENABLE_TOOLS: rust,cargo-dist
 
@@ -123,6 +135,7 @@ jobs:
         if: needs.plan.outputs.publishing == 'false'
         with:
           key: ${{ join(matrix.targets, '-') }}
+          cache-bin: "false"
 
       - name: Install dependencies
         # zizmor: ignore[template-injection] required to run arbitrary commands
@@ -199,15 +212,21 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure mise Rust homes
+        run: |
+          {
+            echo "MISE_RUSTUP_HOME=${HOME}/.local/share/mise/rustup"
+            echo "MISE_CARGO_HOME=${HOME}/.local/share/mise/cargo"
+          } >> "${GITHUB_ENV}"
+
       - name: Install mise
         id: install-mise
-        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # zizmor: ignore[stale-action-refs,ref-version-mismatch] temporary SHA for jdx/mise-action PR 467
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.5
           install_args: --locked
           cache: ${{ needs.plan.outputs.publishing == 'false' }}
-          cache_key: "{{default}}-release"
-          cache_rust: true
+          cache_key: "{{default}}-release-rustup-cargo-home-v1"
         env:
           MISE_ENABLE_TOOLS: rust,cargo-dist
 
@@ -267,8 +286,15 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure mise Rust homes
+        run: |
+          {
+            echo "MISE_RUSTUP_HOME=${HOME}/.local/share/mise/rustup"
+            echo "MISE_CARGO_HOME=${HOME}/.local/share/mise/cargo"
+          } >> "${GITHUB_ENV}"
+
       - name: Install mise
-        uses: risu729/mise-action@f2054108d3926f722fd54c7fc70a1224cb691032 # zizmor: ignore[stale-action-refs,ref-version-mismatch] temporary SHA for jdx/mise-action PR 467
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.5
           install_args: --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           version: 2026.5.5
           install_args: --locked
           cache: ${{ steps.mode.outputs.publishing == 'false' }}
-          cache_key: "{{default}}-release-rustup-cargo-home-v1"
+          cache_key: "{{default}}-release-rustup-cargo-home-v2"
         env:
           MISE_ENABLE_TOOLS: rust,cargo-dist
 
@@ -126,7 +126,7 @@ jobs:
           version: 2026.5.5
           install_args: --locked
           cache: ${{ needs.plan.outputs.publishing == 'false' }}
-          cache_key: "{{default}}-release-rustup-cargo-home-v1"
+          cache_key: "{{default}}-release-rustup-cargo-home-v2"
         env:
           MISE_ENABLE_TOOLS: rust,cargo-dist
 
@@ -226,7 +226,7 @@ jobs:
           version: 2026.5.5
           install_args: --locked
           cache: ${{ needs.plan.outputs.publishing == 'false' }}
-          cache_key: "{{default}}-release-rustup-cargo-home-v1"
+          cache_key: "{{default}}-release-rustup-cargo-home-v2"
         env:
           MISE_ENABLE_TOOLS: rust,cargo-dist
 


### PR DESCRIPTION
## Summary

- replace the temporary `risu729/mise-action` PR SHA with official `jdx/mise-action@v4.0.1`
- configure mise-managed Rust homes under the mise data dir before `mise-action` runs
- rotate mise cache keys and keep rust-cache from owning Cargo binaries

## Test plan

- [x] `mise run check:actionlint`
- [x] `mise run check:pinact`
- [x] `mise run check:yamllint`
- [x] `mise run check:zizmor`
- [x] `mise run check:ghalint`
- [x] `mise run check:oxfmt`
- [x] `git diff --check`

## Notes

This tests the workaround for jdx/mise-action#215. The fresh `rustup-cargo-home-v2` key is intended to prove cache-miss behavior first; a rerun of the same commit should confirm cache-hit behavior.