### PR TITLE
chore(hk): restructure lint groups and add pre-commit hook

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -68,7 +68,7 @@ local const lintSteps = new Mapping<String, Step | Group> {
   ["tombi"] {
     types = List("toml")
     batch = true
-    check = "tombi lint {{ files }}"
+    check = "tombi lint --error-on-warnings {{ files }}"
   }
   ["tombi-format"] {
     types = List("toml")

--- a/hk.pkl
+++ b/hk.pkl
@@ -15,8 +15,6 @@ local github = new Group {
     }
     ["pinact"] = (Builtins.pinact) {
       batch = true
-      check_diff = "pinact run --verify --check {{ files }}"
-      fix = "pinact run --verify {{ files }}"
     }
     ["ghalint"] = (Builtins.ghalint_workflow) {
       depends = "pinact"
@@ -35,8 +33,8 @@ local docs = new Group {
     ["oxlint"] = (Builtins.ox_lint) {
       batch = true
       glob = List(".vitepress/**/*.ts", "**/*.js", "**/*.ts", "**/*.vue")
-      check = "oxlint --no-error-on-unmatched-pattern --report-unused-disable-directives-severity error {{ files }}"
-      fix = "oxlint --no-error-on-unmatched-pattern --report-unused-disable-directives-severity error --fix {{ files }}"
+      check = "oxlint --report-unused-disable-directives-severity error {{ files }}"
+      fix = "oxlint --report-unused-disable-directives-severity error --fix {{ files }}"
     }
     ["tsc"] {
       glob = List(".vitepress/**/*.ts", "**/*.ts", "**/*.vue", "tsconfig*.json")
@@ -63,23 +61,24 @@ local const lintSteps = new Mapping<String, Step | Group> {
   }
   ["github"] = github
   ["oxfmt"] = (Builtins.oxfmt) {
+    // Duplicate .oxfmtrc.json ignorePatterns so hk skips this step when only
+    // ignored paths change; oxfmt ignore alone still runs the step and exits 0.
+    exclude = List("CHANGELOG.md", "docs/src/cli/**", "schema/**", "**/*.toml")
     batch = true
   }
-  ["tombi"] {
-    types = List("toml")
+  ["tombi"] = (Builtins.tombi) {
     batch = true
     check = "tombi lint --error-on-warnings {{ files }}"
   }
-  ["tombi-format"] {
-    types = List("toml")
+  ["tombi-format"] = (Builtins.tombi_format) {
     batch = true
-    check_diff = "tombi format --check --diff {{ files }}"
-    fix = "tombi format {{ files }}"
   }
   ["yamllint"] = (Builtins.yamllint) {
     batch = true
   }
   ["typos"] = (Builtins.typos) {
+    // Duplicate typos.toml extend-exclude for tracked paths matched by **/*.
+    exclude = List(".gitignore", "biwa.usage.kdl", "CHANGELOG.md", "docs/src/cli/**")
     batch = true
   }
   ["docs"] = docs

--- a/hk.pkl
+++ b/hk.pkl
@@ -2,26 +2,51 @@ amends "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Config.
 import "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Builtins.pkl"
 
 local const rustTypes = List("rust")
-local const oxfmtGlobs =
-  List(
-    "**/*.js",
-    "**/*.mjs",
-    "**/*.cjs",
-    "**/*.ts",
-    "**/*.mts",
-    "**/*.cts",
-    "**/*.jsx",
-    "**/*.tsx",
-    "**/*.vue",
-    "**/*.css",
-    "**/*.json",
-    "**/*.jsonc",
-    "**/*.yaml",
-    "**/*.yml",
-    "**/*.md",
-  )
 
-local const lintSteps = new Mapping<String, Step> {
+local github = new Group {
+  steps {
+    ["actionlint"] = (Builtins.actionlint) {
+      check = "actionlint -color {{ files }}"
+      // SC2312: check-extra-masked-returns. GitHub Actions runs bash with
+      // pipefail, but shellcheck cannot detect that from workflow files.
+      env {
+        ["SHELLCHECK_OPTS"] = "--enable=all --exclude=SC2312"
+      }
+    }
+    ["pinact"] = (Builtins.pinact) {
+      batch = true
+      check_diff = "pinact run --verify --check {{ files }}"
+      fix = "pinact run --verify {{ files }}"
+    }
+    ["ghalint"] = (Builtins.ghalint_workflow) {
+      depends = "pinact"
+    }
+    ["zizmor"] = (Builtins.zizmor) {
+      batch = true
+      check_diff = "zizmor --no-progress --pedantic {{ files }}"
+      fix = "zizmor --no-progress --pedantic --fix {{ files }}"
+    }
+  }
+}
+
+local docs = new Group {
+  dir = "docs"
+  steps {
+    ["oxlint"] = (Builtins.ox_lint) {
+      batch = true
+      glob = List(".vitepress/**/*.ts", "**/*.js", "**/*.ts", "**/*.vue")
+      check = "oxlint --no-error-on-unmatched-pattern --report-unused-disable-directives-severity error {{ files }}"
+      fix = "oxlint --no-error-on-unmatched-pattern --report-unused-disable-directives-severity error --fix {{ files }}"
+    }
+    ["tsc"] {
+      glob = List(".vitepress/**/*.ts", "**/*.ts", "**/*.vue", "tsconfig*.json")
+      stomp = true
+      check = "bun run vue-tsc && bun run tsc"
+    }
+  }
+}
+
+local const lintSteps = new Mapping<String, Step | Group> {
   ["clippy"] {
     types = rustTypes
     check = "cargo clippy --all-targets -- --deny warnings"
@@ -36,52 +61,36 @@ local const lintSteps = new Mapping<String, Step> {
     glob = List("Cargo.toml", "Cargo.lock", "deny.toml")
     check = "cargo-deny --locked check"
   }
-  ["actionlint"] {
-    glob = List(".github/workflows/*.yml", ".github/workflows/*.yaml")
-    check = "actionlint -color {{ files }}"
-    // SC2312: check-extra-masked-returns. GitHub Actions runs bash with
-    // pipefail, but shellcheck cannot detect that from workflow files.
-    env {
-      ["SHELLCHECK_OPTS"] = "--enable=all --exclude=SC2312"
-    }
-  }
-  ["pinact"] = Builtins.pinact
-  ["ghalint"] = (Builtins.ghalint_workflow) {
-    depends = "pinact"
-  }
-  ["zizmor"] = (Builtins.zizmor) {
-    check_diff = "zizmor --no-progress --pedantic {{ files }}"
-    fix = "zizmor --no-progress --pedantic --fix {{ files }}"
-  }
-  ["yamllint"] = Builtins.yamllint
-  ["oxfmt"] {
-    glob = oxfmtGlobs
-    check = "oxfmt --check"
-    fix = "oxfmt"
+  ["github"] = github
+  ["oxfmt"] = (Builtins.oxfmt) {
+    batch = true
   }
   ["tombi"] {
     types = List("toml")
-    check = "tombi format --check && tombi lint --error-on-warnings"
-    fix = "tombi format && tombi lint --error-on-warnings"
+    batch = true
+    check = "tombi lint {{ files }}"
   }
-  ["typos"] {
-    check = "typos"
-    fix = "typos --write-changes"
+  ["tombi-format"] {
+    types = List("toml")
+    batch = true
+    check_diff = "tombi format --check --diff {{ files }}"
+    fix = "tombi format {{ files }}"
   }
-  ["oxlint"] {
-    glob = List(".vitepress/**/*.ts", "**/*.js", "**/*.ts", "**/*.vue")
-    check = "oxlint --report-unused-disable-directives-severity error"
-    fix = "oxlint --report-unused-disable-directives-severity error --fix"
-    dir = "docs"
+  ["yamllint"] = (Builtins.yamllint) {
+    batch = true
   }
-  ["tsc"] {
-    glob = List(".vitepress/**/*.ts", "**/*.ts", "**/*.vue", "tsconfig*.json")
-    check = "bun run vue-tsc && bun run tsc"
-    dir = "docs"
+  ["typos"] = (Builtins.typos) {
+    batch = true
   }
+  ["docs"] = docs
 }
 
 hooks {
+  ["pre-commit"] {
+    fix = true
+    stash = "git"
+    steps = lintSteps
+  }
   ["check"] {
     steps = lintSteps
   }

--- a/mise.lock
+++ b/mise.lock
@@ -285,37 +285,37 @@ version = "1.63.0"
 backend = "npm:oxlint"
 
 [[tools.pinact]]
-version = "3.10.1"
+version = "4.1.0"
 backend = "aqua:suzuki-shunsuke/pinact"
 
 [tools.pinact."platforms.linux-arm64"]
-checksum = "sha256:ac2ce7a8d0fb592557e8cd1f26e01c0e7e8cf20733ae40a25e2354fd054f4f25"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.10.1/pinact_linux_arm64.tar.gz"
+checksum = "sha256:2807669cd423a3572bc12ea4a5eab80cd2f30d5644710e0c97a08a075fdadf10"
+url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.1.0/pinact_linux_arm64.tar.gz"
 provenance = "github-attestations"
 
 [tools.pinact."platforms.linux-arm64-musl"]
-checksum = "sha256:ac2ce7a8d0fb592557e8cd1f26e01c0e7e8cf20733ae40a25e2354fd054f4f25"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.10.1/pinact_linux_arm64.tar.gz"
+checksum = "sha256:2807669cd423a3572bc12ea4a5eab80cd2f30d5644710e0c97a08a075fdadf10"
+url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.1.0/pinact_linux_arm64.tar.gz"
 provenance = "github-attestations"
 
 [tools.pinact."platforms.linux-x64"]
-checksum = "sha256:c5234ff3a636cda47719c73ca33a0183a5f441581455eda8a0726e5030942b69"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.10.1/pinact_linux_amd64.tar.gz"
+checksum = "sha256:8fcbf1b3e95551c82fd995535e3c1defa70e23299ce36eb3afd6c98778de6ca0"
+url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.1.0/pinact_linux_amd64.tar.gz"
 provenance = "github-attestations"
 
 [tools.pinact."platforms.linux-x64-musl"]
-checksum = "sha256:c5234ff3a636cda47719c73ca33a0183a5f441581455eda8a0726e5030942b69"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.10.1/pinact_linux_amd64.tar.gz"
+checksum = "sha256:8fcbf1b3e95551c82fd995535e3c1defa70e23299ce36eb3afd6c98778de6ca0"
+url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.1.0/pinact_linux_amd64.tar.gz"
 provenance = "github-attestations"
 
 [tools.pinact."platforms.macos-arm64"]
-checksum = "sha256:ba7ffd6a63e3c96458a582cce7753fb450a4ebc75099b885b2b6c6f57e5620b0"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.10.1/pinact_darwin_arm64.tar.gz"
+checksum = "sha256:b670063ccfa178cdb5c7107d14e3de896f10b93edcc7dbe38b840cb99f2536db"
+url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.1.0/pinact_darwin_arm64.tar.gz"
 provenance = "github-attestations"
 
 [tools.pinact."platforms.macos-x64"]
-checksum = "sha256:64a68d241573907dec8557196423e63f836d7b2c4ce238dd6271a4fe72dbc1e9"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.10.1/pinact_darwin_amd64.tar.gz"
+checksum = "sha256:6338d0220a28093c2c6916a047eea8a17f4ba03a8562010dc8e942b2a2884364"
+url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.1.0/pinact_darwin_amd64.tar.gz"
 provenance = "github-attestations"
 
 [[tools.pitchfork]]

--- a/mise.toml
+++ b/mise.toml
@@ -8,7 +8,7 @@ actionlint = "1.7.12"
 # used in actionlint
 shellcheck = "0.11.0"
 ghalint = "1.5.6"
-pinact = "3.10.1"
+pinact = "4.1.0"
 zizmor = "1.26.1"
 # required for pipx backend
 uv = "0.11.23"


### PR DESCRIPTION
## Summary
- Reorganize `hk.pkl` lint steps into `github` and `docs` groups with batch-enabled builtins.
- Add a `pre-commit` hook that runs the same lint steps with auto-fix and git stash.
- Update pinact integration to pinact v4 CLI flags (`pinact run --verify`).

## Test plan
- [ ] Merge pinact v4 dependency update (#689) into this branch
- [ ] Run `LINT=true mise run check`
- [ ] Run `hk check --all --step pinact`

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Restructure lint configuration into reusable groups, add a pre-commit hook that runs the unified lint suite with autofix, and update pinact to the v4 CLI.

New Features:
- Introduce a pre-commit hook that runs all lint steps with autofix and git stash handling.
- Add grouped lint configurations for GitHub workflows and docs-specific checks.

Enhancements:
- Enable batch execution for several existing linters to improve lint performance and consistency.
- Split TOML linting and formatting into separate tombi steps for clearer responsibilities.

Build:
- Upgrade pinact tooling to version 4 and adopt the new CLI flags in lint commands.