### PR TITLE
fix(hk): ignore generated changelog newline

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -17,6 +17,14 @@ local picked =
 
 hooks =
   helpers.standardHooks((picked) {
+    ["hygiene"] = (picked["hygiene"] as Group) {
+      steps = ((picked["hygiene"] as Group).steps) {
+        ["newlines"] = ((picked["hygiene"] as Group).steps["newlines"]) {
+          // release-plz generates CHANGELOG.md without a trailing newline.
+          exclude = List("CHANGELOG.md")
+        }
+      }
+    }
     ["oxfmt"] = (picked["oxfmt"]) {
       // Duplicate .oxfmtrc.json ignorePatterns so hk skips this step when only
       // ignored paths change; oxfmt ignore alone still runs the step and exits 0.


### PR DESCRIPTION
## Summary

- exclude generated `CHANGELOG.md` from hk's end-of-file newline check
- preserve the remaining hygiene checks for the changelog and all hygiene checks for other files

## Root cause

release-plz generates `CHANGELOG.md` without a trailing newline even though the configured changelog template already ends with `\n`. This makes release PRs fail CI on hk's `end-of-file-fixer` check.

## Impact

Release PRs will no longer be blocked by formatting that release-plz immediately regenerates. Other newline checks and changelog hygiene checks remain enabled.

## Verification

- `hk validate`
- `hk check --all --step newlines`
- `mise run check --lint`
- `git diff --check`

## Summary by Sourcery

Bug Fixes:
- Prevent hk hygiene newlines check from failing on the generated CHANGELOG.md file by excluding it from the end-of-file newline validation.