### PR TITLE
chore(mise): migrate checks to hk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,18 +68,8 @@ It captures the commands, conventions, and guardrails that are actually used her
 
 - `mise run check` - umbrella task for formatters and linters; may autofix when `LINT` is unset.
 - `LINT=true mise run check` - CI-like check mode without formatting/fix writes.
-- `mise run check:clippy` - clippy, with autofix first unless `LINT=true`.
-- `mise run check:rustfmt` - Rust formatting.
-- `mise run check:cargo-deny` - dependency / license / advisory checks.
-- `mise run check:actionlint` - GitHub Actions lint.
-- `mise run check:ghalint` - GitHub Actions policy lint.
-- `mise run check:pinact` - pinned action verification.
-- `mise run check:zizmor` - GitHub Actions security lint.
-- `mise run check:yamllint` - YAML lint.
-- `mise run check:oxfmt` - format Markdown, JSON, YAML, TOML, TS, JS, CSS, Vue.
-- `mise run check:typos` - spellcheck.
-- `mise run check:oxlint` - docs JS/TS/Vue lint.
-- `mise run check:tsc` - docs TypeScript checks.
+- `hk check --all --step clippy` - run one hk check step.
+- `hk fix --all --step rustfmt --no-stage` - run one hk fix step.
 
 ### Docs And Rendered Artifacts
 
@@ -105,7 +95,7 @@ It captures the commands, conventions, and guardrails that are actually used her
 
 ### Formatting
 
-- Run `cargo fmt` or `mise run check:rustfmt` after Rust edits.
+- Run `cargo fmt` or `hk fix --all --step rustfmt --no-stage` after Rust edits.
 - Rust formatting uses hard tabs; `rustfmt.toml` sets `hard_tabs = true`.
 - Match existing layout and let rustfmt own spacing and wrapping.
 
@@ -136,7 +126,7 @@ It captures the commands, conventions, and guardrails that are actually used her
 ### Clippy Expectations
 
 - This repo opts into aggressive clippy groups: `pedantic`, `nursery`, `cargo`, and `restriction`.
-- `mise run check:clippy` is intentionally strict; do not suppress lints unless it is genuinely necessary and you can justify it clearly.
+- The `clippy` hk step is intentionally strict; do not suppress lints unless it is genuinely necessary and you can justify it clearly.
 - Many specific lints are intentionally allowed in `Cargo.toml`; do not assume a triggered restriction lint means the pattern is always forbidden.
 - Prefer targeted `#[expect(..., reason = "...")]` when a lint suppression is justified.
 - Include a real reason string with each `#[expect]` or `#[allow]`.
@@ -182,7 +172,7 @@ It captures the commands, conventions, and guardrails that are actually used her
 ## Safe Agent Workflow
 
 - Before editing, inspect nearby code and mirror the local style.
-- After Rust edits, at minimum run focused tests plus `mise check:rustfmt`.
+- After Rust edits, at minimum run focused tests plus `hk fix --all --step rustfmt --no-stage`.
 - Before finishing broader changes, prefer `LINT=true mise run check` and relevant tests.
 - If you change generated CLI docs or schema inputs, run the corresponding `mise run render:*` task.
 - If you change snapshots intentionally, run `mise run test:update-snapshot`.

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,0 +1,92 @@
+amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
+
+local const rustTypes = List("rust")
+local const oxfmtGlobs =
+  List(
+    "**/*.js",
+    "**/*.mjs",
+    "**/*.cjs",
+    "**/*.ts",
+    "**/*.mts",
+    "**/*.cts",
+    "**/*.jsx",
+    "**/*.tsx",
+    "**/*.vue",
+    "**/*.css",
+    "**/*.json",
+    "**/*.jsonc",
+    "**/*.yaml",
+    "**/*.yml",
+    "**/*.md",
+  )
+
+local const lintSteps = new Mapping<String, Step> {
+  ["clippy"] {
+    types = rustTypes
+    check = "cargo clippy --all-targets -- --deny warnings"
+    fix = "cargo clippy --fix --allow-dirty --allow-staged --all-targets > /dev/null 2>&1; cargo clippy --all-targets -- --deny warnings"
+  }
+  ["rustfmt"] {
+    types = rustTypes
+    check = "cargo fmt --check"
+    fix = "cargo fmt"
+  }
+  ["cargo-deny"] {
+    glob = List("Cargo.toml", "Cargo.lock", "deny.toml")
+    check = "cargo-deny --locked check"
+  }
+  ["actionlint"] {
+    glob = List(".github/workflows/*.yml", ".github/workflows/*.yaml")
+    check = "actionlint -color {{ files }}"
+    // SC2312: check-extra-masked-returns. GitHub Actions runs bash with
+    // pipefail, but shellcheck cannot detect that from workflow files.
+    env {
+      ["SHELLCHECK_OPTS"] = "--enable=all --exclude=SC2312"
+    }
+  }
+  ["pinact"] = Builtins.pinact
+  ["ghalint"] = (Builtins.ghalint_workflow) {
+    depends = "pinact"
+  }
+  ["zizmor"] = (Builtins.zizmor) {
+    check_diff = "zizmor --no-progress --pedantic {{ files }}"
+    fix = "zizmor --no-progress --pedantic --fix {{ files }}"
+  }
+  ["yamllint"] = Builtins.yamllint
+  ["oxfmt"] {
+    glob = oxfmtGlobs
+    check = "oxfmt --check"
+    fix = "oxfmt"
+  }
+  ["tombi"] {
+    types = List("toml")
+    check = "tombi format --check && tombi lint --error-on-warnings"
+    fix = "tombi format && tombi lint --error-on-warnings"
+  }
+  ["typos"] {
+    check = "typos"
+    fix = "typos --write-changes"
+  }
+  ["oxlint"] {
+    glob = List(".vitepress/**/*.ts", "**/*.js", "**/*.ts", "**/*.vue")
+    check = "oxlint --report-unused-disable-directives-severity error"
+    fix = "oxlint --report-unused-disable-directives-severity error --fix"
+    dir = "docs"
+  }
+  ["tsc"] {
+    glob = List(".vitepress/**/*.ts", "**/*.ts", "**/*.vue", "tsconfig*.json")
+    check = "bun run vue-tsc && bun run tsc"
+    dir = "docs"
+  }
+}
+
+hooks {
+  ["check"] {
+    steps = lintSteps
+  }
+  ["fix"] {
+    fix = true
+    steps = lintSteps
+  }
+}

--- a/mise.lock
+++ b/mise.lock
@@ -216,6 +216,30 @@ checksum = "sha256:a48eb40fc541a440ac0e62a22bfb7984819a1409591b4ce7e20d3d1a01625
 url = "https://github.com/xd009642/tarpaulin/releases/download/0.35.4/cargo-tarpaulin-x86_64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/xd009642/tarpaulin/releases/assets/405218940"
 
+[[tools.hk]]
+version = "1.45.0"
+backend = "aqua:jdx/hk"
+
+[tools.hk."platforms.linux-arm64"]
+checksum = "sha256:22293f9c742f0def32299689022891ced7c5c9d5024c91afd33a83e6f714686c"
+url = "https://github.com/jdx/hk/releases/download/v1.45.0/hk-aarch64-unknown-linux-gnu.tar.gz"
+
+[tools.hk."platforms.linux-arm64-musl"]
+checksum = "sha256:81b64f76df8a399f926a4158bfcbef0fa28dcd60b40799b9474ca2ab21d89c02"
+url = "https://github.com/jdx/hk/releases/download/v1.45.0/hk-aarch64-unknown-linux-musl.tar.gz"
+
+[tools.hk."platforms.linux-x64"]
+checksum = "sha256:47a3338403f689cc295d36213cfede4e1098c335d18064416ea9ac2b9739c148"
+url = "https://github.com/jdx/hk/releases/download/v1.45.0/hk-x86_64-unknown-linux-gnu.tar.gz"
+
+[tools.hk."platforms.linux-x64-musl"]
+checksum = "sha256:afdb201d251f35615f00f3880daa5a4e97d7948304473c259245a7123c0fedcf"
+url = "https://github.com/jdx/hk/releases/download/v1.45.0/hk-x86_64-unknown-linux-musl.tar.gz"
+
+[tools.hk."platforms.macos-arm64"]
+checksum = "sha256:17bd1d9eccbfc894c4b0191871a964dc67df80c1bfbee072e5c12d4bb893a8a6"
+url = "https://github.com/jdx/hk/releases/download/v1.45.0/hk-aarch64-apple-darwin.tar.gz"
+
 [[tools.node]]
 version = "25.9.0"
 backend = "core:node"

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,7 @@ rust = { version = "1.95.0", profile = "default" }
 "aqua:EmbarkStudios/cargo-deny" = "0.19.6"
 "github:xd009642/tarpaulin" = "0.35.4"
 usage = "3.3.0"
+hk = "1.45.0"
 actionlint = "1.7.12"
 # used in actionlint
 shellcheck = "0.11.0"
@@ -38,6 +39,7 @@ lockfile_platforms = [
 
 [env]
 '_'.path = ["target/debug/"]
+HK_PKL_BACKEND = "pklr"
 
 [task_config]
 includes = ["tasks.toml", "tasks/"]

--- a/tasks.toml
+++ b/tasks.toml
@@ -19,74 +19,9 @@ description = "Update test snapshots."
 tools = { cargo-insta = "1.46.3" }
 
 [check]
-depends = ["check:*"]
-description = "Run all linters and formatters. Set LINT=true to check formatting without applying it."
-
-["check:clippy"]
-run = [
-	"{% if env.LINT is undefined %}cargo clippy --fix --allow-dirty --allow-staged --all-targets > /dev/null 2>&1{% endif %}",
-	"cargo clippy --all-targets -- --deny warnings",
-]
-description = "Run Clippy to lint Rust code."
-
-["check:rustfmt"]
-run = "cargo fmt {% if env.LINT is defined %}--check{% endif %}"
-description = "Run Rustfmt to format Rust code."
-
-["check:cargo-deny"]
-run = "cargo-deny --locked check"
-description = "Run cargo-deny to check for unsafe dependencies."
-
-["check:actionlint"]
-run = "actionlint -color"
-# SC2312: check-extra-masked-returns
-# pipefail is set by shell: bash in GitHub Actions but cannot be detected by shellcheck
-# ref: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell
-env.SHELLCHECK_OPTS = "--enable=all --exclude=SC2312"
-description = "Run actionlint to check GitHub Actions workflows."
-
-["check:ghalint"]
-wait_for = ["check:pinact"]
-run = "ghalint run"
-description = "Run ghalint to check GitHub Actions workflows."
-
-["check:pinact"]
-run = "pinact run --verify {% if env.LINT is defined %}--check{% endif %}"
-description = "Run pinact to pin/check pinned GitHub Actions dependencies in workflows."
-
-["check:zizmor"]
-run = "zizmor --pedantic {% if env.LINT is undefined %}--fix{% endif %} ."
-env.GH_TOKEN = "{{ env.GITHUB_TOKEN }}"
-description = "Run Zizmor to check GitHub Actions workflows."
-
-["check:yamllint"]
-run = "yamllint --strict ."
-description = "Run yamllint to lint YAML files."
-
-["check:oxfmt"]
-run = "oxfmt {% if env.LINT is defined %}--check{% endif %}"
-description = "Run oxfmt to format JS, TS, CSS, Vue, JSON, JSONC, YAML, and Markdown files."
-
-["check:tombi"]
-run = [
-	"tombi format {% if env.LINT is defined %}--check{% endif %}",
-	"tombi lint --error-on-warnings",
-]
-description = "Run tombi to format TOML files."
-
-["check:typos"]
-run = "typos {% if env.LINT is undefined %}--write-changes{% endif %}"
-description = "Run typos to check typo in files."
-
-["check:oxlint"]
-run = "oxlint --report-unused-disable-directives-severity error {% if env.LINT is undefined %}--fix{% endif %}"
-dir = "docs"
-description = "Run oxlint to lint VitePress documentation."
-
-["check:tsc"]
-run = ["bun run vue-tsc", "bun run tsc"]
-dir = "docs"
-description = "Run tsc to check TypeScript files in docs."
+run = "hk {% if env.LINT is defined %}check{% else %}fix --no-stage{% endif %} --all --no-progress --no-fail-fast"
+env.GH_TOKEN = "{% if env.GITHUB_TOKEN is defined %}{{ env.GITHUB_TOKEN }}{% endif %}"
+description = "Run hk linters and formatters. Set LINT=true to check without applying fixes."
 
 ["docs:dev"]
 run = "bun run --bun vitepress dev"


### PR DESCRIPTION
## Summary
- add hk.pkl with the existing Rust, workflow, docs, TOML, YAML, and typo checks
- make mise run check delegate to hk check/fix while keeping LINT=true as read-only mode
- add hk to mise tools/lockfile and document the new per-step hk commands

## Verification
- hk validate
- LINT=true mise run check
- mise run check
- hk fix --all --no-progress --no-stage --plan
- git diff --check