### PR TITLE
ci: remove redundant mise locked arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,6 @@ jobs:
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           version: 2026.7.11
-          install_args: --locked
       - name: Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -158,7 +157,6 @@ jobs:
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           version: 2026.7.11
-          install_args: --locked
       - name: Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -190,7 +188,6 @@ jobs:
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           version: 2026.7.11
-          install_args: --locked
       - name: Validate schema
         run: mise run schema
   build:
@@ -227,7 +224,6 @@ jobs:
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           version: 2026.7.11
-          install_args: --locked
         env:
           MISE_ENABLE_TOOLS: bun,node,wrangler
       - name: Build docs

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -32,7 +32,6 @@ jobs:
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           version: 2026.7.11
-          install_args: --locked
       - name: Create biwa-bot GitHub App token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: github-app
@@ -67,7 +66,6 @@ jobs:
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           version: 2026.7.11
-          install_args: --locked
       - name: Create biwa-bot GitHub App token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: github-app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,6 @@ jobs:
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           version: 2026.7.11
-          install_args: --locked
           cache: ${{ steps.mode.outputs.publishing == 'false' }}
         env:
           MISE_ENABLE_TOOLS: rust,cargo-dist
@@ -99,7 +98,6 @@ jobs:
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           version: 2026.7.11
-          install_args: --locked
           cache: ${{ needs.plan.outputs.publishing == 'false' }}
         env:
           MISE_ENABLE_TOOLS: rust,cargo-dist
@@ -181,7 +179,6 @@ jobs:
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           version: 2026.7.11
-          install_args: --locked
           cache: ${{ needs.plan.outputs.publishing == 'false' }}
         env:
           MISE_ENABLE_TOOLS: rust,cargo-dist
@@ -242,7 +239,6 @@ jobs:
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           version: 2026.7.11
-          install_args: --locked
           cache: false
         env:
           MISE_ENABLE_TOOLS: rust,cargo-dist


### PR DESCRIPTION
## Summary

- remove explicit `install_args: --locked` from every mise-action invocation
- cover CI, release-plz, and release workflows

## Why

mise-action automatically uses locked installation when `mise.lock` is present. Repeating `--locked` in each action invocation is redundant and creates another setting to keep consistent without changing installation behavior.

## Validation

- `mise run check --lint`
- actionlint, pinact, ghalint, zizmor, yamllint, and yamlfmt
