### PR TITLE
ci: set mise rust homes at job level

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -26,24 +26,20 @@ jobs:
     permissions:
       contents: read # for checkout
 
+    env:
+      MISE_RUSTUP_HOME: /home/runner/.local/share/mise/rustup
+      MISE_CARGO_HOME: /home/runner/.local/share/mise/cargo
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - name: Configure mise Rust homes
-        run: |
-          {
-            echo "MISE_RUSTUP_HOME=${HOME}/.local/share/mise/rustup"
-            echo "MISE_CARGO_HOME=${HOME}/.local/share/mise/cargo"
-          } >> "${GITHUB_ENV}"
-
       - name: Install mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.11
-          cache_key: "{{default}}-rustup-cargo-home-v2"
 
       - name: Update mise lockfile
         if: github.event.pull_request.user.login == 'renovate[bot]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,10 @@ jobs:
       contents: read # for checkout
       id-token: write # for codecov
 
+    env:
+      MISE_RUSTUP_HOME: /home/runner/.local/share/mise/rustup
+      MISE_CARGO_HOME: /home/runner/.local/share/mise/cargo
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -85,19 +89,11 @@ jobs:
       - name: Start SSH test services
         run: docker compose up --build --detach --wait --wait-timeout 60
 
-      - name: Configure mise Rust homes
-        run: |
-          {
-            echo "MISE_RUSTUP_HOME=${HOME}/.local/share/mise/rustup"
-            echo "MISE_CARGO_HOME=${HOME}/.local/share/mise/cargo"
-          } >> "${GITHUB_ENV}"
-
       - name: Install mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.11
           install_args: --locked
-          cache_key: "{{default}}-rustup-cargo-home-v2"
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -125,25 +121,21 @@ jobs:
     permissions:
       contents: read # for checkout
 
+    env:
+      MISE_RUSTUP_HOME: /home/runner/.local/share/mise/rustup
+      MISE_CARGO_HOME: /home/runner/.local/share/mise/cargo
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - name: Configure mise Rust homes
-        run: |
-          {
-            echo "MISE_RUSTUP_HOME=${HOME}/.local/share/mise/rustup"
-            echo "MISE_CARGO_HOME=${HOME}/.local/share/mise/cargo"
-          } >> "${GITHUB_ENV}"
-
       - name: Install mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.11
           install_args: --locked
-          cache_key: "{{default}}-rustup-cargo-home-v2"
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -169,25 +161,21 @@ jobs:
     permissions:
       contents: read
 
+    env:
+      MISE_RUSTUP_HOME: /home/runner/.local/share/mise/rustup
+      MISE_CARGO_HOME: /home/runner/.local/share/mise/cargo
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - name: Configure mise Rust homes
-        run: |
-          {
-            echo "MISE_RUSTUP_HOME=${HOME}/.local/share/mise/rustup"
-            echo "MISE_CARGO_HOME=${HOME}/.local/share/mise/cargo"
-          } >> "${GITHUB_ENV}"
-
       - name: Install mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.11
           install_args: --locked
-          cache_key: "{{default}}-rustup-cargo-home-v2"
 
       - name: Validate schema
         run: mise run schema

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -25,6 +25,10 @@ jobs:
       contents: read # for checkout
     environment: release
 
+    env:
+      MISE_RUSTUP_HOME: /home/runner/.local/share/mise/rustup
+      MISE_CARGO_HOME: /home/runner/.local/share/mise/cargo
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -32,19 +36,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Configure mise Rust homes
-        run: |
-          {
-            echo "MISE_RUSTUP_HOME=${HOME}/.local/share/mise/rustup"
-            echo "MISE_CARGO_HOME=${HOME}/.local/share/mise/cargo"
-          } >> "${GITHUB_ENV}"
-
       - name: Install mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.11
           install_args: --locked
-          cache_key: "{{default}}-rustup-cargo-home-v2"
 
       - name: Create biwa-bot GitHub App token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -70,6 +66,10 @@ jobs:
       id-token: write # for trusted publishing
     environment: release
 
+    env:
+      MISE_RUSTUP_HOME: /home/runner/.local/share/mise/rustup
+      MISE_CARGO_HOME: /home/runner/.local/share/mise/cargo
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -77,19 +77,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Configure mise Rust homes
-        run: |
-          {
-            echo "MISE_RUSTUP_HOME=${HOME}/.local/share/mise/rustup"
-            echo "MISE_CARGO_HOME=${HOME}/.local/share/mise/cargo"
-          } >> "${GITHUB_ENV}"
-
       - name: Install mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.11
           install_args: --locked
-          cache_key: "{{default}}-rustup-cargo-home-v2"
 
       - name: Create biwa-bot GitHub App token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,10 @@ jobs:
       tag-flag: ${{ steps.mode.outputs.tag_flag }}
       publishing: ${{ steps.mode.outputs.publishing }}
 
+    env:
+      MISE_RUSTUP_HOME: /home/runner/.local/share/mise/rustup
+      MISE_CARGO_HOME: /home/runner/.local/share/mise/cargo
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -56,13 +60,6 @@ jobs:
             } >> "${GITHUB_OUTPUT}"
           fi
 
-      - name: Configure mise Rust homes
-        run: |
-          {
-            echo "MISE_RUSTUP_HOME=${HOME}/.local/share/mise/rustup"
-            echo "MISE_CARGO_HOME=${HOME}/.local/share/mise/cargo"
-          } >> "${GITHUB_ENV}"
-
       - name: Install mise
         id: install-mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
@@ -70,7 +67,6 @@ jobs:
           version: 2026.5.11
           install_args: --locked
           cache: ${{ steps.mode.outputs.publishing == 'false' }}
-          cache_key: "{{default}}-release-rustup-cargo-home-v2"
         env:
           MISE_ENABLE_TOOLS: rust,cargo-dist
 
@@ -105,19 +101,14 @@ jobs:
       fail-fast: false
     env:
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
+      MISE_RUSTUP_HOME: ${{ startsWith(matrix.runner, 'macos') && '/Users/runner/.local/share/mise/rustup' || '/home/runner/.local/share/mise/rustup' }}
+      MISE_CARGO_HOME: ${{ startsWith(matrix.runner, 'macos') && '/Users/runner/.local/share/mise/cargo' || '/home/runner/.local/share/mise/cargo' }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
-      - name: Configure mise Rust homes
-        run: |
-          {
-            echo "MISE_RUSTUP_HOME=${HOME}/.local/share/mise/rustup"
-            echo "MISE_CARGO_HOME=${HOME}/.local/share/mise/cargo"
-          } >> "${GITHUB_ENV}"
 
       - name: Install mise
         id: install-mise
@@ -126,7 +117,6 @@ jobs:
           version: 2026.5.11
           install_args: --locked
           cache: ${{ needs.plan.outputs.publishing == 'false' }}
-          cache_key: "{{default}}-release-rustup-cargo-home-v2"
         env:
           MISE_ENABLE_TOOLS: rust,cargo-dist
 
@@ -205,19 +195,14 @@ jobs:
 
     env:
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
+      MISE_RUSTUP_HOME: /home/runner/.local/share/mise/rustup
+      MISE_CARGO_HOME: /home/runner/.local/share/mise/cargo
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
-      - name: Configure mise Rust homes
-        run: |
-          {
-            echo "MISE_RUSTUP_HOME=${HOME}/.local/share/mise/rustup"
-            echo "MISE_CARGO_HOME=${HOME}/.local/share/mise/cargo"
-          } >> "${GITHUB_ENV}"
 
       - name: Install mise
         id: install-mise
@@ -226,7 +211,6 @@ jobs:
           version: 2026.5.11
           install_args: --locked
           cache: ${{ needs.plan.outputs.publishing == 'false' }}
-          cache_key: "{{default}}-release-rustup-cargo-home-v2"
         env:
           MISE_ENABLE_TOOLS: rust,cargo-dist
 
@@ -280,18 +264,15 @@ jobs:
     permissions:
       contents: write # for checkout and create release
 
+    env:
+      MISE_RUSTUP_HOME: /home/runner/.local/share/mise/rustup
+      MISE_CARGO_HOME: /home/runner/.local/share/mise/cargo
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
-      - name: Configure mise Rust homes
-        run: |
-          {
-            echo "MISE_RUSTUP_HOME=${HOME}/.local/share/mise/rustup"
-            echo "MISE_CARGO_HOME=${HOME}/.local/share/mise/cargo"
-          } >> "${GITHUB_ENV}"
 
       - name: Install mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1


### PR DESCRIPTION
## Summary

- move mise Rust home configuration from setup steps to job-level env
- remove custom mise-action cache key suffixes and use the default cache key

## Test plan

- [x] `mise run check:actionlint`
- [x] `mise run check:pinact`
- [x] `mise run check:yamllint`
- [x] `mise run check:zizmor`
- [x] `mise run check:ghalint`
- [x] `git diff --check`
