### PR TITLE
chore(release): omit source tarball

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -9,6 +9,7 @@ cargo-dist-version = "0.32.0"
 allow-dirty = ["ci"]
 ci = ["github"]
 installers = ["shell"]
+source-tarball = false
 targets = [
 	"aarch64-apple-darwin",
 	"aarch64-unknown-linux-gnu",


### PR DESCRIPTION
## Summary

- disable cargo-dist's default source tarball generation
- omit `source.tar.gz` and `source.tar.gz.sha256` from future GitHub Releases

## Why

GitHub already exposes source archives for each release tag, so cargo-dist's additional source archive is redundant for this public GitHub-hosted project. The shell installer uses the platform binary archives and does not consume the source tarball.

## Impact

Future releases will contain the installer, platform binaries, and their checksums without the duplicate source archive assets. Existing releases are unchanged.

## Validation

- `mise x -- dist plan --output-format=json` (verified both source tarball artifacts are absent)
- `mise run check --lint`

## Summary by Sourcery

Build:
- Update cargo-dist workspace configuration to turn off source tarball creation for release builds.