### PR TITLE
docs: document focused testing workflows

### DIFF
--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -41,6 +41,43 @@ normally starts them automatically; if they are not running, use:
 pitchfork start --all
 ```
 
+## Testing
+
+Start with the smallest test that covers the behavior you changed, then run the
+full suite before opening a pull request:
+
+```bash
+# A unit test or module
+cargo test cli_run_subcommand
+
+# One SSH integration test
+cargo test --test ssh_e2e_sync e2e_sync_empty_dir_created
+
+# Keep test output while investigating a failure
+cargo test e2e_sync_empty_dir_created -- --nocapture
+
+# Full Rust suite and CI-like lint checks
+mise run test
+mise run check --lint
+```
+
+Run SSH end-to-end tests for behavior that depends on the server, SFTP, or remote
+shell execution. For parser, configuration, and sync-planning changes, prefer a
+focused unit test first. When adding coverage for a risk-prone path, generate a
+local coverage report with `mise run test:coverage`; the HTML report is written to
+`tarpaulin-report.html`.
+
+Regenerate checked-in artifacts whenever their inputs change:
+
+```bash
+# CLI usage reference and configuration schema
+mise run render:usage
+mise run render:schema
+
+# Intentional snapshot changes
+mise run test:update-snapshot
+```
+
 ## Documentation
 
 To work on documentation:


### PR DESCRIPTION
## Summary

- document focused unit and SSH integration test commands
- explain when to use coverage reporting and how to inspect it
- document regeneration commands for usage, schema, and snapshots

## Why

Contributors need an efficient way to choose the right validation level for a change, especially for SSH-dependent behavior and generated artifacts.

## Impact

The contributing guide now gives a practical progression from a single focused test to the full suite and CI-like lint checks.

Part of #292.

## Validation

- `mise run docs:build`
- `mise run check --lint`

## Summary by Sourcery

Document focused testing workflows and regeneration commands for contributors.

Documentation:
- Add a testing section to the contributing guide covering focused unit tests, SSH integration tests, full suite runs, and coverage reporting.
- Document commands for regenerating CLI usage, configuration schema, and test snapshots in the contributing guide.