### PR TITLE
feat: add usage command effects

### DIFF
--- a/biwa.usage.kdl
+++ b/biwa.usage.kdl
@@ -16,19 +16,19 @@ By default, only warnings and errors are shown.
 }
 flag "-q --quiet" help="Suppress biwa internal logs, only showing remote command output" global=#true
 flag "-s --silent" help="Suppress all output, including remote command stdout/stderr" global=#true
-arg "[RUN_COMMAND_ARGS]…" help="The arguments for the command to run on the remote host" required=#false double_dash=automatic var=#true hide=#true
-cmd activate help="Print shell activation code and manage direct command shims" {
-    flag --shell help="Print activation code for this shell" {
+arg "[RUN_COMMAND_ARGS]…" help="The arguments for the command to run on the remote host" required=#false double_dash=automatic var=#true hide=#true effect=destructive
+cmd activate help="Print shell activation code and manage direct command shims" effect=read {
+    flag --shell help="Print activation code for this shell" effect=write {
         arg <SHELL> {
             choices bash zsh fish
         }
     }
-    cmd install help="Reconcile configured direct command shims" {
-        flag "-f --force" help="Replace existing entries not already managed by biwa"
+    cmd install help="Reconcile configured direct command shims" effect=write {
+        flag "-f --force" help="Replace existing entries not already managed by biwa" effect=destructive
     }
-    cmd doctor help="Print diagnostic information for direct command activation"
+    cmd doctor help="Print diagnostic information for direct command activation" effect=read
 }
-cmd run help="Run commands on remote host" {
+cmd run help="Run commands on remote host" effect=destructive {
     alias r
     flag --skip-sync help="Skip automatic synchronization before running the command (automatically selected if --remote-dir is used)"
     flag --sync help="Push project files before running, even when sync.auto is disabled or --remote-dir is set"
@@ -54,7 +54,7 @@ cmd run help="Run commands on remote host" {
     arg <COMMAND> help="The command to run"
     arg "[COMMAND_ARGS]…" help="The arguments for the command" required=#false double_dash=automatic var=#true
 }
-cmd sync help="Push local project files to the remote host" {
+cmd sync help="Push local project files to the remote host" effect=destructive {
     alias s push
     flag --sync-root help="Local project root used for synchronization" {
         arg <SYNC_ROOT>
@@ -71,7 +71,7 @@ cmd sync help="Push local project files to the remote host" {
         arg <INCLUDE>
     }
 }
-cmd pull help="Mirror remote project files into the local root" {
+cmd pull help="Mirror remote project files into the local root" effect=destructive {
     long_help #"""
 Mirror remote project files into the local root.
 
@@ -92,7 +92,7 @@ The remote project is the source of truth. Selected local files and directories 
         arg <INCLUDE>
     }
 }
-cmd clean help="Clean stale remote project directories" {
+cmd clean help="Clean stale remote project directories" effect=destructive {
     alias c
     flag --all help="Remove all this client's tracked remote directories"
     flag --purge help="Remove ALL biwa directories under `remote_root` (including other clients)"
@@ -102,16 +102,16 @@ cmd clean help="Clean stale remote project directories" {
         choices stop
     }
 }
-cmd init help="Initialize a biwa configuration file" {
-    flag "-f --force" help="Force overwrite if file exists"
+cmd init help="Initialize a biwa configuration file" effect=write {
+    flag "-f --force" help="Force overwrite if file exists" effect=destructive
     flag --format help="Format to generate (toml, json, jsonc, json5, yaml, yml)" default=toml {
         arg <FORMAT>
     }
 }
-cmd schema hide=#true help="Generate the JSON schema for the configuration"
-cmd completion help="Generate shell completion scripts" {
+cmd schema hide=#true help="Generate the JSON schema for the configuration" effect=read
+cmd completion help="Generate shell completion scripts" effect=read {
     arg <SHELL> help="Shell type to generate completions for" {
         choices bash fish zsh
     }
 }
-cmd usage hide=#true help="Generate usage command specifications"
+cmd usage hide=#true help="Generate usage command specifications" effect=read

--- a/docs/src/cli/activate.md
+++ b/docs/src/cli/activate.md
@@ -2,12 +2,15 @@
 # `biwa activate`
 
 - **Usage**: `biwa activate [--shell <SHELL>] <SUBCOMMAND>`
+- **Effect**: read-only
 
 Print shell activation code and manage direct command shims
 
 ## Flags
 
 ### `--shell <SHELL>`
+
+**Effect**: modifies state
 
 Print activation code for this shell
 

--- a/docs/src/cli/activate/doctor.md
+++ b/docs/src/cli/activate/doctor.md
@@ -2,5 +2,6 @@
 # `biwa activate doctor`
 
 - **Usage**: `biwa activate doctor`
+- **Effect**: read-only
 
 Print diagnostic information for direct command activation

--- a/docs/src/cli/activate/install.md
+++ b/docs/src/cli/activate/install.md
@@ -2,11 +2,14 @@
 # `biwa activate install`
 
 - **Usage**: `biwa activate install [-f --force]`
+- **Effect**: modifies state
 
 Reconcile configured direct command shims
 
 ## Flags
 
 ### `-f --force`
+
+**Effect**: destructive — may delete or irreversibly overwrite
 
 Replace existing entries not already managed by biwa

--- a/docs/src/cli/clean.md
+++ b/docs/src/cli/clean.md
@@ -3,6 +3,7 @@
 
 - **Usage**: `biwa clean [FLAGS] [ACTION]`
 - **Aliases**: `c`
+- **Effect**: destructive — may delete or irreversibly overwrite
 
 Clean stale remote project directories
 

--- a/docs/src/cli/completion.md
+++ b/docs/src/cli/completion.md
@@ -2,6 +2,7 @@
 # `biwa completion`
 
 - **Usage**: `biwa completion <SHELL>`
+- **Effect**: read-only
 
 Generate shell completion scripts
 

--- a/docs/src/cli/init.md
+++ b/docs/src/cli/init.md
@@ -2,12 +2,15 @@
 # `biwa init`
 
 - **Usage**: `biwa init [-f --force] [--format <FORMAT>]`
+- **Effect**: modifies state
 
 Initialize a biwa configuration file
 
 ## Flags
 
 ### `-f --force`
+
+**Effect**: destructive — may delete or irreversibly overwrite
 
 Force overwrite if file exists
 

--- a/docs/src/cli/pull.md
+++ b/docs/src/cli/pull.md
@@ -2,6 +2,7 @@
 # `biwa pull`
 
 - **Usage**: `biwa pull [FLAGS]`
+- **Effect**: destructive — may delete or irreversibly overwrite
 
 Mirror remote project files into the local root.
 

--- a/docs/src/cli/run.md
+++ b/docs/src/cli/run.md
@@ -3,6 +3,7 @@
 
 - **Usage**: `biwa run [FLAGS] <COMMAND> [COMMAND_ARGS]…`
 - **Aliases**: `r`
+- **Effect**: destructive — may delete or irreversibly overwrite
 
 Run commands on remote host
 

--- a/docs/src/cli/sync.md
+++ b/docs/src/cli/sync.md
@@ -3,6 +3,7 @@
 
 - **Usage**: `biwa sync [FLAGS]`
 - **Aliases**: `s`, `push`
+- **Effect**: destructive — may delete or irreversibly overwrite
 
 Push local project files to the remote host
 

--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -1,5 +1,6 @@
 use crate::Result;
 use crate::cli::run::validate_direct_options;
+use crate::cli::usage::{CommandEffects, apply_subcommand_effects, set_flag_effect};
 use crate::config::types::Config;
 use alloc::collections::BTreeSet;
 use clap::{Args, Subcommand, ValueEnum};
@@ -103,6 +104,30 @@ impl Activate {
 			bail!("Specify `--shell <bash|zsh|fish>`, `install`, or `doctor`.");
 		}
 		Ok(())
+	}
+}
+
+impl CommandEffects for Activate {
+	const EFFECT: ::usage::SpecCommandEffect = ::usage::SpecCommandEffect::Read;
+
+	fn apply_effects(command: &mut ::usage::SpecCommand) {
+		command.effect = Some(Self::EFFECT);
+		set_flag_effect(command, "shell", ::usage::SpecCommandEffect::Write);
+		apply_subcommand_effects::<Install>(command, "install");
+		command
+			.subcommands
+			.get_mut("doctor")
+			.expect("Clap-generated usage spec must contain activate doctor")
+			.effect = Some(::usage::SpecCommandEffect::Read);
+	}
+}
+
+impl CommandEffects for Install {
+	const EFFECT: ::usage::SpecCommandEffect = ::usage::SpecCommandEffect::Write;
+
+	fn apply_effects(command: &mut ::usage::SpecCommand) {
+		command.effect = Some(Self::EFFECT);
+		set_flag_effect(command, "force", ::usage::SpecCommandEffect::Destructive);
 	}
 }
 

--- a/src/cli/clean.rs
+++ b/src/cli/clean.rs
@@ -1,5 +1,6 @@
 use crate::Result;
 use crate::cli::transfer::TransferArgs;
+use crate::cli::usage::CommandEffects;
 use crate::config::types::{Config, PasswordConfig};
 use crate::duration::HumanDuration;
 use crate::ssh::clean::{
@@ -59,6 +60,10 @@ pub(super) struct Clean {
 	/// Background auto-cleanup mode (used internally by the daemon).
 	#[arg(long, hide = true)]
 	auto: bool,
+}
+
+impl CommandEffects for Clean {
+	const EFFECT: ::usage::SpecCommandEffect = ::usage::SpecCommandEffect::Destructive;
 }
 
 /// Optional action for `biwa clean`.

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -1,4 +1,5 @@
 use crate::Result;
+use crate::cli::usage::CommandEffects;
 use clap::Args;
 use clap::builder::PossibleValue;
 use color_eyre::eyre::bail;
@@ -12,6 +13,10 @@ use strum::EnumString;
 pub(super) struct Completion {
 	/// Shell type to generate completions for.
 	shell: Shell,
+}
+
+impl CommandEffects for Completion {
+	const EFFECT: ::usage::SpecCommandEffect = ::usage::SpecCommandEffect::Read;
 }
 
 impl Completion {

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,4 +1,5 @@
 use crate::Result;
+use crate::cli::usage::{CommandEffects, set_flag_effect};
 use crate::{config::format::ConfigFormat, config::types::Config};
 use clap::Args;
 use color_eyre::eyre::{bail, eyre};
@@ -74,6 +75,15 @@ impl Init {
 		};
 
 		Ok((filename, content))
+	}
+}
+
+impl CommandEffects for Init {
+	const EFFECT: ::usage::SpecCommandEffect = ::usage::SpecCommandEffect::Write;
+
+	fn apply_effects(command: &mut ::usage::SpecCommand) {
+		command.effect = Some(Self::EFFECT);
+		set_flag_effect(command, "force", ::usage::SpecCommandEffect::Destructive);
 	}
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,6 +2,7 @@ use crate::Result;
 use crate::cli::transfer::TransferArgs;
 use crate::config::types::Config;
 use crate::env_flag;
+use ::usage::SpecCommand;
 use clap::{ArgAction, Parser, Subcommand};
 use color_eyre::eyre::eyre;
 use std::env;
@@ -91,6 +92,21 @@ enum Commands {
 	Completion(completion::Completion),
 	/// Generate usage command specifications.
 	Usage(usage::Usage),
+}
+
+/// Applies effects declared by each subcommand to the generated usage tree.
+fn apply_command_effects(root: &mut SpecCommand) {
+	use usage::apply_subcommand_effects;
+
+	apply_subcommand_effects::<activate::Activate>(root, "activate");
+	apply_subcommand_effects::<run::Run>(root, "run");
+	apply_subcommand_effects::<sync::Sync>(root, "sync");
+	apply_subcommand_effects::<pull::Pull>(root, "pull");
+	apply_subcommand_effects::<clean::Clean>(root, "clean");
+	apply_subcommand_effects::<init::Init>(root, "init");
+	apply_subcommand_effects::<schema::Schema>(root, "schema");
+	apply_subcommand_effects::<completion::Completion>(root, "completion");
+	apply_subcommand_effects::<usage::Usage>(root, "usage");
 }
 
 /// Main entry point for the CLI. Parses arguments and routes to the appropriate command.

--- a/src/cli/pull.rs
+++ b/src/cli/pull.rs
@@ -1,6 +1,7 @@
 use crate::Result;
 use crate::cli::clean::spawn_background_cleanup;
 use crate::cli::transfer::{TransferArgs, record_connection_use};
+use crate::cli::usage::CommandEffects;
 use crate::config::types::Config;
 use crate::ssh::exec::connect;
 use crate::ssh::sync::pull_project;
@@ -13,6 +14,10 @@ pub(super) struct Pull {
 	/// Project transfer options.
 	#[clap(flatten)]
 	args: TransferArgs,
+}
+
+impl CommandEffects for Pull {
+	const EFFECT: ::usage::SpecCommandEffect = ::usage::SpecCommandEffect::Destructive;
 }
 
 impl Pull {

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1,6 +1,7 @@
 use crate::Result;
 use crate::cli::clean::spawn_background_cleanup;
 use crate::cli::transfer::{TransferArgs, record_connection_use};
+use crate::cli::usage::CommandEffects;
 use crate::config::types::Config;
 use crate::env_vars::parse_cli_env_vars;
 use crate::{
@@ -55,6 +56,10 @@ pub(super) struct Run {
 	/// The arguments for the command.
 	#[arg(allow_hyphen_values = true, trailing_var_arg = true)]
 	command_args: Vec<String>,
+}
+
+impl CommandEffects for Run {
+	const EFFECT: ::usage::SpecCommandEffect = ::usage::SpecCommandEffect::Destructive;
 }
 
 /// File-transfer workflow surrounding a remote command.

--- a/src/cli/schema.rs
+++ b/src/cli/schema.rs
@@ -1,4 +1,5 @@
 use crate::Result;
+use crate::cli::usage::CommandEffects;
 use crate::config::types::Config;
 use clap::Args;
 use schemars::{generate::SchemaSettings, transform::RestrictFormats};
@@ -7,6 +8,10 @@ use schemars::{generate::SchemaSettings, transform::RestrictFormats};
 #[derive(Args, Debug)]
 #[command(hide = true)]
 pub(super) struct Schema;
+
+impl CommandEffects for Schema {
+	const EFFECT: ::usage::SpecCommandEffect = ::usage::SpecCommandEffect::Read;
+}
 
 impl Schema {
 	/// Run the schema generation logic.

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -1,6 +1,7 @@
 use crate::Result;
 use crate::cli::clean::spawn_background_cleanup;
 use crate::cli::transfer::{TransferArgs, record_connection_use};
+use crate::cli::usage::CommandEffects;
 use crate::config::types::Config;
 use crate::ssh::exec::connect;
 use crate::ssh::sync::push_project;
@@ -14,6 +15,10 @@ pub(super) struct Sync {
 	/// Project transfer options.
 	#[clap(flatten)]
 	args: TransferArgs,
+}
+
+impl CommandEffects for Sync {
+	const EFFECT: ::usage::SpecCommandEffect = ::usage::SpecCommandEffect::Destructive;
 }
 
 impl Sync {

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -1,5 +1,5 @@
 use crate::Result;
-use crate::cli::Cli;
+use crate::cli::{Cli, apply_command_effects};
 use clap::{Args, CommandFactory as _};
 use usage::{Spec, SpecCommand, SpecCommandEffect};
 
@@ -9,6 +9,10 @@ use usage::{Spec, SpecCommand, SpecCommandEffect};
 #[derive(Args, Debug)]
 #[command(hide = true)]
 pub(super) struct Usage;
+
+impl CommandEffects for Usage {
+	const EFFECT: SpecCommandEffect = SpecCommandEffect::Read;
+}
 
 impl Usage {
 	/// Run the usage spec generation logic.
@@ -34,53 +38,36 @@ fn usage_spec() -> Spec {
 
 /// Adds conservative effects to commands, flags, and arguments.
 fn apply_effects(spec: &mut Spec) {
-	use SpecCommandEffect::{Destructive, Read, Write};
-
-	set_arg_effect(&mut spec.cmd, &[], "RUN_COMMAND_ARGS", Destructive);
-
-	set_command_effect(&mut spec.cmd, &["activate"], Read);
-	set_flag_effect(&mut spec.cmd, &["activate"], "shell", Write);
-	set_command_effect(&mut spec.cmd, &["activate", "install"], Write);
-	set_flag_effect(
+	set_arg_effect(
 		&mut spec.cmd,
-		&["activate", "install"],
-		"force",
-		Destructive,
+		"RUN_COMMAND_ARGS",
+		SpecCommandEffect::Destructive,
 	);
-	set_command_effect(&mut spec.cmd, &["activate", "doctor"], Read);
+	apply_command_effects(&mut spec.cmd);
+}
 
-	for command in ["run", "sync", "pull", "clean"] {
-		set_command_effect(&mut spec.cmd, &[command], Destructive);
-	}
+/// Lets a CLI command declare its own usage effects.
+pub(super) trait CommandEffects {
+	/// The effect of invoking the command without effect-raising options.
+	const EFFECT: SpecCommandEffect;
 
-	set_command_effect(&mut spec.cmd, &["init"], Write);
-	set_flag_effect(&mut spec.cmd, &["init"], "force", Destructive);
-
-	for command in ["schema", "completion", "usage"] {
-		set_command_effect(&mut spec.cmd, &[command], Read);
+	/// Adds this command's effects to its Clap-generated usage command.
+	fn apply_effects(command: &mut SpecCommand) {
+		command.effect = Some(Self::EFFECT);
 	}
 }
 
-/// Returns a mutable command at the provided path.
-fn command_mut<'a>(root: &'a mut SpecCommand, path: &[&str]) -> &'a mut SpecCommand {
-	let mut command = root;
-	for name in path {
-		command = command
-			.subcommands
-			.get_mut(*name)
-			.expect("Clap-generated usage spec must contain annotated command");
-	}
-	command
-}
-
-/// Sets the effect for a command at the provided path.
-fn set_command_effect(root: &mut SpecCommand, path: &[&str], effect: SpecCommandEffect) {
-	command_mut(root, path).effect = Some(effect);
+/// Applies a command type's declared effects to a named subcommand.
+pub(super) fn apply_subcommand_effects<T: CommandEffects>(parent: &mut SpecCommand, name: &str) {
+	let command = parent
+		.subcommands
+		.get_mut(name)
+		.expect("Clap-generated usage spec must contain annotated command");
+	T::apply_effects(command);
 }
 
 /// Sets the effect for a long flag on a command.
-fn set_flag_effect(root: &mut SpecCommand, path: &[&str], long: &str, effect: SpecCommandEffect) {
-	let command = command_mut(root, path);
+pub(super) fn set_flag_effect(command: &mut SpecCommand, long: &str, effect: SpecCommandEffect) {
 	let flag = command
 		.flags
 		.iter_mut()
@@ -90,8 +77,7 @@ fn set_flag_effect(root: &mut SpecCommand, path: &[&str], long: &str, effect: Sp
 }
 
 /// Sets the effect for a positional argument on a command.
-fn set_arg_effect(root: &mut SpecCommand, path: &[&str], name: &str, effect: SpecCommandEffect) {
-	let command = command_mut(root, path);
+fn set_arg_effect(command: &mut SpecCommand, name: &str, effect: SpecCommandEffect) {
 	let arg = command
 		.args
 		.iter_mut()

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -1,6 +1,7 @@
 use crate::Result;
 use crate::cli::Cli;
 use clap::{Args, CommandFactory as _};
+use usage::{Spec, SpecCommand, SpecCommandEffect};
 
 /// Generate a usage CLI spec.
 ///
@@ -17,23 +18,96 @@ impl Usage {
 		reason = "usage subcommand doesn't return Err"
 	)]
 	pub(super) fn run(self) -> Result<()> {
-		let cli = Cli::command();
-		let spec: usage::Spec = cli.into();
+		let spec = usage_spec();
 		println!("{}", spec.to_string().trim());
 		Ok(())
 	}
 }
 
+/// Builds the usage specification and annotates command side effects.
+fn usage_spec() -> Spec {
+	let cli = Cli::command();
+	let mut spec: Spec = cli.into();
+	apply_effects(&mut spec);
+	spec
+}
+
+/// Adds conservative effects to commands, flags, and arguments.
+fn apply_effects(spec: &mut Spec) {
+	use SpecCommandEffect::{Destructive, Read, Write};
+
+	set_arg_effect(&mut spec.cmd, &[], "RUN_COMMAND_ARGS", Destructive);
+
+	set_command_effect(&mut spec.cmd, &["activate"], Read);
+	set_flag_effect(&mut spec.cmd, &["activate"], "shell", Write);
+	set_command_effect(&mut spec.cmd, &["activate", "install"], Write);
+	set_flag_effect(
+		&mut spec.cmd,
+		&["activate", "install"],
+		"force",
+		Destructive,
+	);
+	set_command_effect(&mut spec.cmd, &["activate", "doctor"], Read);
+
+	for command in ["run", "sync", "pull", "clean"] {
+		set_command_effect(&mut spec.cmd, &[command], Destructive);
+	}
+
+	set_command_effect(&mut spec.cmd, &["init"], Write);
+	set_flag_effect(&mut spec.cmd, &["init"], "force", Destructive);
+
+	for command in ["schema", "completion", "usage"] {
+		set_command_effect(&mut spec.cmd, &[command], Read);
+	}
+}
+
+/// Returns a mutable command at the provided path.
+fn command_mut<'a>(root: &'a mut SpecCommand, path: &[&str]) -> &'a mut SpecCommand {
+	let mut command = root;
+	for name in path {
+		command = command
+			.subcommands
+			.get_mut(*name)
+			.expect("Clap-generated usage spec must contain annotated command");
+	}
+	command
+}
+
+/// Sets the effect for a command at the provided path.
+fn set_command_effect(root: &mut SpecCommand, path: &[&str], effect: SpecCommandEffect) {
+	command_mut(root, path).effect = Some(effect);
+}
+
+/// Sets the effect for a long flag on a command.
+fn set_flag_effect(root: &mut SpecCommand, path: &[&str], long: &str, effect: SpecCommandEffect) {
+	let command = command_mut(root, path);
+	let flag = command
+		.flags
+		.iter_mut()
+		.find(|flag| flag.long.iter().any(|candidate| candidate == long))
+		.expect("Clap-generated usage spec must contain annotated flag");
+	flag.effect = Some(effect);
+}
+
+/// Sets the effect for a positional argument on a command.
+fn set_arg_effect(root: &mut SpecCommand, path: &[&str], name: &str, effect: SpecCommandEffect) {
+	let command = command_mut(root, path);
+	let arg = command
+		.args
+		.iter_mut()
+		.find(|arg| arg.name == name)
+		.expect("Clap-generated usage spec must contain annotated argument");
+	arg.effect = Some(effect);
+}
+
 #[cfg(test)]
 mod tests {
-	use crate::cli::Cli;
-	use clap::CommandFactory as _;
+	use super::*;
 	use pretty_assertions::assert_eq;
 
 	#[test]
 	fn usage_spec_generation() {
-		let cli = Cli::command();
-		let spec: usage::Spec = cli.into();
+		let spec = usage_spec();
 		let output = spec.to_string();
 		assert!(!output.is_empty());
 		// Should contain the biwa command
@@ -42,12 +116,72 @@ mod tests {
 
 	#[test]
 	fn usage_spec_matches_committed_artifact() {
-		let cli = Cli::command();
-		let spec: usage::Spec = cli.into();
+		let spec = usage_spec();
 
 		assert_eq!(
 			spec.to_string().trim(),
 			include_str!("../../biwa.usage.kdl").trim()
 		);
+	}
+
+	#[test]
+	fn usage_spec_declares_effects() {
+		use SpecCommandEffect::{Destructive, Read, Write};
+
+		let spec = usage_spec();
+		assert_eq!(spec.cmd.effect, None);
+		assert_eq!(spec.cmd.max_effect(), Some(Destructive));
+
+		let activate = spec
+			.cmd
+			.subcommands
+			.get("activate")
+			.expect("activate command should exist");
+		assert_eq!(activate.effect, Some(Read));
+		assert_eq!(activate.max_effect(), Some(Write));
+		assert_eq!(
+			activate
+				.subcommands
+				.get("doctor")
+				.expect("doctor command should exist")
+				.effect,
+			Some(Read)
+		);
+		let install = activate
+			.subcommands
+			.get("install")
+			.expect("install command should exist");
+		assert_eq!(install.effect, Some(Write));
+		assert_eq!(install.max_effect(), Some(Destructive));
+
+		for command in ["run", "sync", "pull", "clean"] {
+			assert_eq!(
+				spec.cmd
+					.subcommands
+					.get(command)
+					.expect("destructive command should exist")
+					.effect,
+				Some(Destructive)
+			);
+		}
+
+		let init = spec
+			.cmd
+			.subcommands
+			.get("init")
+			.expect("init command should exist");
+		assert_eq!(init.effect, Some(Write));
+		assert_eq!(init.max_effect(), Some(Destructive));
+
+		for command in ["schema", "completion", "usage"] {
+			assert_eq!(
+				spec.cmd
+					.subcommands
+					.get(command)
+					.expect("read-only command should exist")
+					.effect,
+				Some(Read)
+			);
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- annotate generated usage commands with read, write, and destructive effects
- use argument- and flag-level effects for implicit remote commands, `activate --shell`, and destructive `--force` behavior
- regenerate the committed usage spec and CLI reference pages with the effect labels

## Why

`usage` v4 can communicate invocation side effects to documentation, shell tooling, and agents. Biwa now classifies state-changing operations conservatively while preserving more precise effects where flags or positional arguments raise the risk of an invocation.

## Validation

- `mise run render:usage`
- `mise run check --lint`
- `mise run test`

## Summary by Sourcery

Annotate the generated CLI usage spec with command, flag, and argument side-effect metadata and refresh the committed spec and reference docs to surface those effects.

Enhancements:
- Introduce helper utilities to build the usage spec and apply conservative read/write/destructive effects across relevant commands and options.

Documentation:
- Update CLI reference pages to display effect labels (read-only, modifies state, destructive) for affected commands and flags.

Tests:
- Extend usage spec tests to verify that side-effect annotations are present and that each command reports the correct maximum effect.