### PR TITLE
ci: use crates.io trusted publishing

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -77,9 +77,6 @@ jobs:
         run: release-plz release
         env:
           GIT_TOKEN: ${{ steps.github-app.outputs.token }}
-          # TODO: use trusted publishing after first release
-          # ref: https://crates.io/docs/trusted-publishing
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
   actions-timeline:
     name: Generate Actions Timeline
     needs:


### PR DESCRIPTION
## Summary

- stop passing the static `CARGO_REGISTRY_TOKEN` to `release-plz release`
- allow release-plz to obtain a short-lived crates.io credential through the job's existing OIDC permission
- retain the GitHub App token used to create tags and GitHub releases

## Root cause

The v1.0.0 release run failed while publishing to crates.io with `403 Forbidden: authentication failed`. Although the release job already has `id-token: write` and uses the `release` environment for trusted publishing, the explicit `CARGO_REGISTRY_TOKEN` environment variable forced release-plz to use the stale repository secret instead.

Removing the token override makes release-plz use crates.io trusted publishing as intended.

Failed run: https://github.com/risu729/biwa/actions/runs/30030289178

## Impact

Future crates.io publishes use short-lived OIDC credentials instead of the long-lived repository token. This also unblocks publishing v1.0.0 after the change is merged.

## Validation

- `mise run check --lint`