### PR TITLE
fix(deps): replace serde-yaml with serde-saphyr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,6 +83,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -135,6 +159,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +190,12 @@ name = "base16ct"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -220,8 +256,8 @@ dependencies = [
  "schemars",
  "scopeguard",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml",
  "serial_test",
  "sha2",
  "shell-words",
@@ -460,7 +496,6 @@ dependencies = [
  "confique-macro",
  "json5 0.4.1",
  "serde",
- "serde_yaml",
  "toml 0.9.12+spec-1.1.0",
 ]
 
@@ -860,6 +895,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "enum_dispatch"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,6 +1136,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -1090,7 +1157,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core",
  "wasm-bindgen",
 ]
@@ -1139,6 +1206,16 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "granit-parser"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d03f81ad4732830d85cfd417a9f62cde6dadda4354d37d078a6084a19560aa2d"
+dependencies = [
+ "arraydeque",
+ "smallvec",
 ]
 
 [[package]]
@@ -1589,6 +1666,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
 name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1980,6 +2063,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -2305,12 +2394,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
 name = "salsa20"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2403,6 +2486,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-saphyr"
+version = "0.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64",
+ "encoding_rs_io",
+ "getrandom 0.3.4",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde_core",
+ "smallvec",
+ "zmij",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2463,19 +2565,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -3064,12 +3153,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3142,6 +3225,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -3597,6 +3689,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "wnaf"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3630,6 +3728,26 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ bytes = "=1.12.1"
 chrono = { version = "=0.4.45", features = ["serde"] }
 clap = { version = "=4.6.1", features = ["derive"] }
 color-eyre = "=0.6.5"
-confique = { version = "=0.4.0", features = ["json5", "toml", "yaml"] }
+confique = { version = "=0.4.0", features = ["json5", "toml"] }
 console = "=0.16.4"
 derive_more = { version = "=2.1.1", features = ["deref"] }
 dialoguer = "=0.12.0"
@@ -36,7 +36,11 @@ schemars = "=1.2.1"
 scopeguard = "=1.2.0"
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.150"
-serde_yaml = "=0.9.34"
+serde-saphyr = {
+	version = "=0.0.29",
+	default-features = false,
+	features = ["deserialize", "serialize"]
+}
 sha2 = "=0.11.0"
 shell-words = "=1.1.1"
 strum = { version = "=0.28.0", features = ["derive"] }

--- a/src/cli/snapshots/biwa__cli__init__tests__init_yaml.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_yaml.snap
@@ -54,8 +54,8 @@ ssh:
   #
   # Can also be specified via environment variable `BIWA_SSH_UMASK`.
   #
-  # Default value: '077'
-  #umask: '077'
+  # Default value: "077"
+  #umask: "077"
 
 # Remote synchronization configuration.
 sync:
@@ -87,8 +87,8 @@ sync:
 
   # Files and directories to exclude during synchronization using globset patterns.
   #
-  # Default value: ['**/.git/**', '**/target/**', '**/node_modules/**']
-  #exclude: ['**/.git/**', '**/target/**', '**/node_modules/**']
+  # Default value: ["**/.git/**", "**/target/**", "**/node_modules/**"]
+  #exclude: ["**/.git/**", "**/target/**", "**/node_modules/**"]
 
   # The synchronization engine to use.
   #
@@ -163,5 +163,5 @@ clean:
   #
   # Example: `{ 80 = "5d" }` means clean dirs older than 5 days when quota ≥ 80%.
   #
-  # Default value: {  }
-  #quota_thresholds: {  }
+  # Default value: {}
+  #quota_thresholds: {}

--- a/src/cli/snapshots/biwa__cli__init__tests__init_yml.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_yml.snap
@@ -54,8 +54,8 @@ ssh:
   #
   # Can also be specified via environment variable `BIWA_SSH_UMASK`.
   #
-  # Default value: '077'
-  #umask: '077'
+  # Default value: "077"
+  #umask: "077"
 
 # Remote synchronization configuration.
 sync:
@@ -87,8 +87,8 @@ sync:
 
   # Files and directories to exclude during synchronization using globset patterns.
   #
-  # Default value: ['**/.git/**', '**/target/**', '**/node_modules/**']
-  #exclude: ['**/.git/**', '**/target/**', '**/node_modules/**']
+  # Default value: ["**/.git/**", "**/target/**", "**/node_modules/**"]
+  #exclude: ["**/.git/**", "**/target/**", "**/node_modules/**"]
 
   # The synchronization engine to use.
   #
@@ -163,5 +163,5 @@ clean:
   #
   # Example: `{ 80 = "5d" }` means clean dirs older than 5 days when quota ≥ 80%.
   #
-  # Default value: {  }
-  #quota_thresholds: {  }
+  # Default value: {}
+  #quota_thresholds: {}

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -1,5 +1,6 @@
 use super::format::ConfigFormat;
 use super::types::Config;
+use super::yaml;
 use crate::Result;
 use crate::env_vars::{EnvVars, parse_env_var_env};
 use crate::state::default_state_dir;
@@ -157,9 +158,7 @@ impl Config {
 		let content = fs::read_to_string(path).wrap_err("Failed to read config file")?;
 		let mut partial: <Self as confique::Config>::Layer = match format {
 			ConfigFormat::Toml => toml::from_str(&content).wrap_err("Failed to parse TOML")?,
-			ConfigFormat::Yaml => {
-				serde_yaml::from_str(&content).wrap_err("Failed to parse YAML")?
-			}
+			ConfigFormat::Yaml => yaml::from_str(&content).wrap_err("Failed to parse YAML")?,
 			ConfigFormat::Json | ConfigFormat::Json5 => {
 				json5::from_str(&content).wrap_err("Failed to parse JSON")?
 			}
@@ -225,9 +224,7 @@ impl Config {
 			ConfigFormat::Toml => {
 				confique::toml::template::<Self>(confique::toml::FormatOptions::default())
 			}
-			ConfigFormat::Yaml => {
-				confique::yaml::template::<Self>(confique::yaml::FormatOptions::default())
-			}
+			ConfigFormat::Yaml => yaml::template::<Self>(),
 			ConfigFormat::Json | ConfigFormat::Json5 => {
 				confique::json5::template::<Self>(confique::json5::FormatOptions::default())
 			}
@@ -1227,7 +1224,7 @@ user = "user"
 		let dir = tempfile::tempdir()?;
 		let path = dir.path().join("config.yaml");
 		// Write invalid YAML
-		fs::write(&path, "invalid:\n  - \n    - :\n")?;
+		fs::write(&path, "invalid: [unterminated\n")?;
 
 		let result = Config::load_partial(&path, ConfigFormat::Yaml, dir.path());
 		let err = match result {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,3 +4,5 @@ pub mod format;
 mod load;
 /// Types for the configuration elements.
 pub mod types;
+/// YAML parsing and template rendering.
+mod yaml;

--- a/src/config/yaml.rs
+++ b/src/config/yaml.rs
@@ -1,0 +1,195 @@
+//! YAML support built on `serde-saphyr`.
+
+use confique::{
+	Config,
+	meta::{Expr, FieldKind, LeafKind, Meta},
+};
+use core::fmt::{self, Display, Write as _};
+use serde::Deserialize;
+use serde_saphyr::{FlowMap, FlowSeq};
+
+/// Deserializes a configuration layer with consistent YAML 1.2 behavior.
+pub(super) fn from_str<'de, T>(input: &'de str) -> Result<T, serde_saphyr::Error>
+where
+	T: Deserialize<'de>,
+{
+	let options = serde_saphyr::options! {
+		strict_booleans: true,
+	};
+	serde_saphyr::from_str_with_options(input, options)
+}
+
+/// Renders the default YAML configuration template.
+pub(super) fn template<C: Config>() -> String {
+	let mut renderer = TemplateRenderer::default();
+	for doc in C::META.doc {
+		renderer.comment(doc);
+	}
+	renderer.gap();
+	renderer.meta(&C::META);
+	renderer.finish()
+}
+
+/// YAML renderer for `confique`'s public configuration metadata.
+#[derive(Default)]
+struct TemplateRenderer {
+	/// Rendered YAML accumulated so far.
+	buffer: String,
+	/// Indentation for the current nested configuration section.
+	indentation: String,
+}
+
+impl TemplateRenderer {
+	/// Renders all leaf fields followed by nested sections.
+	fn meta(&mut self, meta: &Meta) {
+		let mut emitted = false;
+		for field in meta.fields {
+			let FieldKind::Leaf { env, kind } = &field.kind else {
+				continue;
+			};
+			if emitted {
+				self.gap();
+			}
+			emitted = true;
+
+			let mut emitted_comment = false;
+			for doc in field.doc {
+				self.comment(doc);
+				emitted_comment = true;
+			}
+			if let Some(env) = env {
+				self.separate_comments(emitted_comment);
+				self.comment(format_args!(
+					" Can also be specified via environment variable `{env}`."
+				));
+				emitted_comment = true;
+			}
+
+			match kind {
+				LeafKind::Optional => self.disabled_field(field.name, None),
+				LeafKind::Required { default } => {
+					self.separate_comments(emitted_comment);
+					match default {
+						Some(value) => {
+							self.comment(format_args!(" Default value: {}", YamlExpr(value)));
+						}
+						None => self.comment(" Required! This value must be specified."),
+					}
+					self.disabled_field(field.name, default.as_ref());
+				}
+			}
+		}
+
+		for field in meta.fields {
+			let FieldKind::Nested { meta: nested_meta } = field.kind else {
+				continue;
+			};
+			if emitted {
+				self.gap();
+			}
+			emitted = true;
+			for doc in field.doc {
+				self.comment(doc);
+			}
+			self.indent();
+			writeln!(self.buffer, "{}:", field.name).expect("writing to a string cannot fail");
+			self.indentation.push_str("  ");
+			self.meta(nested_meta);
+			self.indentation = self
+				.indentation
+				.strip_suffix("  ")
+				.expect("nested section must add indentation")
+				.to_owned();
+		}
+	}
+
+	/// Adds a blank comment between two comment groups.
+	fn separate_comments(&mut self, emitted_comment: bool) {
+		if emitted_comment {
+			self.comment("");
+		}
+	}
+
+	/// Writes a YAML comment at the current indentation.
+	fn comment(&mut self, comment: impl Display) {
+		self.indent();
+		writeln!(self.buffer, "#{comment}").expect("writing to a string cannot fail");
+	}
+
+	/// Writes a commented-out field and its optional default.
+	fn disabled_field(&mut self, name: &str, value: Option<&Expr>) {
+		self.indent();
+		match value {
+			Some(value) => writeln!(self.buffer, "#{name}: {}", YamlExpr(value)),
+			None => writeln!(self.buffer, "#{name}:"),
+		}
+		.expect("writing to a string cannot fail");
+	}
+
+	/// Ensures one blank line separates template entries.
+	fn gap(&mut self) {
+		if !self.buffer.is_empty() && !self.buffer.ends_with("\n\n") {
+			self.buffer.push('\n');
+		}
+	}
+
+	/// Writes indentation for the current nested configuration depth.
+	fn indent(&mut self) {
+		self.buffer.push_str(&self.indentation);
+	}
+
+	/// Returns the completed template with one trailing newline.
+	fn finish(mut self) -> String {
+		while self.buffer.ends_with("\n\n") {
+			self.buffer.pop();
+		}
+		if !self.buffer.ends_with('\n') {
+			self.buffer.push('\n');
+		}
+		self.buffer
+	}
+}
+
+/// Displays a metadata expression as compact YAML.
+struct YamlExpr<'a>(&'a Expr);
+
+impl Display for YamlExpr<'_> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		let yaml = match self.0 {
+			Expr::Array(_) => serde_saphyr::to_string(&FlowSeq(self.0)),
+			Expr::Map(_) => serde_saphyr::to_string(&FlowMap(self.0)),
+			Expr::Str(_) | Expr::Float(_) | Expr::Integer(_) | Expr::Bool(_) | _ => {
+				serde_saphyr::to_string(self.0)
+			}
+		}
+		.map_err(|_error| fmt::Error)?;
+		f.write_str(yaml.trim_end_matches('\n'))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::from_str;
+	use pretty_assertions::assert_eq;
+	use serde::Deserialize;
+
+	#[derive(Debug, Deserialize, PartialEq, Eq)]
+	struct Example {
+		enabled: bool,
+	}
+
+	#[test]
+	fn rejects_duplicate_keys() {
+		let error = from_str::<Example>("enabled: true\nenabled: false\n")
+			.expect_err("duplicate keys must be rejected");
+		assert!(error.to_string().contains("duplicate"));
+	}
+
+	#[test]
+	fn uses_strict_yaml_1_2_booleans() {
+		let parsed = from_str::<Example>("enabled: true\n").expect("true is a YAML 1.2 boolean");
+		assert_eq!(parsed, Example { enabled: true });
+		from_str::<Example>("enabled: yes\n")
+			.expect_err("YAML 1.1 boolean spellings must be rejected");
+	}
+}


### PR DESCRIPTION
## Summary

- replace deprecated `serde_yaml` with `serde-saphyr` and remove `unsafe-libyaml` from the dependency graph
- parse YAML through Saphyr options with its built-in budgets, duplicate-key rejection, error snippets, and strict YAML 1.2 booleans
- render YAML init templates with Saphyr flow-style wrappers so `confique` no longer needs its `serde_yaml`-backed YAML feature
- update YAML initialization snapshots for Saphyr quoting and empty-map output

## Impact

YAML configuration remains supported while gaining maintained parsing, bounded input processing, duplicate-key diagnostics, and YAML 1.2 boolean semantics. Generated templates now use Saphyr canonical quoting and collection formatting.

## Validation

- `mise run test`
- `mise run check --lint`
- verified `serde_yaml` and `unsafe-libyaml` are absent from source and `Cargo.lock`