### PR TITLE
ci: align CI Check guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,13 +265,11 @@ jobs:
       - schema
       - docs
     # ref: https://github.com/aquaproj/aqua-registry/pull/38449#issuecomment-3038859524
-    if: always()
+    if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - name: Fail CI Check
-        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
-        run: exit 1
+      - run: exit 1
   actions-timeline:
     name: Generate Actions Timeline
     needs:


### PR DESCRIPTION
## Summary

- Move the `CI Check` failure/cancelled condition from the failing step to the `ci-check` job `if:` guard.
- Keep the job behavior aligned with the other active repositories using this pattern.

## Validation

- `mise run check --lint`
- Workflow-specific checks: `actionlint`, `zizmor`, `ghalint`, `yamlfmt`, and `yamllint` on `.github/workflows/ci.yml`

## Summary by Sourcery

Align the CI Check job behavior by moving the failure/cancelled guard from the step level to the job-level condition in the GitHub Actions workflow.