### PR TITLE
test(sync): cover push file-directory replacements

### DIFF
--- a/src/ssh/sync.rs
+++ b/src/ssh/sync.rs
@@ -3452,6 +3452,56 @@ mod tests {
 	}
 
 	#[test]
+	fn calculate_push_actions_replaces_remote_file_with_local_directory() {
+		let actions = calculate_push_actions(
+			&LocalState {
+				files: vec![LocalFile {
+					path: PathBuf::from("node/child.txt"),
+					hash: "local".to_owned(),
+				}],
+				directories: HashSet::from(["node".to_owned()]),
+				symlinks: HashSet::new(),
+			},
+			&RemoteState {
+				file_hashes: HashMap::from([("node".to_owned(), "remote".to_owned())]),
+				directories: HashSet::new(),
+				symlinks: HashSet::new(),
+			},
+			&Options::default(),
+		);
+
+		assert_eq!(actions.uploads, vec![PathBuf::from("node/child.txt")]);
+		assert_eq!(actions.file_deletions, vec!["node".to_owned()]);
+		assert_eq!(actions.directory_creations, vec!["node".to_owned()]);
+		assert!(actions.directory_deletions.is_empty());
+	}
+
+	#[test]
+	fn calculate_push_actions_replaces_remote_directory_with_local_file() {
+		let actions = calculate_push_actions(
+			&LocalState {
+				files: vec![LocalFile {
+					path: PathBuf::from("node"),
+					hash: "local".to_owned(),
+				}],
+				directories: HashSet::new(),
+				symlinks: HashSet::new(),
+			},
+			&RemoteState {
+				file_hashes: HashMap::from([("node/child.txt".to_owned(), "remote".to_owned())]),
+				directories: HashSet::from(["node".to_owned()]),
+				symlinks: HashSet::new(),
+			},
+			&Options::default(),
+		);
+
+		assert_eq!(actions.uploads, vec![PathBuf::from("node")]);
+		assert_eq!(actions.file_deletions, vec!["node/child.txt".to_owned()]);
+		assert!(actions.directory_creations.is_empty());
+		assert_eq!(actions.directory_deletions, vec!["node".to_owned()]);
+	}
+
+	#[test]
 	fn calculate_pull_actions_downloads_changed_and_missing_files() {
 		let actions = calculate_pull_actions(
 			&LocalState {

--- a/tests/ssh_e2e_sync.rs
+++ b/tests/ssh_e2e_sync.rs
@@ -81,6 +81,125 @@ fn e2e_sync_basic() -> Result<()> {
 }
 
 #[test]
+fn e2e_sync_replaces_remote_file_with_local_directory() -> Result<()> {
+	let dir = tempfile::tempdir()?;
+	fs::create_dir_all(dir.path().join("node"))?;
+	fs::write(dir.path().join("node/child.txt"), "local")?;
+	let remote_proj_dir = common::get_remote_project_dir(dir.path())?;
+
+	let setup_output = biwa_cmd_tilde(
+		&[
+			"run",
+			"-d",
+			"~",
+			"sh",
+			"-c",
+			"mkdir -p \"$1\" && printf remote > \"$1/node\"",
+			"--",
+			&remote_proj_dir,
+		],
+		dir.path(),
+	)
+	.stdout_capture()
+	.stderr_capture()
+	.unchecked()
+	.run()?;
+	assert!(
+		setup_output.status.success(),
+		"stderr: {}",
+		String::from_utf8_lossy(&setup_output.stderr)
+	);
+
+	let output = biwa_cmd_tilde(&["sync"], dir.path())
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	assert!(output.status.success(), "stderr: {stderr}");
+	assert_eq!(
+		String::from_utf8_lossy(
+			&biwa_cmd_tilde(
+				&[
+					"run",
+					"--skip-sync",
+					"cat",
+					&format!("{remote_proj_dir}/node/child.txt"),
+				],
+				dir.path(),
+			)
+			.stdout_capture()
+			.stderr_capture()
+			.run()?
+			.stdout,
+		)
+		.trim(),
+		"local"
+	);
+
+	Ok(())
+}
+
+#[test]
+fn e2e_sync_replaces_remote_directory_with_local_file() -> Result<()> {
+	let dir = tempfile::tempdir()?;
+	fs::write(dir.path().join("node"), "local")?;
+	let remote_proj_dir = common::get_remote_project_dir(dir.path())?;
+
+	let setup_output = biwa_cmd_tilde(
+		&[
+			"run",
+			"-d",
+			"~",
+			"sh",
+			"-c",
+			"mkdir -p \"$1/node\" && printf remote > \"$1/node/child.txt\"",
+			"--",
+			&remote_proj_dir,
+		],
+		dir.path(),
+	)
+	.stdout_capture()
+	.stderr_capture()
+	.unchecked()
+	.run()?;
+	assert!(
+		setup_output.status.success(),
+		"stderr: {}",
+		String::from_utf8_lossy(&setup_output.stderr)
+	);
+
+	let output = biwa_cmd_tilde(&["sync"], dir.path())
+		.stdout_capture()
+		.stderr_capture()
+		.unchecked()
+		.run()?;
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	assert!(output.status.success(), "stderr: {stderr}");
+	assert_eq!(
+		String::from_utf8_lossy(
+			&biwa_cmd_tilde(
+				&[
+					"run",
+					"--skip-sync",
+					"cat",
+					&format!("{remote_proj_dir}/node"),
+				],
+				dir.path(),
+			)
+			.stdout_capture()
+			.stderr_capture()
+			.run()?
+			.stdout,
+		)
+		.trim(),
+		"local"
+	);
+
+	Ok(())
+}
+
+#[test]
 fn e2e_pull_downloads_remote_file() -> Result<()> {
 	let dir = tempfile::tempdir()?;
 	let remote_proj_dir = common::get_remote_project_dir(dir.path())?;


### PR DESCRIPTION
## Summary

- add planner coverage for remote file/directory conflicts during push synchronization
- verify both type-replacement directions against the SSH test server

## Why

Push action ordering must delete files, remove directories deepest-first, create directories, and upload in the safe order. Neither conflict direction had a direct regression test.

## Impact

Changes to push planning or SFTP action ordering cannot silently regress file/directory replacement.

Part of #292.

## Validation

- `cargo test calculate_push_actions_replaces_remote`
- `cargo test --test ssh_e2e_sync e2e_sync_replaces_remote -- --nocapture`
- `mise run check --lint`

## Summary by Sourcery

Extend SSH sync push coverage for remote file/directory replacement conflicts.

Tests:
- Add end-to-end SSH sync tests verifying replacing a remote file with a local directory and vice versa.
- Add unit tests for push action planning when local and remote disagree on file vs directory for the same path.