### PR TITLE
feat: enable Workers logs and traces

### DIFF
--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -13,4 +13,12 @@
 	"assets": {
 		"not_found_handling": "single-page-application",
 	},
+	"observability": {
+		"logs": {
+			"enabled": true,
+		},
+		"traces": {
+			"enabled": true,
+		},
+	},
 }


### PR DESCRIPTION
## Summary

- enable persisted Workers Logs for the documentation Worker
- enable automatic Workers Tracing
- keep maximum sampling without committing redundant sampling defaults

## Why

Biwa's VitePress build generates the deployed `.vitepress/dist/wrangler.json` from `docs/wrangler.jsonc`. Adding the nested observability settings to the source configuration makes both logs and traces part of every generated deployment config.

Sampling settings are intentionally omitted because Cloudflare defaults them to the maximum rate of `1` (100%). No paid export destination is configured.

## Impact

Documentation deployments opt into Cloudflare's included logs and traces. Trace spans and log events consume the account's included observability allowance.

## Validation

- `mise run check --lint`
- `mise run docs:build`
- verified the generated Wrangler config contains `logs.enabled` and `traces.enabled`
- Wrangler 4.112 dry-run against `.vitepress/dist/wrangler.json`

## Summary by Sourcery

Enable Cloudflare Workers observability for the documentation worker by turning on logs and traces in the Wrangler configuration.

New Features:
- Enable persisted Workers logs for the documentation worker.
- Enable automatic Workers tracing for the documentation worker.

Deployment:
- Update docs Wrangler configuration so generated deployments include enabled logs and traces without explicit sampling settings.