### PR TITLE
fix(ssh): fall back to agent after key rejection

### DIFF
--- a/docs/src/ssh-key-setup.md
+++ b/docs/src/ssh-key-setup.md
@@ -65,10 +65,10 @@ biwa tries authentication methods in this order. **Explicit configuration is alw
 1. **Configured key file** — If `ssh.key_path` is set, biwa uses it (errors if not found)
 2. **Configured password** — If `ssh.password` is a string, biwa uses it; if `true`, biwa prompts interactively
 3. **Default key files** — biwa checks `~/.ssh/id_ed25519`, then `~/.ssh/id_rsa`
-4. **SSH Agent** — If nothing else is configured and no keys found, biwa falls back to the SSH agent
+4. **SSH Agent** — If no default key exists, or the discovered default key is rejected, biwa falls back to the SSH agent
 
 ::: tip Zero-Config Users
-If you want to delegate authentication to your SSH agent, **don't configure any auth settings**. biwa will automatically use the agent as a fallback.
+If you want to delegate authentication to your SSH agent, **don't configure any auth settings**. biwa will automatically use the agent, including as a fallback when a default key file does not authenticate.
 :::
 
 ## Configuration

--- a/src/ssh/auth.rs
+++ b/src/ssh/auth.rs
@@ -12,21 +12,34 @@ use tracing::{debug, info};
 /// Default SSH key paths to try when no explicit `key_path` is configured.
 const DEFAULT_KEY_PATHS: &[&str] = &["~/.ssh/id_ed25519", "~/.ssh/id_rsa"];
 
-/// Resolve the authentication method based on configuration.
+/// Resolve the authentication methods to try based on configuration.
 ///
 /// Auth cascade (explicit configuration is always respected first):
 /// 1. Explicit key file (`ssh.key_path`) — errors if file not found
 /// 2. Explicit password (`ssh.password = "..."` or `ssh.password = true` for prompt)
 /// 3. Default key file discovery (`~/.ssh/id_ed25519`, `~/.ssh/id_rsa`)
-/// 4. SSH Agent (fallback for zero-config users)
-pub(super) fn resolve_auth(config: &Config) -> Result<Method> {
+/// 4. SSH agent (fallback if the discovered default key is rejected)
+pub(super) fn resolve_auth(config: &Config) -> Result<Vec<Method>> {
+	resolve_auth_with(
+		config,
+		resolve_default_key_path(),
+		env::var("SSH_AUTH_SOCK").ok().as_deref(),
+	)
+}
+
+/// Resolve authentication methods with explicit local authentication state.
+fn resolve_auth_with(
+	config: &Config,
+	default_key_path: Option<PathBuf>,
+	auth_sock: Option<&str>,
+) -> Result<Vec<Method>> {
 	let ssh = &config.ssh;
 
 	// 1. Explicit key_path (paths are already resolved natively by confique)
 	if let Some(path) = &ssh.key_path {
 		if path.exists() {
 			info!(path = %path.display(), "Using configured SSH key file");
-			return load_key(path);
+			return Ok(vec![load_key(path)?]);
 		}
 		bail!("Configured SSH key file not found: {}", path.display());
 	}
@@ -35,14 +48,14 @@ pub(super) fn resolve_auth(config: &Config) -> Result<Method> {
 	match &ssh.password {
 		PasswordConfig::Value(password) => {
 			info!("Using password authentication from config");
-			return Ok(Method::with_password(password));
+			return Ok(vec![Method::with_password(password)]);
 		}
 		PasswordConfig::Interactive(true) => {
 			info!("Prompting for password (ssh.password = true)");
 			let password = Password::new()
 				.with_prompt(format!("Password for {}@{}", ssh.user, ssh.host))
 				.interact()?;
-			return Ok(Method::with_password(&password));
+			return Ok(vec![Method::with_password(&password)]);
 		}
 		PasswordConfig::Interactive(false) => {
 			debug!("Password authentication disabled");
@@ -50,15 +63,20 @@ pub(super) fn resolve_auth(config: &Config) -> Result<Method> {
 	}
 
 	// 3. Try default key file paths
-	if let Some(key_path) = resolve_default_key_path() {
+	if let Some(key_path) = default_key_path {
 		info!(path = %key_path.display(), "Using default SSH key file");
-		return load_key(&key_path);
+		let mut methods = vec![load_key(&key_path)?];
+		if try_agent(auth_sock) {
+			debug!("SSH agent available as fallback authentication");
+			methods.push(Method::with_agent());
+		}
+		return Ok(methods);
 	}
 
 	// 4. SSH Agent as last resort (for zero-config users)
-	if try_agent(env::var("SSH_AUTH_SOCK").ok().as_deref()) {
+	if try_agent(auth_sock) {
 		info!("Using SSH agent authentication");
-		return Ok(Method::with_agent());
+		return Ok(vec![Method::with_agent()]);
 	}
 
 	bail!(
@@ -131,9 +149,8 @@ mod tests {
 	use serial_test::serial;
 	use std::fs;
 
-	#[serial]
 	#[test]
-	fn resolve_default_key_path_explicit() -> Result<()> {
+	fn explicit_key_has_no_fallback() -> Result<()> {
 		let dir = tempfile::tempdir()?;
 		let key_file = dir.path().join("my_key");
 		fs::write(&key_file, "fake key")?;
@@ -141,8 +158,12 @@ mod tests {
 		let mut config = Config::default();
 		config.ssh.key_path = Some(key_file);
 
-		let method = resolve_auth(&config)?;
-		assert_matches!(method, Method::PrivateKeyFile { .. });
+		let methods = resolve_auth_with(
+			&config,
+			Some(PathBuf::from("/unused/default/key")),
+			Some("/tmp/fake-agent.sock"),
+		)?;
+		assert_matches!(methods.as_slice(), [Method::PrivateKeyFile { .. }]);
 		Ok(())
 	}
 
@@ -179,13 +200,44 @@ mod tests {
 		);
 	}
 
+	#[test]
+	fn default_key_falls_back_to_agent() -> Result<()> {
+		let dir = tempfile::tempdir()?;
+		let key_file = dir.path().join("id_ed25519");
+		fs::write(&key_file, "fake key")?;
+
+		let methods = resolve_auth_with(
+			&Config::default(),
+			Some(key_file),
+			Some("/tmp/fake-agent.sock"),
+		)?;
+
+		assert_matches!(
+			methods.as_slice(),
+			[Method::PrivateKeyFile { .. }, Method::Agent]
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn default_key_without_agent_has_no_fallback() -> Result<()> {
+		let dir = tempfile::tempdir()?;
+		let key_file = dir.path().join("id_ed25519");
+		fs::write(&key_file, "fake key")?;
+
+		let methods = resolve_auth_with(&Config::default(), Some(key_file), None)?;
+
+		assert_matches!(methods.as_slice(), [Method::PrivateKeyFile { .. }]);
+		Ok(())
+	}
+
 	#[serial]
 	#[test]
 	fn password_config_string() -> Result<()> {
 		let mut config = Config::default();
 		config.ssh.password = PasswordConfig::Value("secret".to_owned());
-		let method = resolve_auth(&config)?;
-		assert_matches!(method, Method::Password(_));
+		let methods = resolve_auth(&config)?;
+		assert_matches!(methods.as_slice(), [Method::Password(_)]);
 		Ok(())
 	}
 
@@ -197,8 +249,12 @@ mod tests {
 		let result = resolve_auth(&config);
 		// Without explicit password, it may fall back to agent or key, or fail
 		// — but it must not use Password auth (password = false means skip password)
-		if let Ok(method) = result {
-			assert_matches!(method, Method::PrivateKeyFile { .. } | Method::Agent);
+		if let Ok(methods) = result {
+			assert!(
+				methods
+					.iter()
+					.all(|method| matches!(method, Method::PrivateKeyFile { .. } | Method::Agent))
+			);
 		}
 	}
 }

--- a/src/ssh/exec.rs
+++ b/src/ssh/exec.rs
@@ -78,7 +78,10 @@ struct RunCommandOptions<'a> {
 /// Connect to the SSH server using the resolved authentication method.
 #[expect(clippy::redundant_pub_crate, reason = "Preferred by reviewer")]
 pub(crate) async fn connect(config: &Config, quiet: bool) -> Result<Client> {
-	let auth_method = resolve_auth(config)?;
+	let mut auth_methods = resolve_auth(config)?.into_iter();
+	let mut auth_method = auth_methods
+		.next()
+		.expect("authentication resolution must return at least one method");
 	let ssh = &config.ssh;
 
 	let spinner = if quiet {
@@ -104,12 +107,17 @@ pub(crate) async fn connect(config: &Config, quiet: bool) -> Result<Client> {
 		.await
 		{
 			Ok(c) => break c,
-			Err(e) if retries > 0 => {
-				if report_is_authentication_failure(&e) {
-					return Err(e).wrap_err_with(|| {
-						format!("Failed to authenticate as {}@{}", ssh.user, ssh.host)
-					});
+			Err(e) if report_is_authentication_failure(&e) => {
+				if let Some(fallback) = auth_methods.next() {
+					info!("Authentication failed; trying SSH agent");
+					auth_method = fallback;
+					continue;
 				}
+				return Err(e).wrap_err_with(|| {
+					format!("Failed to authenticate as {}@{}", ssh.user, ssh.host)
+				});
+			}
+			Err(e) if retries > 0 => {
 				debug!(
 					error = %e,
 					retry_delay_ms = delay.as_millis(),


### PR DESCRIPTION
## Summary

- resolve automatic SSH authentication as an ordered set of methods
- fall back to the SSH agent when an auto-discovered default key is rejected
- keep explicitly configured keys and passwords strict, without fallback
- document the updated authentication order

## Root cause

Biwa selected an existing `~/.ssh/id_ed25519` before checking `SSH_AUTH_SOCK`. If that default key was valid but unauthorized for the target, authentication stopped immediately even when the agent contained an authorized key.

## Impact

Users with unrelated default key files can authenticate through an available SSH agent after the default key is rejected. Explicit authentication configuration retains its existing fail-fast behavior.

## Validation

- `mise run check --lint`
- `cargo test` (275 unit tests and all SSH end-to-end suites passed)
- `cargo test ssh::auth`
- live verification against `login.cse.unsw.edu.au`: default key rejected, Bitwarden-backed agent fallback connected successfully

## Summary by Sourcery

Adjust SSH authentication to treat resolution as an ordered set of methods and support fallback from a discovered default key to the SSH agent when authentication fails.

Bug Fixes:
- Allow SSH connections to fall back to the SSH agent when an auto-discovered default key is rejected instead of failing immediately.
- Ensure explicitly configured keys and passwords remain fail-fast without agent fallback.

Enhancements:
- Expose authentication resolution as a sequence of methods and update connection logic to iterate through fallbacks on authentication failure.
- Clarify the documented SSH authentication order, including agent behavior when default keys are missing or rejected.

Documentation:
- Update SSH key setup documentation to describe the new authentication order and agent fallback behavior.