### PR TITLE
test(cli): verify generated usage artifact freshness

### DIFF
--- a/biwa.usage.kdl
+++ b/biwa.usage.kdl
@@ -1,6 +1,6 @@
 name biwa
 bin biwa
-version "0.1.0"
+version "1.0.0"
 about "CLI to execute commands on UNSW CSE servers from local"
 usage "Usage: biwa [OPTIONS] [COMMAND]"
 flag "-v --verbose" help="Set the verbosity level." var=#true global=#true count=#true {

--- a/docs/src/cli/index.md
+++ b/docs/src/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `biwa [FLAGS] <SUBCOMMAND>`
 
-**Version**: 0.1.0
+**Version**: 1.0.0
 
 - **Usage**: `biwa [FLAGS] <SUBCOMMAND>`
 

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -28,6 +28,7 @@ impl Usage {
 mod tests {
 	use crate::cli::Cli;
 	use clap::CommandFactory as _;
+	use pretty_assertions::assert_eq;
 
 	#[test]
 	fn usage_spec_generation() {
@@ -37,5 +38,16 @@ mod tests {
 		assert!(!output.is_empty());
 		// Should contain the biwa command
 		assert!(output.contains("biwa"));
+	}
+
+	#[test]
+	fn usage_spec_matches_committed_artifact() {
+		let cli = Cli::command();
+		let spec: usage::Spec = cli.into();
+
+		assert_eq!(
+			spec.to_string().trim(),
+			include_str!("../../biwa.usage.kdl").trim()
+		);
 	}
 }


### PR DESCRIPTION
## Summary

- regenerate the committed usage specification and CLI index with the current release version
- add a unit test that compares generated usage output with the committed KDL artifact

## Why

The committed usage artifact still advertised version 0.1.0 while the CLI now reports 1.0.0. CI renders generated files but did not assert that the committed artifact matches the renderer.

## Impact

Future CLI or metadata changes fail a focused regression test until generated usage artifacts are refreshed.

Part of #292.

## Validation

- `mise run render:usage`
- `cargo fmt --check`
- `cargo test usage_spec_matches_committed_artifact`
- `hk check --all --step clippy`

## Summary by Sourcery

Add a regression test to ensure the generated CLI usage spec stays in sync with the committed usage artifact and refresh the documented version.

New Features:
- Introduce a unit test that compares the generated CLI usage specification with the committed KDL usage artifact.

Bug Fixes:
- Update the documented CLI version in the usage index to match the current 1.0.0 release.

Tests:
- Add a usage spec matching test that fails when the generated CLI usage output diverges from the committed usage file.