### PR TITLE
docs: correct Cloudflare token permissions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,13 @@ It captures the commands, conventions, and guardrails that are actually used her
 - `biwa.toml` is gitignored local config and may contain secrets; do not copy its real values into committed docs or code.
 - Avoid committing `.env` contents or values from local config files.
 
+## Cloudflare Docs Deployment
+
+- Deploy docs through `risu729/wrangler-deploy-action`.
+- Keep the token scoped to `Workers Scripts: Edit` on account `risu` and
+  `Workers Routes: Read` on zone `takuk.me`; ordinary routes require
+  `Workers Routes: Edit`, while Custom Domains do not require `DNS: Edit`.
+
 ## Safe Agent Workflow
 
 - Before editing, inspect nearby code and mirror the local style.

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -50,3 +50,20 @@ mise run docs:dev
 ```
 
 This starts a local development server where you can preview your changes.
+
+## Documentation Deployment
+
+GitHub Actions deploys the documentation Worker through
+`risu729/wrangler-deploy-action`. Maintainers configure repository variable
+`CLOUDFLARE_ACCOUNT_ID` and repository secret `CLOUDFLARE_API_TOKEN`.
+
+The token's minimum permissions are:
+
+- Account `risu`: `Workers Scripts: Edit`.
+- Zone `takuk.me`: `Workers Routes: Read`.
+
+Wrangler reads the zone's Worker routes before publishing the configured Custom
+Domain to detect assignments to another Worker. Cloudflare creates the Custom
+Domain's DNS record and certificate, so `DNS: Edit` is not required. If the
+configuration later uses an ordinary route, replace `Workers Routes: Read`
+with `Workers Routes: Edit`.


### PR DESCRIPTION
## Summary

- document the GitHub variable and secret used for docs deployment
- document the minimum Cloudflare token scopes
- preserve the deployment scope guardrail in `AGENTS.md`

## Why

Wrangler performs a Worker-route conflict preflight before publishing Biwa's Custom Domain. The deployment therefore needs Account `risu` / Workers Scripts / Edit and Zone `takuk.me` / Workers Routes / Read.

Custom Domains do not require DNS / Edit. An ordinary route would instead require Workers Routes / Edit.

## Validation

- `mise run check --lint`
- `mise run docs:build`