### PR TITLE
fix(deps): restore Renovate Cargo extraction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,6 @@ indicatif = "=0.18.4"
 itertools = "=0.15.0"
 json5 = "=1.3.1"
 nix = { version = "=0.31.3", features = ["process", "signal"] }
-russh = {
-	version = "=0.60.3",
-	default-features = false,
-	features = ["flate2", "ring", "rsa"]
-}
 russh-sftp = "=2.3.0"
 schemars = "=1.2.1"
 scopeguard = "=1.2.0"
@@ -52,6 +47,13 @@ toml = "=1.1.2"
 tracing = "=0.1.44"
 tracing-subscriber = "=0.3.23"
 usage-lib = { version = "=3.5.3", features = ["clap", "docs"] }
+
+# TODO: Restore the inline dependency after Renovate supports TOML 1.1.
+# https://github.com/renovatebot/renovate/discussions/44345
+[dependencies.russh]
+version = "=0.60.3"
+default-features = false
+features = ["flate2", "ring", "rsa"]
 
 [dev-dependencies]
 ctor = "=1.0.7"


### PR DESCRIPTION
## Summary

- express the `russh` dependency as a standard TOML table
- keep `Cargo.toml` compatible with Renovate's TOML 1.0 parser
- document the temporary workaround and its removal condition

## Root cause

Tombi formatted the dependency using TOML 1.1 multiline inline-table syntax. Renovate 43.242.2 parses manifests as TOML 1.0, so Cargo extraction failed and Renovate stopped detecting every Rust dependency, including the available `ignore` update.

This workaround can be reverted after [renovatebot/renovate discussion #44345](https://github.com/renovatebot/renovate/discussions/44345) is resolved.

## Validation

- `mise run check --lint` (all checks pass except the existing `RUSTSEC-2026-0204` failure for `crossbeam-epoch 0.9.18`)
- Renovate 43.242.2 full dry run with the Cargo manager: detects `Cargo.toml`, 43 dependencies, and the `ignore 0.4.28` update
- `git diff --check`
