### PR TITLE
feat(ssh)!: resolve OpenSSH target settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,7 @@ dependencies = [
  "pretty_assertions",
  "rstest",
  "russh",
+ "russh-config",
  "russh-sftp",
  "schemars",
  "scopeguard",
@@ -1451,7 +1452,10 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
+ "bitflags",
  "libc",
+ "plain",
+ "redox_syscall 0.9.2",
 ]
 
 [[package]]
@@ -1759,7 +1763,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -1890,6 +1894,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "poly1305"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2009,6 +2019,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1c93da5bb2c5d4e6c0ef7abeead62c89169a0a4882bfb83ac892f2423aea2fe"
 dependencies = [
  "bitflags",
 ]
@@ -2227,6 +2246,20 @@ dependencies = [
  "typenum",
  "universal-hash",
  "zeroize",
+]
+
+[[package]]
+name = "russh-config"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993346101d4741a59c82bafc6b645c52ce3e7b0820f13e4b5d48cdb591e3d955"
+dependencies = [
+ "futures",
+ "globset",
+ "log",
+ "thiserror",
+ "tokio",
+ "whoami",
 ]
 
 [[package]]
@@ -3175,6 +3208,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3230,6 +3269,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3237,6 +3286,17 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ indicatif = "=0.18.6"
 itertools = "=0.15.0"
 json5 = "=1.3.1"
 nix = { version = "=0.31.3", features = ["process", "signal", "user"] }
+russh-config = "=0.58.0"
 russh-sftp = "=2.4.0"
 schemars = "=1.2.2"
 scopeguard = "=1.2.0"

--- a/schema/config.json
+++ b/schema/config.json
@@ -44,9 +44,10 @@
         "host": "cse.unsw.edu.au",
         "key_path": null,
         "password": false,
-        "port": 22,
+        "port": null,
         "umask": "077",
-        "user": "z1234567"
+        "use_ssh_config": true,
+        "user": null
       }
     },
     "state_dir": {
@@ -305,9 +306,11 @@
           "default": false
         },
         "port": {
-          "description": "Port to connect to on the remote host.",
-          "type": "integer",
-          "default": 22,
+          "description": "Optional port override. If unset, uses OpenSSH config and then port 22.",
+          "type": [
+            "integer",
+            "null"
+          ],
           "maximum": 65535,
           "minimum": 0
         },
@@ -316,10 +319,17 @@
           "$ref": "#/$defs/Umask",
           "default": "077"
         },
+        "use_ssh_config": {
+          "description": "Whether to read `~/.ssh/config` when resolving the target.",
+          "type": "boolean",
+          "default": true
+        },
         "user": {
-          "description": "Username for the SSH connection.",
-          "type": "string",
-          "default": "z1234567"
+          "description": "Optional username. If unset, uses the matching OpenSSH `User` value.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },

--- a/src/cli/clean.rs
+++ b/src/cli/clean.rs
@@ -644,19 +644,34 @@ fn configure_daemon_env(cmd: &mut Command, config: &Config, state_dir: &Path) {
 #[cfg(test)]
 mod tests {
 	use super::{
-		CleanTarget, clean_target, configure_daemon_env, join_remote_child, purge_cleanup_paths,
-		remote_dir_is_older_than, resolve_current_project_root, state_dir_from_env_or_default,
+		CleanTarget, clean_target, collect_tracked_default_dirs, configure_daemon_env,
+		join_remote_child, purge_cleanup_paths, remote_dir_is_older_than,
+		resolve_current_project_root, state_dir_from_env_or_default,
 	};
 	use crate::config::types::{Config, PasswordConfig};
 	use crate::ssh::clean::RemoteDirEntry;
+	use crate::ssh::target::ResolvedSshTarget;
+	use crate::state::{Connection, State};
 	use crate::testing::EnvCleanup;
 	use alloc::collections::BTreeMap;
 	use chrono::Utc;
 	use core::time::Duration;
 	use pretty_assertions::assert_eq;
+	use std::collections::HashSet;
+	use std::ffi::OsStr;
 	use std::path::{Path, PathBuf};
 	use std::process::Command;
 	use std::{env, fs};
+
+	fn resolved_target() -> ResolvedSshTarget {
+		ResolvedSshTarget {
+			lookup_host: "alias".to_owned(),
+			hostname: "example.test".to_owned(),
+			port: 2222,
+			user: "alice".to_owned(),
+			identity_files: Vec::new(),
+		}
+	}
 
 	struct CurrentDirGuard(PathBuf);
 
@@ -847,6 +862,64 @@ mod tests {
 		assert_eq!(
 			envs.get("BIWA_STATE_DIR").map(String::as_str),
 			Some("/tmp/state")
+		);
+	}
+
+	#[test]
+	fn configure_daemon_env_omits_unconfigured_user_and_port() {
+		let config = Config::default();
+		let mut cmd = Command::new("biwa");
+		configure_daemon_env(&mut cmd, &config, Path::new("/tmp/state"));
+		let envs = cmd
+			.get_envs()
+			.map(|(key, value)| (key.to_string_lossy().into_owned(), value))
+			.collect::<BTreeMap<_, _>>();
+
+		assert!(!envs.contains_key("BIWA_SSH_PORT"));
+		assert!(!envs.contains_key("BIWA_SSH_USER"));
+		assert_eq!(
+			envs.get("BIWA_SSH_USE_CONFIG").and_then(|value| *value),
+			Some(OsStr::new("true"))
+		);
+	}
+
+	#[test]
+	fn tracked_default_dirs_require_the_resolved_target() {
+		let target = resolved_target();
+		let remote_root = Path::new("~/root");
+		let host_hash = "abcd1234";
+		let matching = Connection {
+			host: target.hostname.clone(),
+			user: target.user.clone(),
+			port: target.port,
+			remote_dir: "~/root/project-abcd1234-deadbeef".to_owned(),
+			last_used: Utc::now(),
+		};
+		let state = State {
+			connections: vec![
+				matching.clone(),
+				Connection {
+					host: target.lookup_host.clone(),
+					..matching.clone()
+				},
+				Connection {
+					user: "bob".to_owned(),
+					..matching.clone()
+				},
+				Connection {
+					port: 22,
+					..matching.clone()
+				},
+				Connection {
+					remote_dir: "~/root/not-biwa".to_owned(),
+					..matching
+				},
+			],
+		};
+
+		assert_eq!(
+			collect_tracked_default_dirs(&target, &state, remote_root, host_hash),
+			HashSet::from(["~/root/project-abcd1234-deadbeef".to_owned()])
 		);
 	}
 }

--- a/src/cli/clean.rs
+++ b/src/cli/clean.rs
@@ -13,6 +13,7 @@ use crate::ssh::sync::{
 	compute_client_host_hash, compute_project_remote_dir, is_biwa_remote_dir,
 	is_default_biwa_remote_dir,
 };
+use crate::ssh::target::ResolvedSshTarget;
 use crate::state::{
 	Connection, State, default_state_dir, is_daemon_running, kill_daemon, load_state,
 	remove_connections_for_target, remove_pid_file, stale_connections, write_pid_file,
@@ -213,6 +214,7 @@ async fn remove_remote_dirs_bounded(
 
 /// Clean current project's remote directory.
 async fn run_current_cleanup(config: &Config, dry_run: bool, quiet: bool) -> Result<()> {
+	let target = ResolvedSshTarget::resolve(&config.ssh)?;
 	let sync_root = resolve_current_project_root(config)?;
 	let remote_dir = compute_project_remote_dir(config, &sync_root)?;
 
@@ -226,9 +228,9 @@ async fn run_current_cleanup(config: &Config, dry_run: bool, quiet: bool) -> Res
 	let state_dir = config.resolved_state_dir();
 	remove_connections_for_target(
 		&state_dir,
-		&config.ssh.host,
-		&config.ssh.user,
-		config.ssh.port,
+		&target.hostname,
+		&target.user,
+		target.port,
 		&[remote_dir.as_str()],
 	)?;
 
@@ -248,6 +250,7 @@ fn resolve_current_project_root(config: &Config) -> Result<PathBuf> {
 
 /// Clean all this client's tracked remote directories.
 async fn run_all_cleanup(config: &Config, dry_run: bool, quiet: bool) -> Result<()> {
+	let target = ResolvedSshTarget::resolve(&config.ssh)?;
 	let state_dir = config.resolved_state_dir();
 	let state = load_state(&state_dir)?;
 	let host_hash = compute_client_host_hash();
@@ -257,8 +260,11 @@ async fn run_all_cleanup(config: &Config, dry_run: bool, quiet: bool) -> Result<
 	let matching: Vec<_> = state
 		.connections
 		.iter()
-		.filter(|c| {
-			c.host == config.ssh.host && c.user == config.ssh.user && c.port == config.ssh.port
+		.filter(|connection| {
+			let host_matches = connection.host == target.hostname;
+			let user_matches = connection.user == target.user;
+			let port_matches = connection.port == target.port;
+			host_matches && user_matches && port_matches
 		})
 		.filter(|c| is_default_biwa_remote_dir(&c.remote_dir, remote_root, &host_hash))
 		.collect();
@@ -291,9 +297,9 @@ async fn run_all_cleanup(config: &Config, dry_run: bool, quiet: bool) -> Result<
 	let dir_refs: Vec<&str> = succeeded.iter().map(String::as_str).collect();
 	remove_connections_for_target(
 		&state_dir,
-		&config.ssh.host,
-		&config.ssh.user,
-		config.ssh.port,
+		&target.hostname,
+		&target.user,
+		target.port,
 		&dir_refs,
 	)?;
 
@@ -315,6 +321,7 @@ async fn run_all_cleanup(config: &Config, dry_run: bool, quiet: bool) -> Result<
 
 /// Clean ALL biwa directories under `remote_root` (including other clients).
 async fn run_purge_cleanup(config: &Config, dry_run: bool, quiet: bool) -> Result<()> {
+	let target = ResolvedSshTarget::resolve(&config.ssh)?;
 	let client = connect(config, quiet).await?;
 	let remote_root = config.sync.remote_root.to_string_lossy().into_owned();
 	let dirs = list_remote_dirs(&client, &remote_root).await?;
@@ -343,9 +350,9 @@ async fn run_purge_cleanup(config: &Config, dry_run: bool, quiet: bool) -> Resul
 	let state_dir = config.resolved_state_dir();
 	remove_connections_for_target(
 		&state_dir,
-		&config.ssh.host,
-		&config.ssh.user,
-		config.ssh.port,
+		&target.hostname,
+		&target.user,
+		target.port,
 		&dir_refs,
 	)?;
 
@@ -377,6 +384,7 @@ fn purge_cleanup_paths(remote_root: &Path, dirs: &[String]) -> Vec<String> {
 
 /// Automatic background cleanup driven by quota thresholds.
 async fn run_auto_cleanup(config: &Config, state_dir: &Path) -> Result<()> {
+	let target = ResolvedSshTarget::resolve(&config.ssh)?;
 	// Ensure only one daemon runs at a time.
 	let already_running = write_pid_file(state_dir)?;
 	if already_running {
@@ -403,7 +411,7 @@ async fn run_auto_cleanup(config: &Config, state_dir: &Path) -> Result<()> {
 	};
 
 	let to_remove =
-		auto_cleanup_candidates(&client, config, &state, max_age, remote_root, &host_hash).await?;
+		auto_cleanup_candidates(&client, &target, &state, max_age, remote_root, &host_hash).await?;
 
 	if to_remove.is_empty() {
 		debug!("No stale directories to clean");
@@ -426,9 +434,9 @@ async fn run_auto_cleanup(config: &Config, state_dir: &Path) -> Result<()> {
 	let dir_refs: Vec<&str> = succeeded.iter().map(String::as_str).collect();
 	remove_connections_for_target(
 		state_dir,
-		&config.ssh.host,
-		&config.ssh.user,
-		config.ssh.port,
+		&target.hostname,
+		&target.user,
+		target.port,
 		&dir_refs,
 	)?;
 
@@ -468,16 +476,16 @@ fn applicable_cleanup_threshold(
 /// Collects tracked stale dirs and safe orphan dirs for automatic cleanup.
 async fn auto_cleanup_candidates(
 	client: &Client,
-	config: &Config,
+	target: &ResolvedSshTarget,
 	state: &State,
 	max_age: Duration,
 	remote_root: &Path,
 	host_hash: &str,
 ) -> Result<HashSet<String>> {
-	let tracked_default_dirs = collect_tracked_default_dirs(config, state, remote_root, host_hash);
+	let tracked_default_dirs = collect_tracked_default_dirs(target, state, remote_root, host_hash);
 	let mut to_remove: HashSet<String> = stale_connections(state, max_age)
 		.into_iter()
-		.filter(|connection| default_target_connection(config, connection, remote_root, host_hash))
+		.filter(|connection| default_target_connection(target, connection, remote_root, host_hash))
 		.map(|connection| connection.remote_dir.clone())
 		.collect();
 
@@ -517,7 +525,7 @@ fn remote_dir_is_older_than(
 
 /// Returns tracked default-layout dirs for the current SSH target.
 fn collect_tracked_default_dirs(
-	config: &Config,
+	target: &ResolvedSshTarget,
 	state: &State,
 	remote_root: &Path,
 	host_hash: &str,
@@ -525,22 +533,23 @@ fn collect_tracked_default_dirs(
 	state
 		.connections
 		.iter()
-		.filter(|connection| default_target_connection(config, connection, remote_root, host_hash))
+		.filter(|connection| default_target_connection(target, connection, remote_root, host_hash))
 		.map(|connection| connection.remote_dir.clone())
 		.collect()
 }
 
 /// Returns whether a state connection belongs to this target and default biwa layout.
 fn default_target_connection(
-	config: &Config,
+	target: &ResolvedSshTarget,
 	connection: &Connection,
 	remote_root: &Path,
 	host_hash: &str,
 ) -> bool {
-	connection.host == config.ssh.host
-		&& connection.user == config.ssh.user
-		&& connection.port == config.ssh.port
-		&& is_default_biwa_remote_dir(&connection.remote_dir, remote_root, host_hash)
+	let host_matches = connection.host == target.hostname;
+	let user_matches = connection.user == target.user;
+	let port_matches = connection.port == target.port;
+	let path_matches = is_default_biwa_remote_dir(&connection.remote_dir, remote_root, host_hash);
+	host_matches && user_matches && port_matches && path_matches
 }
 
 /// Joins a remote root and direct child name without introducing a duplicate slash.
@@ -606,8 +615,13 @@ pub fn spawn_background_cleanup(config: &Config) -> Result<()> {
 /// Applies resolved config values needed by the detached cleanup process.
 fn configure_daemon_env(cmd: &mut Command, config: &Config, state_dir: &Path) {
 	cmd.env("BIWA_SSH_HOST", &config.ssh.host);
-	cmd.env("BIWA_SSH_PORT", config.ssh.port.to_string());
-	cmd.env("BIWA_SSH_USER", &config.ssh.user);
+	if let Some(port) = config.ssh.port {
+		cmd.env("BIWA_SSH_PORT", port.to_string());
+	}
+	if let Some(user) = &config.ssh.user {
+		cmd.env("BIWA_SSH_USER", user);
+	}
+	cmd.env("BIWA_SSH_USE_CONFIG", config.ssh.use_ssh_config.to_string());
 	cmd.env("BIWA_SSH_UMASK", config.ssh.umask.to_string());
 	cmd.env("BIWA_SYNC_REMOTE_ROOT", &config.sync.remote_root);
 	cmd.env("BIWA_STATE_DIR", state_dir);
@@ -791,8 +805,8 @@ mod tests {
 	fn configure_daemon_env_uses_resolved_config_values() {
 		let mut config = Config::default();
 		config.ssh.host = "example.test".to_owned();
-		config.ssh.port = 2222;
-		config.ssh.user = "alice".to_owned();
+		config.ssh.port = Some(2222);
+		config.ssh.user = Some("alice".to_owned());
 		config.ssh.key_path = Some(PathBuf::from("/tmp/key"));
 		config.ssh.password = PasswordConfig::Value("secret".to_owned());
 		config.sync.remote_root = PathBuf::from("~/remote");

--- a/src/cli/snapshots/biwa__cli__init__tests__init_json.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_json.snap
@@ -25,9 +25,10 @@ expression: content
     "host": "cse.unsw.edu.au",
     "key_path": null,
     "password": false,
-    "port": 22,
+    "port": null,
     "umask": "077",
-    "user": "z1234567"
+    "use_ssh_config": true,
+    "user": null
   },
   "state_dir": null,
   "sync": {

--- a/src/cli/snapshots/biwa__cli__init__tests__init_json5.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_json5.snap
@@ -19,19 +19,22 @@ expression: content
     // Default value: "cse.unsw.edu.au"
     //host: "cse.unsw.edu.au",
 
-    // Port to connect to on the remote host.
+    // Optional port override. If unset, uses OpenSSH config and then port 22.
     //
     // Can also be specified via environment variable `BIWA_SSH_PORT`.
-    //
-    // Default value: 22
-    //port: 22,
+    //port: ,
 
-    // Username for the SSH connection.
+    // Optional username. If unset, uses the matching OpenSSH `User` value.
     //
     // Can also be specified via environment variable `BIWA_SSH_USER`.
+    //user: ,
+
+    // Whether to read `~/.ssh/config` when resolving the target.
     //
-    // Default value: "z1234567"
-    //user: "z1234567",
+    // Can also be specified via environment variable `BIWA_SSH_USE_CONFIG`.
+    //
+    // Default value: true
+    //use_ssh_config: true,
 
     // Optional path to the SSH private key.
     //

--- a/src/cli/snapshots/biwa__cli__init__tests__init_jsonc.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_jsonc.snap
@@ -19,19 +19,22 @@ expression: content
     // Default value: "cse.unsw.edu.au"
     //"host": "cse.unsw.edu.au",
 
-    // Port to connect to on the remote host.
+    // Optional port override. If unset, uses OpenSSH config and then port 22.
     //
     // Can also be specified via environment variable `BIWA_SSH_PORT`.
-    //
-    // Default value: 22
-    //"port": 22,
+    //"port": ,
 
-    // Username for the SSH connection.
+    // Optional username. If unset, uses the matching OpenSSH `User` value.
     //
     // Can also be specified via environment variable `BIWA_SSH_USER`.
+    //"user": ,
+
+    // Whether to read `~/.ssh/config` when resolving the target.
     //
-    // Default value: "z1234567"
-    //"user": "z1234567",
+    // Can also be specified via environment variable `BIWA_SSH_USE_CONFIG`.
+    //
+    // Default value: true
+    //"use_ssh_config": true,
 
     // Optional path to the SSH private key.
     //

--- a/src/cli/snapshots/biwa__cli__init__tests__init_toml.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_toml.snap
@@ -21,19 +21,22 @@ expression: content
 # Default value: "cse.unsw.edu.au"
 #host = "cse.unsw.edu.au"
 
-# Port to connect to on the remote host.
+# Optional port override. If unset, uses OpenSSH config and then port 22.
 #
 # Can also be specified via environment variable `BIWA_SSH_PORT`.
-#
-# Default value: 22
-#port = 22
+#port =
 
-# Username for the SSH connection.
+# Optional username. If unset, uses the matching OpenSSH `User` value.
 #
 # Can also be specified via environment variable `BIWA_SSH_USER`.
+#user =
+
+# Whether to read `~/.ssh/config` when resolving the target.
 #
-# Default value: "z1234567"
-#user = "z1234567"
+# Can also be specified via environment variable `BIWA_SSH_USE_CONFIG`.
+#
+# Default value: true
+#use_ssh_config = true
 
 # Optional path to the SSH private key.
 #

--- a/src/cli/snapshots/biwa__cli__init__tests__init_yaml.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_yaml.snap
@@ -20,19 +20,22 @@ ssh:
   # Default value: cse.unsw.edu.au
   #host: cse.unsw.edu.au
 
-  # Port to connect to on the remote host.
+  # Optional port override. If unset, uses OpenSSH config and then port 22.
   #
   # Can also be specified via environment variable `BIWA_SSH_PORT`.
-  #
-  # Default value: 22
-  #port: 22
+  #port:
 
-  # Username for the SSH connection.
+  # Optional username. If unset, uses the matching OpenSSH `User` value.
   #
   # Can also be specified via environment variable `BIWA_SSH_USER`.
+  #user:
+
+  # Whether to read `~/.ssh/config` when resolving the target.
   #
-  # Default value: z1234567
-  #user: z1234567
+  # Can also be specified via environment variable `BIWA_SSH_USE_CONFIG`.
+  #
+  # Default value: true
+  #use_ssh_config: true
 
   # Optional path to the SSH private key.
   #

--- a/src/cli/snapshots/biwa__cli__init__tests__init_yml.snap
+++ b/src/cli/snapshots/biwa__cli__init__tests__init_yml.snap
@@ -20,19 +20,22 @@ ssh:
   # Default value: cse.unsw.edu.au
   #host: cse.unsw.edu.au
 
-  # Port to connect to on the remote host.
+  # Optional port override. If unset, uses OpenSSH config and then port 22.
   #
   # Can also be specified via environment variable `BIWA_SSH_PORT`.
-  #
-  # Default value: 22
-  #port: 22
+  #port:
 
-  # Username for the SSH connection.
+  # Optional username. If unset, uses the matching OpenSSH `User` value.
   #
   # Can also be specified via environment variable `BIWA_SSH_USER`.
+  #user:
+
+  # Whether to read `~/.ssh/config` when resolving the target.
   #
-  # Default value: z1234567
-  #user: z1234567
+  # Can also be specified via environment variable `BIWA_SSH_USE_CONFIG`.
+  #
+  # Default value: true
+  #use_ssh_config: true
 
   # Optional path to the SSH private key.
   #

--- a/src/cli/transfer.rs
+++ b/src/cli/transfer.rs
@@ -413,4 +413,50 @@ mod tests {
 		assert!(error.to_string().contains("must not be empty"));
 		Ok(())
 	}
+
+	#[test]
+	fn record_connection_use_persists_resolved_target() -> Result<()> {
+		let dir = tempdir()?;
+		let mut ssh = Config::default().ssh;
+		ssh.host = "example.test".to_owned();
+		ssh.user = Some("alice".to_owned());
+		ssh.port = Some(2222);
+		ssh.use_ssh_config = false;
+		let config = Config {
+			state_dir: Some(dir.path().to_path_buf()),
+			ssh,
+			..Config::default()
+		};
+
+		record_connection_use(&config, "~/remote/project-deadbeef");
+
+		let state = state::load_state(dir.path())?;
+		assert_eq!(state.connections.len(), 1);
+		let connection = state
+			.connections
+			.first()
+			.expect("one connection was recorded");
+		assert_eq!(connection.host, "example.test");
+		assert_eq!(connection.user, "alice");
+		assert_eq!(connection.port, 2222);
+		Ok(())
+	}
+
+	#[test]
+	fn record_connection_use_skips_unresolved_target() -> Result<()> {
+		let dir = tempdir()?;
+		let mut ssh = Config::default().ssh;
+		ssh.host = "example.test".to_owned();
+		ssh.use_ssh_config = false;
+		let config = Config {
+			state_dir: Some(dir.path().to_path_buf()),
+			ssh,
+			..Config::default()
+		};
+
+		record_connection_use(&config, "~/remote/project-deadbeef");
+
+		assert!(state::load_state(dir.path())?.connections.is_empty());
+		Ok(())
+	}
 }

--- a/src/cli/transfer.rs
+++ b/src/cli/transfer.rs
@@ -1,6 +1,7 @@
 use crate::Result;
 use crate::config::types::Config;
 use crate::ssh::sync::{Options, compute_project_remote_dir, normalize_remote_dir};
+use crate::ssh::target::ResolvedSshTarget;
 use crate::state;
 use clap::Args;
 use std::env;
@@ -130,11 +131,18 @@ impl TransferArgs {
 /// Records a remote directory use in local persisted state.
 pub(super) fn record_connection_use(config: &Config, remote_dir: &str) {
 	let state_dir = config.resolved_state_dir();
+	let target = match ResolvedSshTarget::resolve(&config.ssh) {
+		Ok(target) => target,
+		Err(error) => {
+			warn!(%error, "Failed to resolve SSH target for connection state");
+			return;
+		}
+	};
 	if let Err(error) = state::record_connection(
 		&state_dir,
-		&config.ssh.host,
-		&config.ssh.user,
-		config.ssh.port,
+		&target.hostname,
+		&target.user,
+		target.port,
 		remote_dir,
 	) {
 		warn!(%error, "Failed to record connection in local state");

--- a/src/cli/transfer.rs
+++ b/src/cli/transfer.rs
@@ -138,15 +138,24 @@ pub(super) fn record_connection_use(config: &Config, remote_dir: &str) {
 			return;
 		}
 	};
-	if let Err(error) = state::record_connection(
-		&state_dir,
+	if let Err(error) = record_resolved_connection_use(&state_dir, &target, remote_dir) {
+		warn!(%error, "Failed to record connection in local state");
+	}
+}
+
+/// Records an already-resolved SSH target in local persisted state.
+fn record_resolved_connection_use(
+	state_dir: &Path,
+	target: &ResolvedSshTarget,
+	remote_dir: &str,
+) -> Result<()> {
+	state::record_connection(
+		state_dir,
 		&target.hostname,
 		&target.user,
 		target.port,
 		remote_dir,
-	) {
-		warn!(%error, "Failed to record connection in local state");
-	}
+	)
 }
 
 /// Returns the default sync root for the current directory.
@@ -417,18 +426,15 @@ mod tests {
 	#[test]
 	fn record_connection_use_persists_resolved_target() -> Result<()> {
 		let dir = tempdir()?;
-		let mut ssh = Config::default().ssh;
-		ssh.host = "example.test".to_owned();
-		ssh.user = Some("alice".to_owned());
-		ssh.port = Some(2222);
-		ssh.use_ssh_config = false;
-		let config = Config {
-			state_dir: Some(dir.path().to_path_buf()),
-			ssh,
-			..Config::default()
+		let target = ResolvedSshTarget {
+			lookup_host: "cse".to_owned(),
+			hostname: "login.cse.unsw.edu.au".to_owned(),
+			port: 2222,
+			user: "alice".to_owned(),
+			identity_files: Vec::new(),
 		};
 
-		record_connection_use(&config, "~/remote/project-deadbeef");
+		record_resolved_connection_use(dir.path(), &target, "~/remote/project-deadbeef")?;
 
 		let state = state::load_state(dir.path())?;
 		assert_eq!(state.connections.len(), 1);
@@ -436,9 +442,10 @@ mod tests {
 			.connections
 			.first()
 			.expect("one connection was recorded");
-		assert_eq!(connection.host, "example.test");
+		assert_eq!(connection.host, "login.cse.unsw.edu.au");
 		assert_eq!(connection.user, "alice");
 		assert_eq!(connection.port, 2222);
+		assert_eq!(connection.remote_dir, "~/remote/project-deadbeef");
 		Ok(())
 	}
 

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -15,8 +15,6 @@ use tracing::{debug, info, warn};
 struct RequiredConfigPresence {
 	/// Whether `ssh.host` was provided by any config layer or environment variable.
 	ssh_host: bool,
-	/// Whether `ssh.user` was provided by any config layer or environment variable.
-	ssh_user: bool,
 }
 
 impl Config {
@@ -284,14 +282,12 @@ impl RequiredConfigPresence {
 	fn from_env() -> Self {
 		Self {
 			ssh_host: env::var_os("BIWA_SSH_HOST").is_some(),
-			ssh_user: env::var_os("BIWA_SSH_USER").is_some(),
 		}
 	}
 
 	/// Marks required SSH fields that were present in a preloaded config layer.
 	const fn observe_layer(&mut self, partial: &<Config as confique::Config>::Layer) {
 		self.ssh_host |= partial.ssh.host.is_some();
-		self.ssh_user |= partial.ssh.user.is_some();
 	}
 
 	/// Fails when any required SSH setting was not supplied by configuration input.
@@ -300,10 +296,6 @@ impl RequiredConfigPresence {
 
 		if !self.ssh_host {
 			missing.push("ssh.host (or BIWA_SSH_HOST)");
-		}
-
-		if !self.ssh_user {
-			missing.push("ssh.user (or BIWA_SSH_USER)");
 		}
 
 		if !missing.is_empty() {
@@ -412,8 +404,9 @@ mod tests {
 	fn default() {
 		let config = Config::default();
 		assert_eq!(config.ssh.host, "cse.unsw.edu.au");
-		assert_eq!(config.ssh.port, 22);
-		assert_eq!(config.ssh.user, "z1234567");
+		assert_eq!(config.ssh.port, None);
+		assert_eq!(config.ssh.user, None);
+		assert!(config.ssh.use_ssh_config);
 		assert_eq!(
 			config.sync.remote_root,
 			PathBuf::from("~/.cache/biwa/projects")
@@ -434,7 +427,7 @@ mod tests {
 		let config = load_internal(None, None, Some(dir.path().to_path_buf()).as_ref())?;
 
 		assert_eq!(config.ssh.host, "env");
-		assert_eq!(config.ssh.port, 8080);
+		assert_eq!(config.ssh.port, Some(8080));
 		Ok(())
 	}
 
@@ -446,8 +439,9 @@ mod tests {
 		{
 		  "ssh": {
 		    "host": "cse.unsw.edu.au",
-		    "port": 22,
-		    "user": "z1234567",
+		    "port": null,
+		    "user": null,
+		    "use_ssh_config": true,
 		    "key_path": null,
 		    "password": false,
 		    "umask": "077"
@@ -947,25 +941,20 @@ child = ["--skip-sync"]
 		};
 
 		assert!(err.contains("ssh.host (or BIWA_SSH_HOST)"));
-		assert!(err.contains("ssh.user (or BIWA_SSH_USER)"));
+		assert!(!err.contains("ssh.user (or BIWA_SSH_USER)"));
 		Ok(())
 	}
 
 	#[serial]
 	#[test]
-	fn missing_required_config_values_error_when_partial_file_exists() -> Result<()> {
+	fn user_may_be_supplied_by_openssh_config() -> Result<()> {
 		let dir = tempdir()?;
 		let (_cleanup_host, _cleanup_user) = clear_required_ssh_env();
 		fs::write(dir.path().join("biwa.toml"), r#"ssh.host = "configured""#)?;
 
-		let result = load_internal(None, None, Some(dir.path().to_path_buf()).as_ref());
-		let err = match result {
-			Err(err) => err.to_string(),
-			Ok(_) => bail!("Expected missing required config values to fail"),
-		};
-
-		assert!(!err.contains("ssh.host (or BIWA_SSH_HOST)"));
-		assert!(err.contains("ssh.user (or BIWA_SSH_USER)"));
+		let config = load_internal(None, None, Some(dir.path().to_path_buf()).as_ref())?;
+		assert_eq!(config.ssh.host, "configured");
+		assert_eq!(config.ssh.user, None);
 		Ok(())
 	}
 
@@ -981,7 +970,7 @@ child = ["--skip-sync"]
 		let config = load_internal(None, None, Some(dir.path().to_path_buf()).as_ref())?;
 
 		assert_eq!(config.ssh.host, "env-host");
-		assert_eq!(config.ssh.user, "env-user");
+		assert_eq!(config.ssh.user.as_deref(), Some("env-user"));
 		Ok(())
 	}
 

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -82,16 +82,10 @@ mod schema_defaults {
 		"cse.unsw.edu.au".to_owned()
 	}
 
-	/// Default for `SshConfig::port` in schema.
+	/// Default `true` value used by boolean configuration fields.
 	#[must_use]
-	pub const fn ssh_port() -> u16 {
-		22
-	}
-
-	/// Default for `SshConfig::user` in schema.
-	#[must_use]
-	pub fn ssh_user() -> String {
-		"z1234567".to_owned()
+	pub const fn bool_true() -> bool {
+		true
 	}
 
 	/// Default for `SyncConfig::remote_root` in schema.
@@ -254,14 +248,20 @@ pub struct SshConfig {
 	#[config(default = "cse.unsw.edu.au", env = "BIWA_SSH_HOST")]
 	#[schemars(default = "crate::config::types::schema_defaults::ssh_host")]
 	pub host: String,
-	/// Port to connect to on the remote host.
-	#[config(default = 22, env = "BIWA_SSH_PORT")]
-	#[schemars(default = "crate::config::types::schema_defaults::ssh_port")]
-	pub port: u16,
-	/// Username for the SSH connection.
-	#[config(default = "z1234567", env = "BIWA_SSH_USER")]
-	#[schemars(default = "crate::config::types::schema_defaults::ssh_user")]
-	pub user: String,
+	/// Optional port override. If unset, uses OpenSSH config and then port 22.
+	#[config(env = "BIWA_SSH_PORT")]
+	pub port: Option<u16>,
+	/// Optional username. If unset, uses the matching OpenSSH `User` value.
+	#[config(env = "BIWA_SSH_USER")]
+	pub user: Option<String>,
+	/// Whether to read `~/.ssh/config` when resolving the target.
+	#[config(default = true, env = "BIWA_SSH_USE_CONFIG")]
+	#[schemars(default = "crate::config::types::schema_defaults::bool_true")]
+	#[expect(
+		clippy::struct_field_names,
+		reason = "the public ssh.use_ssh_config key is intentionally explicit"
+	)]
+	pub use_ssh_config: bool,
 	/// Optional path to the SSH private key.
 	#[config(env = "BIWA_SSH_KEY_PATH")]
 	pub key_path: Option<PathBuf>,

--- a/src/ssh/auth.rs
+++ b/src/ssh/auth.rs
@@ -2,6 +2,7 @@ use crate::Result;
 use crate::config::types::Config;
 use crate::config::types::PasswordConfig;
 use crate::ssh::client::auth::Method;
+use crate::ssh::target::ResolvedSshTarget;
 use color_eyre::eyre::bail;
 use dialoguer::Password;
 use russh::keys::{Error as RusshKeysError, load_secret_key};
@@ -19,9 +20,10 @@ const DEFAULT_KEY_PATHS: &[&str] = &["~/.ssh/id_ed25519", "~/.ssh/id_rsa"];
 /// 2. Explicit password (`ssh.password = "..."` or `ssh.password = true` for prompt)
 /// 3. Default key file discovery (`~/.ssh/id_ed25519`, `~/.ssh/id_rsa`)
 /// 4. SSH agent (fallback if the discovered default key is rejected)
-pub(super) fn resolve_auth(config: &Config) -> Result<Vec<Method>> {
+pub(super) fn resolve_auth(config: &Config, target: &ResolvedSshTarget) -> Result<Vec<Method>> {
 	resolve_auth_with(
 		config,
+		target,
 		resolve_default_key_path(),
 		env::var("SSH_AUTH_SOCK").ok().as_deref(),
 	)
@@ -30,6 +32,7 @@ pub(super) fn resolve_auth(config: &Config) -> Result<Vec<Method>> {
 /// Resolve authentication methods with explicit local authentication state.
 fn resolve_auth_with(
 	config: &Config,
+	target: &ResolvedSshTarget,
 	default_key_path: Option<PathBuf>,
 	auth_sock: Option<&str>,
 ) -> Result<Vec<Method>> {
@@ -53,7 +56,7 @@ fn resolve_auth_with(
 		PasswordConfig::Interactive(true) => {
 			info!("Prompting for password (ssh.password = true)");
 			let password = Password::new()
-				.with_prompt(format!("Password for {}@{}", ssh.user, ssh.host))
+				.with_prompt(format!("Password for {}@{}", target.user, target.hostname))
 				.interact()?;
 			return Ok(vec![Method::with_password(&password)]);
 		}
@@ -149,6 +152,16 @@ mod tests {
 	use serial_test::serial;
 	use std::fs;
 
+	fn target() -> ResolvedSshTarget {
+		ResolvedSshTarget {
+			lookup_host: "example.test".to_owned(),
+			hostname: "example.test".to_owned(),
+			port: 22,
+			user: "alice".to_owned(),
+			identity_files: Vec::new(),
+		}
+	}
+
 	#[test]
 	fn explicit_key_has_no_fallback() -> Result<()> {
 		let dir = tempfile::tempdir()?;
@@ -160,6 +173,7 @@ mod tests {
 
 		let methods = resolve_auth_with(
 			&config,
+			&target(),
 			Some(PathBuf::from("/unused/default/key")),
 			Some("/tmp/fake-agent.sock"),
 		)?;
@@ -173,7 +187,7 @@ mod tests {
 		let mut config = Config::default();
 		config.ssh.key_path = Some(PathBuf::from("/nonexistent/path/key"));
 
-		let result = resolve_auth(&config);
+		let result = resolve_auth(&config, &target());
 		assert!(result.is_err());
 		let err_msg = result.unwrap_err().to_string();
 		assert!(err_msg.contains("not found"), "Error: {err_msg}");
@@ -208,6 +222,7 @@ mod tests {
 
 		let methods = resolve_auth_with(
 			&Config::default(),
+			&target(),
 			Some(key_file),
 			Some("/tmp/fake-agent.sock"),
 		)?;
@@ -225,7 +240,7 @@ mod tests {
 		let key_file = dir.path().join("id_ed25519");
 		fs::write(&key_file, "fake key")?;
 
-		let methods = resolve_auth_with(&Config::default(), Some(key_file), None)?;
+		let methods = resolve_auth_with(&Config::default(), &target(), Some(key_file), None)?;
 
 		assert_matches!(methods.as_slice(), [Method::PrivateKeyFile { .. }]);
 		Ok(())
@@ -236,7 +251,7 @@ mod tests {
 	fn password_config_string() -> Result<()> {
 		let mut config = Config::default();
 		config.ssh.password = PasswordConfig::Value("secret".to_owned());
-		let methods = resolve_auth(&config)?;
+		let methods = resolve_auth(&config, &target())?;
 		assert_matches!(methods.as_slice(), [Method::Password(_)]);
 		Ok(())
 	}
@@ -246,7 +261,7 @@ mod tests {
 	fn password_config_false() {
 		let mut config = Config::default();
 		config.ssh.password = PasswordConfig::Interactive(false);
-		let result = resolve_auth(&config);
+		let result = resolve_auth(&config, &target());
 		// Without explicit password, it may fall back to agent or key, or fail
 		// — but it must not use Password auth (password = false means skip password)
 		if let Ok(methods) = result {

--- a/src/ssh/exec.rs
+++ b/src/ssh/exec.rs
@@ -9,6 +9,7 @@ use crate::env_vars::{
 use crate::ssh::client::Client;
 use crate::ssh::client::auth::AuthenticationFailed;
 use crate::ssh::client::execute::{await_channel_confirmation, exit_status_from_signal};
+use crate::ssh::target::ResolvedSshTarget;
 use crate::ui::create_spinner;
 use bytes::Bytes;
 use color_eyre::eyre::{Context as _, Report, bail};
@@ -78,18 +79,17 @@ struct RunCommandOptions<'a> {
 /// Connect to the SSH server using the resolved authentication method.
 #[expect(clippy::redundant_pub_crate, reason = "Preferred by reviewer")]
 pub(crate) async fn connect(config: &Config, quiet: bool) -> Result<Client> {
-	let mut auth_methods = resolve_auth(config)?.into_iter();
+	let target = ResolvedSshTarget::resolve(&config.ssh)?;
+	let mut auth_methods = resolve_auth(config, &target)?.into_iter();
 	let mut auth_method = auth_methods
 		.next()
 		.expect("authentication resolution must return at least one method");
-	let ssh = &config.ssh;
-
 	let spinner = if quiet {
 		None
 	} else {
 		Some(create_spinner(format!(
 			"Connecting to {}@{}:{}...",
-			ssh.user, ssh.host, ssh.port
+			target.user, target.hostname, target.port
 		)))
 	};
 
@@ -100,8 +100,8 @@ pub(crate) async fn connect(config: &Config, quiet: bool) -> Result<Client> {
 
 	let client = loop {
 		match Client::connect(
-			(ssh.host.as_str(), ssh.port),
-			ssh.user.as_str(),
+			(target.hostname.as_str(), target.port),
+			target.user.as_str(),
 			auth_method.clone(),
 		)
 		.await
@@ -114,7 +114,10 @@ pub(crate) async fn connect(config: &Config, quiet: bool) -> Result<Client> {
 					continue;
 				}
 				return Err(e).wrap_err_with(|| {
-					format!("Failed to authenticate as {}@{}", ssh.user, ssh.host)
+					format!(
+						"Failed to authenticate as {}@{}",
+						target.user, target.hostname
+					)
 				});
 			}
 			Err(e) if retries > 0 => {
@@ -132,7 +135,7 @@ pub(crate) async fn connect(config: &Config, quiet: bool) -> Result<Client> {
 				return Err(e).wrap_err_with(|| {
 					format!(
 						"Failed to connect to {}@{}:{}",
-						ssh.user, ssh.host, ssh.port
+						target.user, target.hostname, target.port
 					)
 				});
 			}
@@ -140,9 +143,9 @@ pub(crate) async fn connect(config: &Config, quiet: bool) -> Result<Client> {
 	};
 
 	info!(
-		host = %ssh.host,
-		port = ssh.port,
-		user = %ssh.user,
+		host = %target.hostname,
+		port = target.port,
+		user = %target.user,
 		"Connected to SSH server"
 	);
 

--- a/src/ssh/mod.rs
+++ b/src/ssh/mod.rs
@@ -11,3 +11,5 @@ pub mod exec;
 pub mod sync;
 /// Helpers shared by SSH synchronization modules.
 mod sync_paths;
+/// Effective SSH target resolution from Biwa and OpenSSH configuration.
+pub mod target;

--- a/src/ssh/target.rs
+++ b/src/ssh/target.rs
@@ -182,6 +182,10 @@ mod tests {
 	use std::fs;
 	use tempfile::tempdir;
 
+	const PUBLIC_KEY_A: &str =
+		"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGqfEeyNrOxuH87ZVirsvRm72W3vrW3qJKbBqjsoKn3Z biwa-e2e";
+	const PUBLIC_KEY_B: &str = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIWBVymg7tyFs+jzE07UpfXkQEibpPg23d2KCVnIvxLN biwa-other";
+
 	fn config(host: &str) -> SshConfig {
 		let mut ssh = Config::default().ssh;
 		ssh.host = host.to_owned();
@@ -245,6 +249,211 @@ mod tests {
 		let target = ResolvedSshTarget::resolve_with_path(&ssh, Some(Path::new("missing")))?;
 		assert_eq!(target.hostname, "example.test");
 		assert_eq!(target.port, 22);
+		Ok(())
+	}
+
+	#[test]
+	fn resolve_uses_direct_values_when_openssh_is_disabled() -> Result<()> {
+		let mut ssh = config("example.test");
+		ssh.user = Some("alice".to_owned());
+		ssh.key_path = Some(PathBuf::from("unused-key"));
+		ssh.use_ssh_config = false;
+
+		let target = ResolvedSshTarget::resolve(&ssh)?;
+		assert_eq!(target.hostname, "example.test");
+		assert_eq!(target.user, "alice");
+		assert_eq!(target.port, 22);
+		Ok(())
+	}
+
+	#[test]
+	fn missing_openssh_config_uses_biwa_values() -> Result<()> {
+		let dir = tempdir()?;
+		let mut ssh = config("example.test");
+		ssh.user = Some("alice".to_owned());
+		let target =
+			ResolvedSshTarget::resolve_with_path(&ssh, Some(&dir.path().join("missing-config")))?;
+
+		assert_eq!(target.hostname, "example.test");
+		assert_eq!(target.user, "alice");
+		assert_eq!(target.port, 22);
+		assert!(target.identity_files.is_empty());
+		Ok(())
+	}
+
+	#[test]
+	fn missing_user_reports_how_to_configure_it() {
+		let error = ResolvedSshTarget::resolve_with_path(&config("example.test"), None)
+			.expect_err("a user is required");
+
+		assert!(error.to_string().contains("Missing SSH user"));
+	}
+
+	#[test]
+	fn rejects_conflicting_port() -> Result<()> {
+		let dir = tempdir()?;
+		let path = dir.path().join("config");
+		fs::write(&path, "Host cse\n  User alice\n  Port 2222\n")?;
+		let mut ssh = config("cse");
+		ssh.user = Some("alice".to_owned());
+		ssh.port = Some(22);
+
+		let error = ResolvedSshTarget::resolve_with_path(&ssh, Some(&path))
+			.expect_err("different ports conflict");
+		assert!(error.to_string().contains("Conflicting SSH port"));
+		Ok(())
+	}
+
+	#[test]
+	fn invalid_openssh_config_has_actionable_context() -> Result<()> {
+		let dir = tempdir()?;
+		let path = dir.path().join("config");
+		fs::write(&path, "User alice\nHost cse\n")?;
+
+		let error = ResolvedSshTarget::resolve_with_path(&config("cse"), Some(&path))
+			.expect_err("settings before the first Host block must not be ignored");
+		let message = error.to_string();
+		assert!(message.contains("Failed to parse OpenSSH configuration"));
+		assert!(message.contains("ssh.use_ssh_config = false"));
+		Ok(())
+	}
+
+	#[test]
+	fn rejects_multiple_openssh_identities_with_biwa_key() -> Result<()> {
+		let dir = tempdir()?;
+		let path = dir.path().join("config");
+		fs::write(
+			&path,
+			"Host cse\n  User alice\n  IdentityFile first\n  IdentityFile second\n",
+		)?;
+		let mut ssh = config("cse");
+		ssh.key_path = Some(dir.path().join("biwa-key"));
+
+		let error = ResolvedSshTarget::resolve_with_path(&ssh, Some(&path))
+			.expect_err("one Biwa key cannot match multiple OpenSSH identities");
+		assert!(
+			error
+				.to_string()
+				.contains("supplies 2 IdentityFile entries")
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn accepts_matching_public_identity_files() -> Result<()> {
+		let dir = tempdir()?;
+		let biwa_key = dir.path().join("biwa.pub");
+		let openssh_key = dir.path().join("openssh.pub");
+		fs::write(&biwa_key, PUBLIC_KEY_A)?;
+		fs::write(&openssh_key, PUBLIC_KEY_A)?;
+		let config_path = dir.path().join("config");
+		fs::write(
+			&config_path,
+			format!(
+				"Host cse\n  User alice\n  IdentityFile {}\n",
+				openssh_key.display()
+			),
+		)?;
+		let mut ssh = config("cse");
+		ssh.key_path = Some(biwa_key);
+
+		let target = ResolvedSshTarget::resolve_with_path(&ssh, Some(&config_path))?;
+		assert_eq!(target.identity_files, vec![openssh_key]);
+		Ok(())
+	}
+
+	#[test]
+	fn accepts_companion_public_key() -> Result<()> {
+		let dir = tempdir()?;
+		let biwa_key = dir.path().join("biwa");
+		fs::write(biwa_key.with_extension("pub"), PUBLIC_KEY_A)?;
+		let openssh_key = dir.path().join("openssh.pub");
+		fs::write(&openssh_key, PUBLIC_KEY_A)?;
+		let config_path = dir.path().join("config");
+		fs::write(
+			&config_path,
+			format!(
+				"Host cse\n  User alice\n  IdentityFile {}\n",
+				openssh_key.display()
+			),
+		)?;
+		let mut ssh = config("cse");
+		ssh.key_path = Some(biwa_key);
+
+		ResolvedSshTarget::resolve_with_path(&ssh, Some(&config_path))?;
+		Ok(())
+	}
+
+	#[test]
+	fn rejects_different_identity_keys() -> Result<()> {
+		let dir = tempdir()?;
+		let biwa_key = dir.path().join("biwa.pub");
+		let openssh_key = dir.path().join("openssh.pub");
+		fs::write(&biwa_key, PUBLIC_KEY_A)?;
+		fs::write(&openssh_key, PUBLIC_KEY_B)?;
+		let config_path = dir.path().join("config");
+		fs::write(
+			&config_path,
+			format!(
+				"Host cse\n  User alice\n  IdentityFile {}\n",
+				openssh_key.display()
+			),
+		)?;
+		let mut ssh = config("cse");
+		ssh.key_path = Some(biwa_key);
+
+		let error = ResolvedSshTarget::resolve_with_path(&ssh, Some(&config_path))
+			.expect_err("different public keys conflict");
+		assert!(error.to_string().contains("contain different public keys"));
+		Ok(())
+	}
+
+	#[test]
+	fn unreadable_biwa_identity_has_comparison_context() -> Result<()> {
+		let dir = tempdir()?;
+		let openssh_key = dir.path().join("openssh.pub");
+		fs::write(&openssh_key, PUBLIC_KEY_A)?;
+		let config_path = dir.path().join("config");
+		fs::write(
+			&config_path,
+			format!(
+				"Host cse\n  User alice\n  IdentityFile {}\n",
+				openssh_key.display()
+			),
+		)?;
+		let mut ssh = config("cse");
+		ssh.key_path = Some(dir.path().join("missing"));
+
+		let error = ResolvedSshTarget::resolve_with_path(&ssh, Some(&config_path))
+			.expect_err("missing key material cannot be compared");
+		assert!(error.to_string().contains("Cannot compare ssh.key_path"));
+		Ok(())
+	}
+
+	#[test]
+	fn unreadable_openssh_identity_has_comparison_context() -> Result<()> {
+		let dir = tempdir()?;
+		let biwa_key = dir.path().join("biwa.pub");
+		fs::write(&biwa_key, PUBLIC_KEY_A)?;
+		let missing_openssh_key = dir.path().join("missing.pub");
+		let config_path = dir.path().join("config");
+		fs::write(
+			&config_path,
+			format!(
+				"Host cse\n  User alice\n  IdentityFile {}\n",
+				missing_openssh_key.display()
+			),
+		)?;
+		let mut ssh = config("cse");
+		ssh.key_path = Some(biwa_key);
+
+		let error = ResolvedSshTarget::resolve_with_path(&ssh, Some(&config_path))
+			.expect_err("missing OpenSSH key material cannot be compared");
+		assert!(
+			error
+				.to_string()
+				.contains("Cannot compare OpenSSH IdentityFile")
+		);
 		Ok(())
 	}
 }

--- a/src/ssh/target.rs
+++ b/src/ssh/target.rs
@@ -1,0 +1,250 @@
+//! Resolution of effective SSH connection settings.
+
+use crate::Result;
+use crate::config::types::SshConfig;
+use color_eyre::eyre::{WrapErr as _, bail};
+use russh::keys::{PublicKey, load_public_key, load_secret_key};
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+/// A fully resolved SSH connection target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[expect(
+	clippy::module_name_repetitions,
+	reason = "the explicit name distinguishes the resolved target from config input"
+)]
+pub struct ResolvedSshTarget {
+	/// Host or alias originally supplied to Biwa.
+	pub lookup_host: String,
+	/// Network hostname after applying OpenSSH `HostName`.
+	pub hostname: String,
+	/// Effective remote port.
+	pub port: u16,
+	/// Effective remote username.
+	pub user: String,
+	/// Ordered OpenSSH `IdentityFile` entries.
+	pub identity_files: Vec<PathBuf>,
+}
+
+impl ResolvedSshTarget {
+	/// Resolves a target using the current user's OpenSSH configuration path.
+	pub fn resolve(config: &SshConfig) -> Result<Self> {
+		let ssh_config_path = homedir::my_home()
+			.ok()
+			.flatten()
+			.map(|home| home.join(".ssh/config"));
+		Self::resolve_with_path(config, ssh_config_path.as_deref())
+	}
+
+	/// Resolves a target with an explicit OpenSSH configuration path.
+	pub(crate) fn resolve_with_path(
+		config: &SshConfig,
+		ssh_config_path: Option<&Path>,
+	) -> Result<Self> {
+		let openssh = if config.use_ssh_config {
+			ssh_config_path
+				.map(|path| parse_openssh(path, &config.host))
+				.transpose()?
+				.flatten()
+		} else {
+			None
+		};
+
+		let openssh_host = openssh.as_ref().map(|parsed| &parsed.host_config);
+		let openssh_user = openssh_host.and_then(|host| host.user.as_deref());
+		let user = reconcile_user(config.user.as_deref(), openssh_user, &config.host)?;
+		let port = reconcile_port(
+			config.port,
+			openssh_host.and_then(|host| host.port),
+			&config.host,
+		)?;
+		let identity_files = openssh_host
+			.and_then(|host| host.identity_file.clone())
+			.unwrap_or_default();
+
+		if let Some(key_path) = config.key_path.as_deref() {
+			reconcile_identity(key_path, &identity_files, &config.host)?;
+		}
+
+		Ok(Self {
+			lookup_host: config.host.clone(),
+			hostname: openssh
+				.as_ref()
+				.and_then(|parsed| parsed.host_config.hostname.clone())
+				.unwrap_or_else(|| config.host.clone()),
+			port,
+			user,
+			identity_files,
+		})
+	}
+}
+
+/// Parses the matching OpenSSH host block, treating a missing config as empty.
+fn parse_openssh(path: &Path, host: &str) -> Result<Option<russh_config::Config>> {
+	match russh_config::parse_path(path, host) {
+		Ok(config) => Ok(Some(config)),
+		Err(russh_config::Error::Io(error)) if error.kind() == ErrorKind::NotFound => Ok(None),
+		Err(error) => Err(error).wrap_err_with(|| {
+			format!(
+				"Failed to parse OpenSSH configuration at {}. Fix the file or set ssh.use_ssh_config = false",
+				path.display()
+			)
+		}),
+	}
+}
+
+/// Reconciles the Biwa and OpenSSH username values.
+fn reconcile_user(biwa: Option<&str>, openssh: Option<&str>, host: &str) -> Result<String> {
+	match (biwa, openssh) {
+		(Some(biwa), Some(openssh)) if biwa != openssh => bail!(
+			"Conflicting SSH user configuration for `{host}`: Biwa specifies `{biwa}`, but ~/.ssh/config specifies `{openssh}`. Remove one setting or make them match"
+		),
+		(Some(user), _) | (None, Some(user)) => Ok(user.to_owned()),
+		(None, None) => bail!(
+			"Missing SSH user for `{host}`. Set ssh.user (or BIWA_SSH_USER), or add User to the matching ~/.ssh/config entry"
+		),
+	}
+}
+
+/// Reconciles the Biwa and OpenSSH port values.
+fn reconcile_port(biwa: Option<u16>, openssh: Option<u16>, host: &str) -> Result<u16> {
+	match (biwa, openssh) {
+		(Some(biwa), Some(openssh)) if biwa != openssh => bail!(
+			"Conflicting SSH port configuration for `{host}`: Biwa specifies `{biwa}`, but ~/.ssh/config specifies `{openssh}`. Remove one setting or make them match"
+		),
+		(Some(port), _) | (None, Some(port)) => Ok(port),
+		(None, None) => Ok(22),
+	}
+}
+
+/// Ensures duplicate Biwa and OpenSSH identity settings select the same key.
+fn reconcile_identity(biwa: &Path, openssh: &[PathBuf], host: &str) -> Result<()> {
+	if openssh.is_empty() {
+		return Ok(());
+	}
+	if openssh.len() != 1 {
+		bail!(
+			"Conflicting SSH identity configuration for `{host}`: ssh.key_path is singular, but ~/.ssh/config supplies {} IdentityFile entries. Remove one source or configure exactly one equivalent identity",
+			openssh.len()
+		);
+	}
+
+	let biwa_key = public_key_for_identity(biwa).wrap_err_with(|| {
+		format!(
+			"Cannot compare ssh.key_path `{}` with OpenSSH IdentityFile",
+			biwa.display()
+		)
+	})?;
+	let openssh_path = openssh.first().expect("length checked above");
+	let openssh_key = public_key_for_identity(openssh_path).wrap_err_with(|| {
+		format!(
+			"Cannot compare OpenSSH IdentityFile `{}` with ssh.key_path",
+			openssh_path.display()
+		)
+	})?;
+
+	if biwa_key.key_data() != openssh_key.key_data() {
+		bail!(
+			"Conflicting SSH identity configuration for `{host}`: ssh.key_path `{}` and OpenSSH IdentityFile `{}` contain different public keys",
+			biwa.display(),
+			openssh_path.display()
+		);
+	}
+	Ok(())
+}
+
+/// Loads public key material from a public key, companion file, or private key.
+fn public_key_for_identity(path: &Path) -> Result<PublicKey> {
+	if let Ok(key) = load_public_key(path) {
+		return Ok(key);
+	}
+
+	let companion = PathBuf::from(format!("{}.pub", path.to_string_lossy()));
+	if let Ok(key) = load_public_key(&companion) {
+		return Ok(key);
+	}
+
+	let private = load_secret_key(path, None).wrap_err_with(|| {
+		format!(
+			"Failed to read public key material from `{}` or `{}`",
+			path.display(),
+			companion.display()
+		)
+	})?;
+	Ok(private.public_key().clone())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::config::types::Config;
+	use pretty_assertions::assert_eq;
+	use std::fs;
+	use tempfile::tempdir;
+
+	fn config(host: &str) -> SshConfig {
+		let mut ssh = Config::default().ssh;
+		ssh.host = host.to_owned();
+		ssh.user = None;
+		ssh.port = None;
+		ssh
+	}
+
+	#[test]
+	fn resolves_openssh_alias() -> Result<()> {
+		let dir = tempdir()?;
+		let path = dir.path().join("config");
+		fs::write(
+			&path,
+			"Host cse\n  HostName login.cse.unsw.edu.au\n  User z1234567\n  Port 2222\n  IdentityFile ~/.ssh/cse.pub\n",
+		)?;
+
+		let target = ResolvedSshTarget::resolve_with_path(&config("cse"), Some(&path))?;
+		assert_eq!(target.lookup_host, "cse");
+		assert_eq!(target.hostname, "login.cse.unsw.edu.au");
+		assert_eq!(target.user, "z1234567");
+		assert_eq!(target.port, 2222);
+		assert_eq!(target.identity_files.len(), 1);
+		Ok(())
+	}
+
+	#[test]
+	fn accepts_matching_values() -> Result<()> {
+		let dir = tempdir()?;
+		let path = dir.path().join("config");
+		fs::write(&path, "Host cse\n  User alice\n  Port 22\n")?;
+		let mut ssh = config("cse");
+		ssh.user = Some("alice".to_owned());
+		ssh.port = Some(22);
+
+		let target = ResolvedSshTarget::resolve_with_path(&ssh, Some(&path))?;
+		assert_eq!(target.user, "alice");
+		assert_eq!(target.port, 22);
+		Ok(())
+	}
+
+	#[test]
+	fn rejects_conflicting_user() -> Result<()> {
+		let dir = tempdir()?;
+		let path = dir.path().join("config");
+		fs::write(&path, "Host cse\n  User bob\n")?;
+		let mut ssh = config("cse");
+		ssh.user = Some("alice".to_owned());
+
+		let error = ResolvedSshTarget::resolve_with_path(&ssh, Some(&path))
+			.expect_err("different users conflict");
+		assert!(error.to_string().contains("Conflicting SSH user"));
+		Ok(())
+	}
+
+	#[test]
+	fn disabled_openssh_config_uses_biwa_values() -> Result<()> {
+		let mut ssh = config("example.test");
+		ssh.user = Some("alice".to_owned());
+		ssh.use_ssh_config = false;
+		let target = ResolvedSshTarget::resolve_with_path(&ssh, Some(Path::new("missing")))?;
+		assert_eq!(target.hostname, "example.test");
+		assert_eq!(target.port, 22);
+		Ok(())
+	}
+}


### PR DESCRIPTION
## Summary

- add `russh-config` target resolution for `Host`, `HostName`, `User`, `Port`, and `IdentityFile`
- reconcile Biwa and OpenSSH values, accepting equivalent duplicates and rejecting conflicts before connecting
- use resolved host, user, and port consistently for connections, state, cleanup, and background environment propagation

## Stack

First PR in #1047.

## Validation

- `mise run test:update-snapshot`
- `mise run render:schema`
- `mise run check --lint`

## Summary by Sourcery

Resolve effective SSH connection settings from Biwa and OpenSSH configuration and use them consistently throughout the application.

New Features:
- Add OpenSSH configuration support for resolving SSH hostnames, users, ports, and identity files.
- Allow SSH users to omit Biwa port and user values when they are supplied by OpenSSH configuration.

Bug Fixes:
- Ensure connections, persisted state, cleanup operations, and background cleanup use the same resolved SSH target.
- Reject conflicting Biwa and OpenSSH user, port, or identity settings before connecting.

Enhancements:
- Centralize SSH target resolution with actionable errors for missing users, invalid configuration, and identity comparison failures.

Build:
- Add the russh-config dependency and update generated configuration schema and examples.

Documentation:
- Update configuration schema and generated initialization snapshots for optional SSH settings and OpenSSH configuration support.

Tests:
- Add coverage for OpenSSH alias resolution, matching and conflicting settings, disabled or missing SSH configuration, and identity-file reconciliation.
- Add coverage ensuring resolved targets are used for connection state and background cleanup environment propagation.