### PR TITLE
docs(ssh): explain zero-config authentication

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -45,14 +45,21 @@ For example, if you set `key_path = "id_rsa"` in `./.config/biwa.toml`, it will 
 
 ### `[ssh]` — SSH Connection Settings
 
-| Key        | Type           | Default             | Description                                                                                               |
-| ---------- | -------------- | ------------------- | --------------------------------------------------------------------------------------------------------- |
-| `host`     | string         | `"cse.unsw.edu.au"` | SSH server hostname                                                                                       |
-| `port`     | integer        | `22`                | SSH server port                                                                                           |
-| `user`     | string         | `"z5555555"`        | Username (your zID)                                                                                       |
-| `key_path` | string?        | `null`              | Path to SSH private key (auto-detected if not set)                                                        |
-| `password` | bool \| string | `false`             | `false`: disabled, `true`: interactive prompt, `"string"`: literal password                               |
-| `umask`    | string         | `"077"`             | Umask (3-digit octal: owner/group/other) applied to the remote SSH execution environment and sync actions |
+| Key                | Type    | Default             | Description                                                                                               |
+| ------------------ | ------- | ------------------- | --------------------------------------------------------------------------------------------------------- |
+| `host`             | string  | `"cse.unsw.edu.au"` | Hostname or OpenSSH `Host` alias                                                                          |
+| `port`             | integer | OpenSSH, then `22`  | Optional direct port; must match OpenSSH config when both specify it                                      |
+| `user`             | string? | OpenSSH `User`      | Optional direct username; required from either Biwa or OpenSSH config                                     |
+| `use_ssh_config`   | boolean | `true`              | Read the supported subset of `~/.ssh/config`                                                              |
+| `key_path`         | string? | `null`              | Explicit private key; disables automatic agent and default-key discovery                                  |
+| `auth`             | string  | `"public-key"`      | Authentication mode: `"public-key"` or `"password"`                                                     |
+| `host_key_checking`| string  | `"strict"`          | Host-key policy: `"strict"`, `"accept-new"`, or `"insecure"`                                           |
+| `known_hosts`      | string? | `~/.ssh/known_hosts`| Optional known-hosts file override                                                                        |
+| `umask`            | string  | `"077"`             | Umask (3-digit octal: owner/group/other) applied to the remote SSH execution environment and sync actions |
+
+Biwa reads `Host`, `HostName`, `User`, `Port`, and `IdentityFile` from OpenSSH config. You may put `user`, `port`, and key selection in either Biwa or OpenSSH config. Equivalent duplicate values are accepted; conflicting values fail before connecting. `host` remains the lookup alias, while `HostName` supplies the network destination.
+
+This is intentionally a subset of `ssh_config`. `Include`, `Match`, `IdentityAgent`, `IdentitiesOnly`, `PreferredAuthentications`, `PasswordAuthentication`, `KbdInteractiveAuthentication`, `ProxyCommand`, and `ProxyJump` behavior is not implemented. Some unsupported directives are ignored by `russh-config`; set `use_ssh_config = false` if parsing or partial support makes the result unsuitable.
 
 ::: tip Understanding `umask`
 The `umask` setting ensures that any directories or files synced/created on the remote server maintain secure permissions (by default `077` prevents group and other access). Only the lower three digits are supported; to set the first digit (setuid/setgid/sticky), run `umask` manually on the remote server.
@@ -62,9 +69,25 @@ The `umask` setting ensures that any directories or files synced/created on the 
 If you need looser permissions (e.g. making a file readable by others), you must manually run `chmod`. However, be aware that biwa's umask does not protect against manual `chmod` operations. If you mistakenly run `chmod +r` or `chmod +x` without restricting it to the user (e.g., `chmod u+x`), you might accidentally grant read/execute permissions to everyone.
 :::
 
-::: warning Password in Config
-Storing your password in a configuration file is **not recommended** for security reasons. If you must use password authentication, prefer `password = true` for an interactive prompt or use environment variables (`BIWA_SSH_PASSWORD`).
+::: warning Password migration
+The old `ssh.password` boolean/string field was removed. Select `auth = "password"` explicitly. Biwa prompts when interactive, or reads the secret from `BIWA_SSH_PASSWORD`; passwords are never accepted from configuration files and are never an automatic fallback from public keys.
 :::
+
+### Host key verification
+
+`strict` is the secure default: the resolved hostname and port must already match `~/.ssh/known_hosts`. Connecting once with OpenSSH normally creates this entry. `accept-new` records an unknown key on first use but still rejects changed keys. `insecure` accepts every key, emits a warning, and should be limited to isolated test environments.
+
+```toml
+[ssh]
+host_key_checking = "accept-new"
+# known_hosts = "./test-known-hosts"
+```
+
+```bash
+ssh-keyscan -p 22 cse.unsw.edu.au >> ~/.ssh/known_hosts
+```
+
+Verify a scanned key's fingerprint through a trusted channel before relying on it; `ssh-keyscan` alone does not authenticate the server.
 
 ### `[env]` — Environment Variable Settings
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -75,11 +75,12 @@ The old `ssh.password` boolean/string field was removed. Select `auth = "passwor
 
 ### Host key verification
 
-`strict` is the secure default: the resolved hostname and port must already match `~/.ssh/known_hosts`. Connecting once with OpenSSH normally creates this entry. `accept-new` records an unknown key on first use but still rejects changed keys. `insecure` accepts every key, emits a warning, and should be limited to isolated test environments.
+`strict` is the secure default: the resolved hostname and port must already match `~/.ssh/known_hosts`. Connecting once with OpenSSH normally creates this entry. `accept-new` records an unknown key on first use but still rejects changed keys. Both policies reject a matching `@revoked` key. `insecure` accepts every key, emits a warning, and should be limited to isolated test environments.
 
 ```toml
 [ssh]
 host_key_checking = "accept-new"
+# Relative paths follow the configuration path rules described above.
 # known_hosts = "./test-known-hosts"
 ```
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -64,8 +64,22 @@ host = "cse.unsw.edu.au"
 user = "z5555555"  # Your zID
 port = 22
 
-# Path to your SSH private key (optional, uses default if not specified)
+# Authentication defaults to public keys. Usually omit this.
 # key_path = "~/.ssh/id_ed25519"
+```
+
+If you already use an OpenSSH alias, Biwa can reuse it instead:
+
+```sshconfig
+# ~/.ssh/config
+Host cse
+    HostName cse.unsw.edu.au
+    User z5555555
+```
+
+```toml
+[ssh]
+host = "cse"
 ```
 
 ::: tip SSH Key Authentication

--- a/docs/src/ssh-key-setup.md
+++ b/docs/src/ssh-key-setup.md
@@ -60,18 +60,42 @@ If this prints "Success!" without asking for a password, key auth is working.
 
 ## How biwa Resolves Authentication
 
-biwa tries authentication methods in this order. **Explicit configuration is always respected first:**
+Public-key authentication is the default. No Biwa authentication setting is required. For automatic discovery, Biwa tries concrete credentials in this order:
 
-1. **Configured key file** — If `ssh.key_path` is set, biwa uses it (errors if not found)
-2. **Configured password** — If `ssh.password` is a string, biwa uses it; if `true`, biwa prompts interactively
-3. **Default key files** — biwa checks `~/.ssh/id_ed25519`, then `~/.ssh/id_rsa`
-4. **SSH Agent** — If no default key exists, or the discovered default key is rejected, biwa falls back to the SSH agent
+1. Agent identities matching OpenSSH `IdentityFile` entries, in configured order
+2. Private keys named by `IdentityFile`
+3. Remaining agent identities, preserving agent order
+4. Existing `~/.ssh/id_ed25519` and `~/.ssh/id_rsa` files
+
+Every agent identity gets a fresh SSH connection, avoiding one connection's `MaxAuthTries` budget. Matching identities are all tried; unrelated agent identities are limited to 10. If an agent exposes more, add an `IdentityFile` public-key hint.
+
+Setting `ssh.key_path` selects only that private key. It does not fall back to unrelated agent or default keys. Encrypted private keys prompt for a passphrase only when reached and only in an interactive process.
 
 ::: tip Zero-Config Users
-If you want to delegate authentication to your SSH agent, **don't configure any auth settings**. biwa will automatically use the agent, including as a fallback when a default key file does not authenticate.
+If your key is at a standard path or loaded into the agent named by `SSH_AUTH_SOCK`, omit authentication settings. Biwa discovers it automatically and never falls back to a password prompt.
 :::
 
-## Configuration
+## OpenSSH aliases and per-host agent selection
+
+Biwa supports `Host`, `HostName`, `User`, `Port`, and `IdentityFile` from `~/.ssh/config`. This lets OpenSSH and Biwa share the destination and key hint:
+
+```sshconfig
+Host cse
+    HostName cse.unsw.edu.au
+    User z5555555
+    IdentityFile ~/.ssh/cse.pub
+```
+
+```toml
+[ssh]
+host = "cse"
+```
+
+`IdentityFile` may point to a public-key file. Biwa compares its key bytes with identities exposed by Bitwarden, 1Password, OpenSSH `ssh-agent`, or another compatible agent. The private key does not need to exist on disk. A public key contains no secret and can be stored in dotfiles if that suits your setup.
+
+`IdentitiesOnly` and `IdentityAgent` are not supported yet. Biwa uses `SSH_AUTH_SOCK`, and after configured matches it may try up to 10 unrelated agent identities.
+
+## Explicit private key
 
 To use a non-default key path:
 
@@ -80,6 +104,39 @@ To use a non-default key path:
 user = "z5555555"
 key_path = "~/.ssh/my_custom_key"
 ```
+
+If `key_path` and OpenSSH `IdentityFile` are both present, they must select the same public-key bytes and `IdentityFile` must contain exactly one entry. Different or ambiguous selections are configuration errors.
+
+## Password authentication
+
+Password authentication is opt-in and never follows a failed public key automatically:
+
+```toml
+[ssh]
+host = "cse"
+auth = "password"
+```
+
+Biwa prompts once in an interactive terminal. For CI or another non-interactive process, provide the secret only through the environment:
+
+```bash
+BIWA_SSH_AUTH=password BIWA_SSH_PASSWORD='...' biwa run --skip-sync true
+```
+
+`ssh.password` was removed, and literal passwords are not accepted in configuration files. Environment variables can be visible to other processes on some platforms, so use your CI secret facility and keep logs redacted.
+
+## Host key verification
+
+Biwa defaults to strict host-key verification. Running the OpenSSH verification command above normally records the server in `~/.ssh/known_hosts`. An unknown or changed key stops before authentication.
+
+For trust on first use on a private host:
+
+```toml
+[ssh]
+host_key_checking = "accept-new"
+```
+
+`insecure` disables verification and is intended only for isolated tests.
 
 ## Windows Users
 
@@ -106,6 +163,19 @@ Ensure your SSH agent is running and has your key loaded:
 ```bash
 eval "$(ssh-agent -s)"
 ssh-add ~/.ssh/id_ed25519
+```
+
+Check that `SSH_AUTH_SOCK` points to the intended agent. For Bitwarden, enable its SSH agent integration and configure your shell to use the socket it provides. If many identities are available, put the matching public key in `IdentityFile` as shown above.
+
+### OpenSSH config parsing fails
+
+Biwa supports only the subset listed above. `Include` and `Match` are not fully evaluated, and proxy/authentication directives are not executed. As an escape hatch, configure all required connection values directly and disable reading OpenSSH config:
+
+```toml
+[ssh]
+host = "cse.unsw.edu.au"
+user = "z5555555"
+use_ssh_config = false
 ```
 
 ## Further Reading

--- a/docs/src/ssh-key-setup.md
+++ b/docs/src/ssh-key-setup.md
@@ -67,7 +67,7 @@ Public-key authentication is the default. No Biwa authentication setting is requ
 3. Remaining agent identities, preserving agent order
 4. Existing `~/.ssh/id_ed25519` and `~/.ssh/id_rsa` files
 
-Every agent identity gets a fresh SSH connection, avoiding one connection's `MaxAuthTries` budget. Matching identities are all tried; unrelated agent identities are limited to 10. If an agent exposes more, add an `IdentityFile` public-key hint.
+Every selected, deduplicated agent identity gets a fresh SSH connection, avoiding one connection's `MaxAuthTries` budget. A plain public key and an OpenSSH certificate for that key remain separate identities, so either can authenticate. Matching identities are all tried; unrelated agent identities are limited to 10. If an agent exposes more, add an `IdentityFile` public-key hint.
 
 Setting `ssh.key_path` selects only that private key. It does not fall back to unrelated agent or default keys. Encrypted private keys prompt for a passphrase only when reached and only in an interactive process.
 
@@ -127,7 +127,7 @@ BIWA_SSH_AUTH=password BIWA_SSH_PASSWORD='...' biwa run --skip-sync true
 
 ## Host key verification
 
-Biwa defaults to strict host-key verification. Running the OpenSSH verification command above normally records the server in `~/.ssh/known_hosts`. An unknown or changed key stops before authentication.
+Biwa defaults to strict host-key verification. Running the OpenSSH verification command above normally records the server in `~/.ssh/known_hosts`. An unknown, changed, or explicitly `@revoked` key stops before authentication. A revoked key is also rejected in `accept-new` mode rather than being learned again.
 
 For trust on first use on a private host:
 

--- a/docs/src/sync-behavior.md
+++ b/docs/src/sync-behavior.md
@@ -132,7 +132,7 @@ Biwa stores active transfer targets before remote work begins so automatic clean
 
 ### Automatic cleanup after sync, pull, and run
 
-When **`clean.auto`** is `true` (the default), biwa may start a **background** `biwa clean --auto` process after a successful `biwa sync`, `biwa pull`, or `biwa run`, as long as password authentication is not interactive-only (non-interactive auth such as env password, key, or agent is required). You can turn this off globally with **`BIWA_CLEAN_AUTO=false`** or in config:
+When **`clean.auto`** is `true` (the default), biwa may start a **background** `biwa clean --auto` process after a successful `biwa sync`, `biwa pull`, or `biwa run`. Public keys and agents work without special cleanup settings. Password mode requires `BIWA_SSH_PASSWORD` because a detached process cannot prompt. You can turn cleanup off globally with **`BIWA_CLEAN_AUTO=false`** or in config:
 
 ```toml
 [clean]

--- a/docs/src/sync-behavior.md
+++ b/docs/src/sync-behavior.md
@@ -132,7 +132,7 @@ Biwa stores active transfer targets before remote work begins so automatic clean
 
 ### Automatic cleanup after sync, pull, and run
 
-When **`clean.auto`** is `true` (the default), biwa may start a **background** `biwa clean --auto` process after a successful `biwa sync`, `biwa pull`, or `biwa run`. Public keys and agents work without special cleanup settings. Password mode requires `BIWA_SSH_PASSWORD` because a detached process cannot prompt. You can turn cleanup off globally with **`BIWA_CLEAN_AUTO=false`** or in config:
+When **`clean.auto`** is `true` (the default), biwa may start a **background** `biwa clean --auto` process after a successful `biwa sync`, `biwa pull`, or `biwa run`. Agent identities and unencrypted private keys work without special cleanup settings. Password mode requires `BIWA_SSH_PASSWORD` because a detached process cannot prompt. If the successful foreground connection used a prompted password or a private-key passphrase, biwa warns and skips detached cleanup instead of prompting again. You can turn cleanup off globally with **`BIWA_CLEAN_AUTO=false`** or in config:
 
 ```toml
 [clean]
@@ -146,7 +146,7 @@ Automatic cleanup connects over SSH, reads disk **quota** usage when the server 
 
 Candidates for removal are **tracked** connection entries that are older than the effective age limit, plus **orphan** directories on the server that look like default biwa project folders under `remote_root`, are no longer listed in local state, and have a remote filesystem modification time older than the effective age limit. Orphan detection only runs when local state already has at least one tracked path for that SSH target, so it is not run on an empty or broken state file.
 
-Background cleanup does not run if another cleanup process already holds the PID lock, or if interactive password auth would be required.
+Background cleanup does not run if another cleanup process already holds the PID lock, or if reusing the successful credential would require terminal input.
 
 ### Manual `biwa clean`
 


### PR DESCRIPTION
## Summary

- document zero-config public-key discovery and explicit password mode
- add OpenSSH alias and Bitwarden `IdentityFile` public-key examples
- document conflict behavior, the supported OpenSSH subset, and unsupported directives
- explain strict host-key verification, background cleanup, and migration from `ssh.password`

## Stack

Stacked on #1050 and completes the user-facing delivery plan.

Closes #1047.

## Validation

- `mise run docs:build`
- `mise run check --lint`

## Summary by Sourcery

Document zero-config SSH authentication and the configuration, verification, and cleanup behavior users need to use it safely.

New Features:
- Document zero-configuration public-key authentication discovery and explicit password authentication.
- Add guidance for OpenSSH aliases and public-key hints through IdentityFile, including agent-backed keys.

Enhancements:
- Document supported OpenSSH configuration, conflict handling, host-key verification policies, and unsupported directives.
- Clarify authentication precedence, explicit key selection, password migration, and credential behavior during background cleanup.

Documentation:
- Expand SSH setup and configuration documentation with authentication, OpenSSH integration, host-key verification, and troubleshooting guidance.
- Update cleanup documentation to explain credential requirements for detached cleanup processes.