### PR TITLE
test(sync): cover pull file-directory replacements

### DIFF
--- a/src/ssh/sync.rs
+++ b/src/ssh/sync.rs
@@ -3591,6 +3591,61 @@ mod tests {
 	}
 
 	#[test]
+	fn calculate_pull_actions_replaces_local_file_with_remote_directory() {
+		let actions = calculate_pull_actions(
+			&LocalState {
+				files: vec![LocalFile {
+					path: PathBuf::from("node"),
+					hash: "local".to_owned(),
+				}],
+				directories: HashSet::new(),
+				symlinks: HashSet::new(),
+			},
+			&RemoteState {
+				file_hashes: HashMap::from([("node/child.txt".to_owned(), "remote".to_owned())]),
+				directories: HashSet::from(["node".to_owned()]),
+				symlinks: HashSet::new(),
+			},
+			&Options::default(),
+			false,
+		);
+
+		assert_eq!(
+			actions.downloads,
+			vec![download("node/child.txt", "remote")]
+		);
+		assert_eq!(actions.file_deletions, vec!["node".to_owned()]);
+		assert_eq!(actions.directory_creations, vec!["node".to_owned()]);
+		assert!(actions.directory_deletions.is_empty());
+	}
+
+	#[test]
+	fn calculate_pull_actions_replaces_local_directory_with_remote_file() {
+		let actions = calculate_pull_actions(
+			&LocalState {
+				files: vec![LocalFile {
+					path: PathBuf::from("node/child.txt"),
+					hash: "local".to_owned(),
+				}],
+				directories: HashSet::from(["node".to_owned()]),
+				symlinks: HashSet::new(),
+			},
+			&RemoteState {
+				file_hashes: HashMap::from([("node".to_owned(), "remote".to_owned())]),
+				directories: HashSet::new(),
+				symlinks: HashSet::new(),
+			},
+			&Options::default(),
+			false,
+		);
+
+		assert_eq!(actions.downloads, vec![download("node", "remote")]);
+		assert_eq!(actions.file_deletions, vec!["node/child.txt".to_owned()]);
+		assert!(actions.directory_creations.is_empty());
+		assert_eq!(actions.directory_deletions, vec!["node".to_owned()]);
+	}
+
+	#[test]
 	fn calculate_pull_actions_removes_local_symlinks() {
 		let actions = calculate_pull_actions(
 			&LocalState {

--- a/tests/ssh_e2e_sync.rs
+++ b/tests/ssh_e2e_sync.rs
@@ -223,6 +223,153 @@ fn e2e_pull_overwrites_changed_file() -> Result<()> {
 }
 
 #[test]
+fn e2e_pull_replaces_local_file_with_remote_directory() -> Result<()> {
+	let dir = tempfile::tempdir()?;
+	fs::write(dir.path().join("node"), "local file")?;
+	let remote_proj_dir = common::get_remote_project_dir(dir.path())?;
+
+	let setup_output = biwa_cmd_tilde(
+		&[
+			"run",
+			"-d",
+			"~",
+			"sh",
+			"-c",
+			"mkdir -p \"$1/node\" && printf remote > \"$1/node/child.txt\"",
+			"--",
+			&remote_proj_dir,
+		],
+		dir.path(),
+	)
+	.stdout_capture()
+	.stderr_capture()
+	.unchecked()
+	.run()?;
+	assert!(
+		setup_output.status.success(),
+		"stderr: {}",
+		String::from_utf8_lossy(&setup_output.stderr)
+	);
+
+	let output = biwa_cmd_tilde(&["pull"], dir.path())
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	assert!(output.status.success(), "stderr: {stderr}");
+	assert_eq!(
+		fs::read_to_string(dir.path().join("node/child.txt"))?,
+		"remote"
+	);
+
+	Ok(())
+}
+
+#[test]
+fn e2e_pull_replaces_local_directory_with_remote_file() -> Result<()> {
+	let dir = tempfile::tempdir()?;
+	fs::create_dir_all(dir.path().join("node"))?;
+	fs::write(dir.path().join("node/child.txt"), "local child")?;
+	let remote_proj_dir = common::get_remote_project_dir(dir.path())?;
+
+	let setup_output = biwa_cmd_tilde(
+		&[
+			"run",
+			"-d",
+			"~",
+			"sh",
+			"-c",
+			"mkdir -p \"$1\" && printf remote > \"$1/node\"",
+			"--",
+			&remote_proj_dir,
+		],
+		dir.path(),
+	)
+	.stdout_capture()
+	.stderr_capture()
+	.unchecked()
+	.run()?;
+	assert!(
+		setup_output.status.success(),
+		"stderr: {}",
+		String::from_utf8_lossy(&setup_output.stderr)
+	);
+
+	let output = biwa_cmd_tilde(&["pull"], dir.path())
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	assert!(output.status.success(), "stderr: {stderr}");
+	assert_eq!(fs::read_to_string(dir.path().join("node"))?, "remote");
+
+	Ok(())
+}
+
+#[test]
+fn e2e_pull_refuses_remote_file_over_non_empty_selected_directory() -> Result<()> {
+	let dir = tempfile::tempdir()?;
+	fs::create_dir_all(dir.path().join("node"))?;
+	fs::write(dir.path().join("node/kept.txt"), "keep")?;
+	let remote_proj_dir = common::get_remote_project_dir(dir.path())?;
+
+	let setup_output = biwa_cmd_tilde(
+		&[
+			"run",
+			"-d",
+			"~",
+			"sh",
+			"-c",
+			"mkdir -p \"$1\" && printf remote > \"$1/node\"",
+			"--",
+			&remote_proj_dir,
+		],
+		dir.path(),
+	)
+	.stdout_capture()
+	.stderr_capture()
+	.unchecked()
+	.run()?;
+	assert!(
+		setup_output.status.success(),
+		"stderr: {}",
+		String::from_utf8_lossy(&setup_output.stderr)
+	);
+
+	let output = biwa_cmd_tilde(&["pull", "--include", "node"], dir.path())
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	assert!(!output.status.success(), "stderr: {stderr}");
+	assert!(
+		stderr.contains("Refusing to overwrite non-empty local directory with remote file"),
+		"stderr: {stderr}"
+	);
+	assert_eq!(
+		fs::read_to_string(dir.path().join("node/kept.txt"))?,
+		"keep"
+	);
+	assert!(dir.path().join("node").is_dir());
+	assert!(
+		fs::read_dir(dir.path())?.all(|entry| {
+			entry.is_ok_and(|entry| {
+				!entry
+					.file_name()
+					.to_string_lossy()
+					.starts_with(".biwa-pull-")
+			})
+		}),
+		"pull staging data was not removed"
+	);
+
+	Ok(())
+}
+
+#[test]
 fn e2e_pull_deletes_local_file_missing_remotely() -> Result<()> {
 	let dir = tempfile::tempdir()?;
 	fs::write(dir.path().join("stale.txt"), "stale")?;


### PR DESCRIPTION
## Summary

- add planner coverage for local file/directory conflicts during pull synchronization
- verify both type-replacement directions against the SSH test server
- reject replacing a selected non-empty local directory with a remote file and confirm the pull transaction is cleaned up

## Why

Pull commit safety depends on staging, backup, directory creation, and download installation happening in a specific order. These conflict paths had no direct regression coverage.

## Impact

Contributors can safely change pull planning or transactional commit behavior without silently regressing file/directory replacement or data-preservation safeguards.

Part of #292.

## Validation

- `cargo test calculate_pull_actions_replaces_local`
- `cargo test --test ssh_e2e_sync e2e_pull_ -- --nocapture`
- `mise run check --lint`

## Summary by Sourcery

Expand pull synchronization coverage for file/directory replacement and conflict handling between local and remote state.

Tests:
- Add SSH end-to-end tests covering replacement of a local file with a remote directory and vice versa.
- Add an end-to-end test ensuring pull refuses overwriting a non-empty selected local directory with a remote file and leaves local data and staging clean.
- Add planner-level tests verifying calculate_pull_actions handles file-to-directory and directory-to-file replacements correctly.